### PR TITLE
Detect SIMD (sse, avx, fma) CPU features

### DIFF
--- a/scilab/Makefile.in
+++ b/scilab/Makefile.in
@@ -175,7 +175,9 @@ check_PROGRAMS = call_scilab_c_simple$(EXEEXT) call_scilab_c$(EXEEXT) \
 	call_scilab_readwritestring$(EXEEXT)
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -737,6 +739,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/aclocal.m4
+++ b/scilab/aclocal.m4
@@ -3553,7 +3553,9 @@ AC_SUBST([am__tar])
 AC_SUBST([am__untar])
 ]) # _AM_PROG_TAR
 
+m4_include([m4/ax_check_x86_features.m4])
 m4_include([m4/ax_cxx_compile_stdcxx_11.m4])
+m4_include([m4/ax_gcc_x86_cpu_supports.m4])
 m4_include([m4/backtrace.m4])
 m4_include([m4/compiler.m4])
 m4_include([m4/curl.m4])

--- a/scilab/configure
+++ b/scilab/configure
@@ -876,6 +876,7 @@ IS_HPUX_FALSE
 IS_HPUX_TRUE
 IS_MACOSX_FALSE
 IS_MACOSX_TRUE
+X86_FEATURE_CFLAGS
 LOGGING_LEVEL
 cxx_present
 am__fastdepCXX_FALSE
@@ -3363,8 +3364,8 @@ else
 $as_echo "no, using $LN_S" >&6; }
 fi
 
-# Expand $ac_aux_dir to an absolute path.
-am_aux_dir=`cd "$ac_aux_dir" && pwd`
+# expand $ac_aux_dir to an absolute path
+am_aux_dir=`cd $ac_aux_dir && pwd`
 
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -4413,7 +4414,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -4459,7 +4460,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -4483,7 +4484,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -4528,7 +4529,7 @@ else
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -4552,7 +4553,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T ((((off_t) 1 << 31) << 31) - 1 + (((off_t) 1 << 31) << 31))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
@@ -5559,7 +5560,7 @@ fi
 
 
 
-am__api_version='1.15'
+am__api_version='1.14'
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether build environment is sane" >&5
 $as_echo_n "checking whether build environment is sane... " >&6; }
@@ -5655,7 +5656,7 @@ else
 $as_echo "$as_me: WARNING: 'missing' script is too old or missing" >&2;}
 fi
 
-if test x"${install_sh+set}" != xset; then
+if test x"${install_sh}" != xset; then
   case $am_aux_dir in
   *\ * | *\	*)
     install_sh="\${SHELL} '$am_aux_dir/install-sh'" ;;
@@ -6046,8 +6047,8 @@ MAKEINFO=${MAKEINFO-"${am_missing_run}makeinfo"}
 # <http://lists.gnu.org/archive/html/automake/2012-07/msg00014.html>
 mkdir_p='$(MKDIR_P)'
 
-# We need awk for the "check" target (and possibly the TAP driver).  The
-# system "awk" is bad on some platforms.
+# We need awk for the "check" target.  The system "awk" is bad on
+# some platforms.
 # Always define AMTAR for backward compatibility.  Yes, it's still used
 # in the wild :-(  We should find a proper way to deprecate it ...
 AMTAR='$${TAR-tar}'
@@ -6231,8 +6232,7 @@ to "yes", and re-run configure.
 END
     as_fn_error $? "Your 'rm' program is bad, sorry." "$LINENO" 5
   fi
-fi
- # Not using -Werror because we override {C,F}FLAGS in order to disable optimisation
+fi # Not using -Werror because we override {C,F}FLAGS in order to disable optimisation
 
 
 
@@ -9752,6 +9752,750 @@ SCIVERSION=`cat $SCI_SRCDIR/Version.incl | sed -e "s/SCIVERSION=//" `
 ## Compilers and options according to machine
 #############################################
 
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gcc __builtin_cpu_init function" >&5
+$as_echo_n "checking for gcc __builtin_cpu_init function... " >&6; }
+if ${ax_cv_gcc_check_x86_cpu_init+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+__builtin_cpu_init ();
+  ;
+  return 0;
+}
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_check_x86_cpu_init=yes
+else
+  ax_cv_gcc_check_x86_cpu_init=no
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_check_x86_cpu_init" >&5
+$as_echo "$ax_cv_gcc_check_x86_cpu_init" >&6; }
+  if test "X$ax_cv_gcc_check_x86_cpu_init" = "Xno"; then :
+  as_fn_error $? "Need GCC to support X86 CPU features tests" "$LINENO" 5
+fi
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 sse2 instruction support" >&5
+$as_echo_n "checking for x86 sse2 instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_sse2+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("sse2"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_sse2=yes
+else
+  ax_cv_gcc_x86_cpu_supports_sse2=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_sse2" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_sse2" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_sse2" = xyes; then :
+
+$as_echo "#define HAVE_SSE2_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -msse2"
+fi
+
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 sse3 instruction support" >&5
+$as_echo_n "checking for x86 sse3 instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_sse3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("sse3"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_sse3=yes
+else
+  ax_cv_gcc_x86_cpu_supports_sse3=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_sse3" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_sse3" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_sse3" = xyes; then :
+
+$as_echo "#define HAVE_SSE3_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -msse3"
+fi
+
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 sse4.1 instruction support" >&5
+$as_echo_n "checking for x86 sse4.1 instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_sse4_1+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("sse4.1"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_sse4_1=yes
+else
+  ax_cv_gcc_x86_cpu_supports_sse4_1=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_sse4_1" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_sse4_1" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_sse4_1" = xyes; then :
+
+$as_echo "#define HAVE_SSE4_1_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -msse4.1"
+fi
+
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 sse4.2 instruction support" >&5
+$as_echo_n "checking for x86 sse4.2 instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_sse4_2+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("sse4.2"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_sse4_2=yes
+else
+  ax_cv_gcc_x86_cpu_supports_sse4_2=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_sse4_2" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_sse4_2" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_sse4_2" = xyes; then :
+
+$as_echo "#define HAVE_SSE4_2_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -msse4.2"
+fi
+
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 sse4a instruction support" >&5
+$as_echo_n "checking for x86 sse4a instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_sse4a+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("sse4a"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_sse4a=yes
+else
+  ax_cv_gcc_x86_cpu_supports_sse4a=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_sse4a" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_sse4a" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_sse4a" = xyes; then :
+
+$as_echo "#define HAVE_SSE4A_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -msse4a"
+fi
+
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 avx instruction support" >&5
+$as_echo_n "checking for x86 avx instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_avx+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("avx"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_avx=yes
+else
+  ax_cv_gcc_x86_cpu_supports_avx=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_avx" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_avx" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_avx" = xyes; then :
+
+$as_echo "#define HAVE_AVX_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -mavx"
+fi
+
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 avx instruction support" >&5
+$as_echo_n "checking for x86 avx instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_avx+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("avx"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_avx=yes
+else
+  ax_cv_gcc_x86_cpu_supports_avx=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_avx" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_avx" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_avx" = xyes; then :
+
+$as_echo "#define HAVE_AVX_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -mavx"
+fi
+
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 avx2 instruction support" >&5
+$as_echo_n "checking for x86 avx2 instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_avx2+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("avx2"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_avx2=yes
+else
+  ax_cv_gcc_x86_cpu_supports_avx2=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_avx2" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_avx2" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_avx2" = xyes; then :
+
+$as_echo "#define HAVE_AVX2_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -mavx2"
+fi
+
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 avx512f instruction support" >&5
+$as_echo_n "checking for x86 avx512f instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_avx512f+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("avx512f"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_avx512f=yes
+else
+  ax_cv_gcc_x86_cpu_supports_avx512f=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_avx512f" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_avx512f" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_avx512f" = xyes; then :
+
+$as_echo "#define HAVE_AVX512F_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -mavx512f"
+fi
+
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 fma instruction support" >&5
+$as_echo_n "checking for x86 fma instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_fma+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("fma"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_fma=yes
+else
+  ax_cv_gcc_x86_cpu_supports_fma=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_fma" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_fma" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_fma" = xyes; then :
+
+$as_echo "#define HAVE_FMA_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -mfma"
+fi
+
+
+
+
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for x86 fma4 instruction support" >&5
+$as_echo_n "checking for x86 fma4 instruction support... " >&6; }
+if ${ax_cv_gcc_x86_cpu_supports_fma4+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+int
+main ()
+{
+ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("fma4"))
+           return 0;
+         return 1;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ax_cv_gcc_x86_cpu_supports_fma4=yes
+else
+  ax_cv_gcc_x86_cpu_supports_fma4=no
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_gcc_x86_cpu_supports_fma4" >&5
+$as_echo "$ax_cv_gcc_x86_cpu_supports_fma4" >&6; }
+   ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+   if test "x$ax_cv_gcc_x86_cpu_supports_fma4" = xyes; then :
+
+$as_echo "#define HAVE_FMA4_INSTRUCTIONS 1" >>confdefs.h
+
+          X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -mfma4"
+fi
+
+
+
+
+  CFLAGS="$CFLAGS $X86_FEATURE_CFLAGS" CXXFLAGS="$CXXFLAGS $X86_FEATURE_CFLAGS"
+
+
+
 ######################
 ######## Set compilation options for intel C/Fortran compilers
 ######################
@@ -11697,7 +12441,7 @@ $as_echo "$ac_java_classpath" >&6; }
 $as_echo_n "checking to see if the java compiler works... " >&6; }
 
     cat << \EOF > conftest.java
-// #line 11700 "configure"
+// #line 12444 "configure"
 import java.util.regex.Pattern;
 
 
@@ -11784,7 +12528,7 @@ $as_echo_n "checking type of jvm... " >&6; }
     if test "x$ac_java_jvm_name" = "x" ; then
 
     cat << \EOF > conftest.java
-// #line 11787 "configure"
+// #line 12531 "configure"
 import java.util.regex.Pattern;
 
 import gnu.java.io.EncodingManager;
@@ -11868,7 +12612,7 @@ $as_echo_n "checking java API version... " >&6; }
     # The class java.nio.charset.Charset is new to 1.4
 
     cat << \EOF > conftest.java
-// #line 11871 "configure"
+// #line 12615 "configure"
 import java.util.regex.Pattern;
 
 import java.nio.charset.Charset;
@@ -11933,7 +12677,7 @@ EOF
     # The class java.lang.StringBuilder is new to 1.5
 
     cat << \EOF > conftest.java
-// #line 11936 "configure"
+// #line 12680 "configure"
 import java.util.regex.Pattern;
 
 import java.lang.StringBuilder;
@@ -11998,7 +12742,7 @@ EOF
     # The class java.util.ArrayDeque is new to 1.6
 
     cat << \EOF > conftest.java
-// #line 12001 "configure"
+// #line 12745 "configure"
 import java.util.regex.Pattern;
 
 import java.util.ArrayDeque;
@@ -12063,7 +12807,7 @@ EOF
     # The class java.nio.file.Path is new to 1.7
 
     cat << \EOF > conftest.java
-// #line 12066 "configure"
+// #line 12810 "configure"
 import java.util.regex.Pattern;
 
 import java.nio.file.Path;
@@ -12128,7 +12872,7 @@ EOF
     # The class java.util.stream.DoubleStream is new to 1.8
 
     cat << \EOF > conftest.java
-// #line 12131 "configure"
+// #line 12875 "configure"
 import java.util.regex.Pattern;
 
 import java.util.stream.DoubleStream;
@@ -13591,7 +14335,7 @@ fi
                    # jgraphx
 
     cat << \EOF > conftestSharedChecker.java
-// #line 13594 "configure"
+// #line 14338 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -13780,7 +14524,7 @@ $as_echo_n "checking jgraphx... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 13783 "configure"
+// #line 14527 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -14001,7 +14745,7 @@ $as_echo_n "checking scirenderer... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 14004 "configure"
+// #line 14748 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -14228,7 +14972,7 @@ $as_echo_n "checking flexdock... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 14231 "configure"
+// #line 14975 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -14447,7 +15191,7 @@ $as_echo_n "checking looks... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 14450 "configure"
+// #line 15194 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -14666,7 +15410,7 @@ $as_echo_n "checking jgoodies-looks... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 14669 "configure"
+// #line 15413 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -14886,7 +15630,7 @@ $as_echo_n "checking skinlf... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 14889 "configure"
+// #line 15633 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -15105,7 +15849,7 @@ $as_echo_n "checking jogl2... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 15108 "configure"
+// #line 15852 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -15316,7 +16060,7 @@ $as_echo_n "checking minimal version (Specification-Version 2.2) of jogl2... " >
     if test "x" == "x"; then
 
     cat << \EOF > conftest.java
-// #line 15319 "configure"
+// #line 16063 "configure"
 import java.util.regex.Pattern;
 
 import java.io.IOException;
@@ -15393,7 +16137,7 @@ EOF
     else
 
     cat << \EOF > conftest.java
-// #line 15396 "configure"
+// #line 16140 "configure"
 import java.util.regex.Pattern;
 
 import java.io.IOException;
@@ -15592,7 +16336,7 @@ $as_echo_n "checking gluegen2-rt... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 15595 "configure"
+// #line 16339 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -15868,7 +16612,7 @@ $as_echo_n "checking jhall... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 15871 "configure"
+// #line 16615 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -16085,7 +16829,7 @@ $as_echo_n "checking javahelp2... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 16088 "configure"
+// #line 16832 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -16305,7 +17049,7 @@ $as_echo_n "checking lucene-core... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 16308 "configure"
+// #line 17052 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -16524,7 +17268,7 @@ $as_echo_n "checking lucene-analyzers-common... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 16527 "configure"
+// #line 17271 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -16743,7 +17487,7 @@ $as_echo_n "checking lucene-queryparser... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 16746 "configure"
+// #line 17490 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -16962,7 +17706,7 @@ $as_echo_n "checking jrosetta-API... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 16965 "configure"
+// #line 17709 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -17178,7 +17922,7 @@ $as_echo_n "checking jrosetta-api... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 17181 "configure"
+// #line 17925 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -17398,7 +18142,7 @@ $as_echo_n "checking jrosetta-engine... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 17401 "configure"
+// #line 18145 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -17619,7 +18363,7 @@ $as_echo_n "checking jeuclid-core... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 17622 "configure"
+// #line 18366 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -17840,7 +18584,7 @@ $as_echo_n "checking fop... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 17843 "configure"
+// #line 18587 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -18066,7 +18810,7 @@ $as_echo_n "checking freehep-graphics2d... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 18069 "configure"
+// #line 18813 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -18285,7 +19029,7 @@ $as_echo_n "checking freehep-graphicsio... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 18288 "configure"
+// #line 19032 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -18504,7 +19248,7 @@ $as_echo_n "checking freehep-graphicsio-emf... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 18507 "configure"
+// #line 19251 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -18723,7 +19467,7 @@ $as_echo_n "checking freehep-io... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 18726 "configure"
+// #line 19470 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -18942,7 +19686,7 @@ $as_echo_n "checking freehep-util... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 18945 "configure"
+// #line 19689 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -19162,7 +19906,7 @@ $as_echo_n "checking batik-all... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 19165 "configure"
+// #line 19909 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -19381,7 +20125,7 @@ $as_echo_n "checking batik... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 19384 "configure"
+// #line 20128 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -19601,7 +20345,7 @@ $as_echo_n "checking commons-io... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 19604 "configure"
+// #line 20348 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -19820,7 +20564,7 @@ $as_echo_n "checking xmlgraphics-commons... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 19823 "configure"
+// #line 20567 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -20039,7 +20783,7 @@ $as_echo_n "checking avalon-framework... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 20042 "configure"
+// #line 20786 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -20258,7 +21002,7 @@ $as_echo_n "checking xml-apis-ext... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 20261 "configure"
+// #line 21005 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -20477,7 +21221,7 @@ $as_echo_n "checking xml-commons-apis-ext... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 20480 "configure"
+// #line 21224 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -20700,7 +21444,7 @@ $as_echo_n "checking commons-logging... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 20703 "configure"
+// #line 21447 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -20919,7 +21663,7 @@ $as_echo_n "checking jlatexmath... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 20922 "configure"
+// #line 21666 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -21138,7 +21882,7 @@ $as_echo_n "checking jlatexmath-fop... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 21141 "configure"
+// #line 21885 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -21363,7 +22107,7 @@ $as_echo_n "checking checkstyle... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 21366 "configure"
+// #line 22110 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -21582,7 +22326,7 @@ $as_echo_n "checking commons-beanutils... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 21585 "configure"
+// #line 22329 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -21801,7 +22545,7 @@ $as_echo_n "checking antlr... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 21804 "configure"
+// #line 22548 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -22020,7 +22764,7 @@ $as_echo_n "checking junit4... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 22023 "configure"
+// #line 22767 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -22236,7 +22980,7 @@ $as_echo_n "checking junit... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 22239 "configure"
+// #line 22983 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -22459,7 +23203,7 @@ $as_echo_n "checking hamcrest-all... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 22462 "configure"
+// #line 23206 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -22675,7 +23419,7 @@ $as_echo_n "checking hamcrest/all... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 22678 "configure"
+// #line 23422 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -22895,7 +23639,7 @@ $as_echo_n "checking cobertura... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 22898 "configure"
+// #line 23642 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -23114,7 +23858,7 @@ $as_echo_n "checking asm3... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 23117 "configure"
+// #line 23861 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -23330,7 +24074,7 @@ $as_echo_n "checking asm... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 23333 "configure"
+// #line 24077 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -23549,7 +24293,7 @@ $as_echo_n "checking ecj... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 23552 "configure"
+// #line 24296 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -25183,7 +25927,7 @@ $as_echo "$USE_NLS" >&6; }
 
 
 
-      GETTEXT_MACRO_VERSION=0.19
+      GETTEXT_MACRO_VERSION=0.18
 
 
 
@@ -26152,21 +26896,16 @@ else
 /* end confdefs.h.  */
 
 #include <libintl.h>
-#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
+$gt_revision_test_code
 extern int _nl_msg_cat_cntr;
 extern int *_nl_domain_bindings;
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_domain_bindings)
-#else
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
-#endif
-$gt_revision_test_code
 
 int
 main ()
 {
 
 bindtextdomain ("", "");
-return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
+return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_domain_bindings
 
   ;
   return 0;
@@ -26286,42 +27025,36 @@ else
       if test $am_cv_lib_iconv = yes; then
         LIBS="$LIBS $LIBICONV"
       fi
-      am_cv_func_iconv_works=no
-      for ac_iconv_const in '' 'const'; do
-        if test "$cross_compiling" = yes; then :
-  case "$host_os" in
-             aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
-             *)            am_cv_func_iconv_works="guessing yes" ;;
-           esac
+      if test "$cross_compiling" = yes; then :
+
+         case "$host_os" in
+           aix* | hpux*) am_cv_func_iconv_works="guessing no" ;;
+           *)            am_cv_func_iconv_works="guessing yes" ;;
+         esac
+
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <iconv.h>
 #include <string.h>
-
-#ifndef ICONV_CONST
-# define ICONV_CONST $ac_iconv_const
-#endif
-
-int
-main ()
+int main ()
 {
-int result = 0;
+  int result = 0;
   /* Test against AIX 5.1 bug: Failures are not distinguishable from successful
      returns.  */
   {
     iconv_t cd_utf8_to_88591 = iconv_open ("ISO8859-1", "UTF-8");
     if (cd_utf8_to_88591 != (iconv_t)(-1))
       {
-        static ICONV_CONST char input[] = "\342\202\254"; /* EURO SIGN */
+        static const char input[] = "\342\202\254"; /* EURO SIGN */
         char buf[10];
-        ICONV_CONST char *inptr = input;
+        const char *inptr = input;
         size_t inbytesleft = strlen (input);
         char *outptr = buf;
         size_t outbytesleft = sizeof (buf);
         size_t res = iconv (cd_utf8_to_88591,
-                            &inptr, &inbytesleft,
+                            (char **) &inptr, &inbytesleft,
                             &outptr, &outbytesleft);
         if (res == 0)
           result |= 1;
@@ -26334,14 +27067,14 @@ int result = 0;
     iconv_t cd_ascii_to_88591 = iconv_open ("ISO8859-1", "646");
     if (cd_ascii_to_88591 != (iconv_t)(-1))
       {
-        static ICONV_CONST char input[] = "\263";
+        static const char input[] = "\263";
         char buf[10];
-        ICONV_CONST char *inptr = input;
+        const char *inptr = input;
         size_t inbytesleft = strlen (input);
         char *outptr = buf;
         size_t outbytesleft = sizeof (buf);
         size_t res = iconv (cd_ascii_to_88591,
-                            &inptr, &inbytesleft,
+                            (char **) &inptr, &inbytesleft,
                             &outptr, &outbytesleft);
         if (res == 0)
           result |= 2;
@@ -26353,14 +27086,14 @@ int result = 0;
     iconv_t cd_88591_to_utf8 = iconv_open ("UTF-8", "ISO-8859-1");
     if (cd_88591_to_utf8 != (iconv_t)(-1))
       {
-        static ICONV_CONST char input[] = "\304";
+        static const char input[] = "\304";
         static char buf[2] = { (char)0xDE, (char)0xAD };
-        ICONV_CONST char *inptr = input;
+        const char *inptr = input;
         size_t inbytesleft = 1;
         char *outptr = buf;
         size_t outbytesleft = 1;
         size_t res = iconv (cd_88591_to_utf8,
-                            &inptr, &inbytesleft,
+                            (char **) &inptr, &inbytesleft,
                             &outptr, &outbytesleft);
         if (res != (size_t)(-1) || outptr - buf > 1 || buf[1] != (char)0xAD)
           result |= 4;
@@ -26373,14 +27106,14 @@ int result = 0;
     iconv_t cd_88591_to_utf8 = iconv_open ("utf8", "iso88591");
     if (cd_88591_to_utf8 != (iconv_t)(-1))
       {
-        static ICONV_CONST char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
+        static const char input[] = "\304rger mit b\366sen B\374bchen ohne Augenma\337";
         char buf[50];
-        ICONV_CONST char *inptr = input;
+        const char *inptr = input;
         size_t inbytesleft = strlen (input);
         char *outptr = buf;
         size_t outbytesleft = sizeof (buf);
         size_t res = iconv (cd_88591_to_utf8,
-                            &inptr, &inbytesleft,
+                            (char **) &inptr, &inbytesleft,
                             &outptr, &outbytesleft);
         if ((int)res > 0)
           result |= 8;
@@ -26400,20 +27133,17 @@ int result = 0;
       && iconv_open ("utf8", "eucJP") == (iconv_t)(-1))
     result |= 16;
   return result;
-
-  ;
-  return 0;
 }
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :
   am_cv_func_iconv_works=yes
+else
+  am_cv_func_iconv_works=no
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
   conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
-        test "$am_cv_func_iconv_works" = no || break
-      done
       LIBS="$am_save_LIBS"
 
 fi
@@ -26919,25 +27649,20 @@ else
 /* end confdefs.h.  */
 
 #include <libintl.h>
-#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
+$gt_revision_test_code
 extern int _nl_msg_cat_cntr;
 extern
 #ifdef __cplusplus
 "C"
 #endif
 const char *_nl_expand_alias (const char *);
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
-#else
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
-#endif
-$gt_revision_test_code
 
 int
 main ()
 {
 
 bindtextdomain ("", "");
-return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
+return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_expand_alias ("")
 
   ;
   return 0;
@@ -26956,25 +27681,20 @@ rm -f core conftest.err conftest.$ac_objext \
 /* end confdefs.h.  */
 
 #include <libintl.h>
-#ifndef __GNU_GETTEXT_SUPPORTED_REVISION
+$gt_revision_test_code
 extern int _nl_msg_cat_cntr;
 extern
 #ifdef __cplusplus
 "C"
 #endif
 const char *_nl_expand_alias (const char *);
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION (_nl_msg_cat_cntr + *_nl_expand_alias (""))
-#else
-#define __GNU_GETTEXT_SYMBOL_EXPRESSION 0
-#endif
-$gt_revision_test_code
 
 int
 main ()
 {
 
 bindtextdomain ("", "");
-return * gettext ("")$gt_expression_test_code + __GNU_GETTEXT_SYMBOL_EXPRESSION
+return * gettext ("")$gt_expression_test_code + _nl_msg_cat_cntr + *_nl_expand_alias ("")
 
   ;
   return 0;
@@ -27935,7 +28655,7 @@ CHK_EIGEN_MINOR=2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if Eigen is version $CHK_EIGEN_WORLD.$CHK_EIGEN_MAJOR.$CHK_EIGEN_MINOR or later" >&5
 $as_echo_n "checking if Eigen is version $CHK_EIGEN_WORLD.$CHK_EIGEN_MAJOR.$CHK_EIGEN_MINOR or later... " >&6; }
 cat > conftest.$ac_ext <<EOF
-#line 27938 "configure"
+#line 28658 "configure"
 #include "confdefs.h"
 
 #include "$PATH_TO_EIGEN/Eigen/Sparse"
@@ -32612,7 +33332,7 @@ CPPFLAGS="$CPPFLAGS -I$CHK_TCL_INCLUDE_PATH"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if tcl is version $CHK_TCL_MAJOR.$CHK_TCL_MINOR or later" >&5
 $as_echo_n "checking if tcl is version $CHK_TCL_MAJOR.$CHK_TCL_MINOR or later... " >&6; }
 cat > conftest.$ac_ext <<EOF
-#line 32615 "configure"
+#line 33335 "configure"
 #include "confdefs.h"
 
 #include "$CHK_TCL_INCLUDE_PATH/$CHK_TCL_INC_NAME"
@@ -32923,7 +33643,7 @@ CPPFLAGS="$CPPFLAGS $TCL_INC_PATH -I$CHK_TK_INCLUDE_PATH $X_CFLAGS"
 $as_echo_n "checking if tk is version $CHK_TK_MAJOR.$CHK_TK_MINOR or later... " >&6; }
 
 cat > conftest.$ac_ext <<EOF
-#line 32926 "configure"
+#line 33646 "configure"
 #include "confdefs.h"
 
 #include "$CHK_TK_INCLUDE_PATH/$CHK_TK_INC_NAME"
@@ -33512,7 +34232,7 @@ $as_echo_n "checking saxon9he... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 33515 "configure"
+// #line 34235 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -33729,7 +34449,7 @@ $as_echo_n "checking saxon... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 33732 "configure"
+// #line 34452 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;
@@ -33947,7 +34667,7 @@ $as_echo_n "checking saxon... " >&6; }
     if test ! -f conftestSharedChecker.class ; then
 
     cat << \EOF > conftestSharedChecker.java
-// #line 33950 "configure"
+// #line 34670 "configure"
 import java.util.regex.Pattern;
 import java.io.File;
 import java.io.IOException;

--- a/scilab/configure.ac
+++ b/scilab/configure.ac
@@ -394,6 +394,12 @@ SCIVERSION=`cat $SCI_SRCDIR/Version.incl | sed -e "s/SCIVERSION=//" `
 #############################################
 
 ######################
+####### Set SIMD comilation flags
+######################
+
+AX_CHECK_X86_FEATURES
+
+######################
 ######## Set compilation options for intel C/Fortran compilers
 ######################
 

--- a/scilab/contrib/Makefile.in
+++ b/scilab/contrib/Makefile.in
@@ -89,7 +89,9 @@ subdir = contrib
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/config/mkinstalldirs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -353,6 +355,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/desktop/Makefile.in
+++ b/scilab/desktop/Makefile.in
@@ -96,7 +96,9 @@ subdir = desktop
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/config/mkinstalldirs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -450,6 +452,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/desktop/images/icons/Makefile.in
+++ b/scilab/desktop/images/icons/Makefile.in
@@ -96,7 +96,9 @@ subdir = desktop/images/icons
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/config/mkinstalldirs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -389,6 +391,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/m4/ax_check_x86_features.m4
+++ b/scilab/m4/ax_check_x86_features.m4
@@ -1,0 +1,83 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_x86_features.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_X86_FEATURES([ACTION-IF-FOUND],[ACTION-IF-NOT-FOUND])
+#
+# DESCRIPTION
+#
+#   Checks if the host cpu supports various x86 instruction set, the
+#   instructions that will get tested are "mmx, popcnt, sse, sse2, sse3,
+#   sse4.1, sse4.2, sse4a, avx, avx2, avx512f, fma, fma4, bmi, bmi2". If the
+#   instruction set is supported by the host cpu, the C preprocessor macro
+#   HAVE_XXX_INSTRUCTIONS is set to 1. The XXX is up-cased instruction case
+#   with dot replaced by underscore. For example, the test for "sse4.2"
+#   would export HAVE_SSE4_2_INSTRUCTIONS=1. Also the compiler flag
+#   "-msse4.2" would be added to X86_FEATURE_CFLAGS variable, that can be
+#   obtained in Makefile.am using @X86_FEATURE_CFLAGS@.
+#
+#   If any of the test for the instruction set were succeeded, the configure
+#   script would run ACTION-IF-FOUND if it is specified, or append
+#   X86_FEATURE_CFLAGS to CFLAGS. If none of the instruction were found,
+#   ACTION-IF-NOT-FOUND hook is triggered.
+#
+#   This macro requires gcc extended builtin function "__builtin_cpu_init"
+#   and "__builtin_cpu_supports" to detect the cpu features. It will error
+#   out if the compiler doesn't has these builtins.
+#
+#   See also AX_GCC_X86_CPU_SUPPORTS, which is the actual macro that perform
+#   the checks for the instruction sets.
+#
+# LICENSE
+#
+#   Copyright (c) 2016 Felix Chern <idryman@gmail.com>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+#
+######
+#
+#   Modifications for Balisc (https://github.com/rdbyk/balisc/)
+#   Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+#
+
+#serial 2
+
+AC_DEFUN([AX_CHECK_X86_FEATURES],
+ [m4_foreach_w(
+   [ax_x86_feature],
+   [sse2 sse3 sse4.1 sse4.2 sse4a avx avx avx2 avx512f fma fma4],
+   [AX_GCC_X86_CPU_SUPPORTS(ax_x86_feature,
+     [X86_FEATURE_CFLAGS="$X86_FEATURE_CFLAGS -m[]ax_x86_feature"],
+     [])
+  ])
+  AC_SUBST([X86_FEATURE_CFLAGS])
+  m4_ifval([$1],[$1],
+    [CFLAGS="$CFLAGS $X86_FEATURE_CFLAGS" CXXFLAGS="$CXXFLAGS $X86_FEATURE_CFLAGS"])
+  $2
+])

--- a/scilab/m4/ax_gcc_x86_cpu_supports.m4
+++ b/scilab/m4/ax_gcc_x86_cpu_supports.m4
@@ -1,0 +1,104 @@
+# ============================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_gcc_x86_cpu_supports.html
+# ============================================================================
+#
+# SYNOPSIS
+#
+#   AX_GCC_X86_CPU_SUPPORTS(X86-INSTRUCTION-SET,
+#     [ACTION-IF-FOUND],[ACTION-IF-NOT-FOUND])
+#
+# DESCRIPTION
+#
+#   Checks if the host cpu supports X86-INSTRUCTION-SET. The instruction set
+#   that can be tested are "mmx, popcnt, sse, sse2, sse3, sse4.1, sse4.2,
+#   sse4a, avx, avx2, avx512f, fma, fma4, bmi, bmi2". If the instruction set
+#   is supported by the host cpu, the C preprocessor macro
+#   HAVE_XXX_INSTRUCTIONS is set to 1. The XXX is up-cased instruction case
+#   with dot replaced by underscore. For example, the test for "sse4.2"
+#   would export HAVE_SSE4_2_INSTRUCTIONS=1. This macro requires gcc
+#   extended builtin function "__builtin_cpu_init" and
+#   "__builtin_cpu_supports" to detect the cpu features. It will error out
+#   if the compiler doesn't has these builtins.
+#
+#   If the test for the instruction set succeeded, the hook ACTION-IF-FOUND
+#   would run. Otherwise the hook ACTION-IF-NOT-FOUND would run if
+#   specified.
+#
+#   See also AX_CHECK_X86_FEATURES, which checks all the possible
+#   instruction set and export the corresponding CFLAGS.
+#
+# LICENSE
+#
+#   Copyright (c) 2016 Felix Chern <idryman@gmail.com>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 3
+
+AC_DEFUN_ONCE([_AX_GCC_X86_CPU_INIT],
+ [AC_LANG_PUSH([C])
+  AC_CACHE_CHECK([for gcc __builtin_cpu_init function],
+    [ax_cv_gcc_check_x86_cpu_init],
+    [AC_RUN_IFELSE(
+      [AC_LANG_PROGRAM([#include <stdlib.h>],
+        [__builtin_cpu_init ();])
+      ],
+      [ax_cv_gcc_check_x86_cpu_init=yes],
+      [ax_cv_gcc_check_x86_cpu_init=no])])
+  AS_IF([test "X$ax_cv_gcc_check_x86_cpu_init" = "Xno"],
+    [AC_MSG_ERROR([Need GCC to support X86 CPU features tests])])
+])
+
+AC_DEFUN([AX_GCC_X86_CPU_SUPPORTS],
+  [AC_REQUIRE([AC_PROG_CC])
+   AC_REQUIRE([_AX_GCC_X86_CPU_INIT])
+   AC_LANG_PUSH([C])
+   AS_VAR_PUSHDEF([gcc_x86_feature], [AS_TR_SH([ax_cv_gcc_x86_cpu_supports_$1])])
+   AC_CACHE_CHECK([for x86 $1 instruction support],
+     [gcc_x86_feature],
+     [AC_RUN_IFELSE(
+       [AC_LANG_PROGRAM( [#include <stdlib.h> ],
+       [ __builtin_cpu_init ();
+         if (__builtin_cpu_supports("$1"))
+           return 0;
+         return 1;
+        ])],
+        [gcc_x86_feature=yes],
+        [gcc_x86_feature=no]
+     )]
+   )
+   AC_LANG_POP([C])
+   AS_VAR_IF([gcc_x86_feature],[yes],
+         [AC_DEFINE(
+           AS_TR_CPP([HAVE_$1_INSTRUCTIONS]),
+           [1],
+           [Define if $1 instructions are supported])
+          $2],
+          [$3]
+         )
+   AS_VAR_POPDEF([gcc_x86_feature])
+])

--- a/scilab/modules/Makefile.in
+++ b/scilab/modules/Makefile.in
@@ -121,7 +121,9 @@ subdir = modules
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/config/mkinstalldirs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -525,6 +527,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/action_binding/Makefile.in
+++ b/scilab/modules/action_binding/Makefile.in
@@ -120,7 +120,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_4 = java
 subdir = modules/action_binding
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -515,6 +517,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/api_scilab/Makefile.in
+++ b/scilab/modules/api_scilab/Makefile.in
@@ -113,7 +113,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/api_scilab
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -486,6 +488,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/arnoldi/Makefile.in
+++ b/scilab/modules/arnoldi/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/arnoldi
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -471,6 +473,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/ast/Makefile.in
+++ b/scilab/modules/ast/Makefile.in
@@ -119,7 +119,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_2 = java
 subdir = modules/ast
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -918,6 +920,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/atoms/Makefile.in
+++ b/scilab/modules/atoms/Makefile.in
@@ -114,7 +114,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/atoms
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -412,6 +414,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/boolean/Makefile.in
+++ b/scilab/modules/boolean/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/boolean
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -489,6 +491,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/cacsd/Makefile.in
+++ b/scilab/modules/cacsd/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/cacsd
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -578,6 +580,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/call_scilab/Makefile.in
+++ b/scilab/modules/call_scilab/Makefile.in
@@ -111,7 +111,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/call_scilab
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -472,6 +474,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/commons/Makefile.in
+++ b/scilab/modules/commons/Makefile.in
@@ -122,7 +122,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_5 = java
 subdir = modules/commons
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -504,6 +506,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/compatibility_functions/Makefile.in
+++ b/scilab/modules/compatibility_functions/Makefile.in
@@ -108,7 +108,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/compatibility_functions
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -404,6 +406,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/completion/Makefile.in
+++ b/scilab/modules/completion/Makefile.in
@@ -118,7 +118,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/completion
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -536,6 +538,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/console/Makefile.in
+++ b/scilab/modules/console/Makefile.in
@@ -132,7 +132,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_6 = java
 subdir = modules/console
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -555,6 +557,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/core/Makefile.in
+++ b/scilab/modules/core/Makefile.in
@@ -131,7 +131,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_3 = java
 subdir = modules/core
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -678,6 +680,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/core/includes/machine.h.in
+++ b/scilab/modules/core/includes/machine.h.in
@@ -287,6 +287,9 @@
 /* Define to 1 if you have the `sqrt' function. */
 #undef HAVE_SQRT
 
+/* Define if sse2 instructions are supported */
+#undef HAVE_SSE2_INSTRUCTIONS
+
 /* Define to 1 if `stat' has the bug that it succeeds when given the
    zero-length file name argument. */
 #undef HAVE_STAT_EMPTY_STRING_BUG

--- a/scilab/modules/coverage/Makefile.in
+++ b/scilab/modules/coverage/Makefile.in
@@ -113,7 +113,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/coverage
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -482,6 +484,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/data_structures/Makefile.in
+++ b/scilab/modules/data_structures/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/data_structures
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -465,6 +467,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/demo_tools/Makefile.in
+++ b/scilab/modules/demo_tools/Makefile.in
@@ -107,7 +107,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/demo_tools
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -404,6 +406,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/development_tools/Makefile.in
+++ b/scilab/modules/development_tools/Makefile.in
@@ -107,7 +107,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/development_tools
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -404,6 +406,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/development_tools/src/fake/Makefile.in
+++ b/scilab/modules/development_tools/src/fake/Makefile.in
@@ -81,7 +81,9 @@ subdir = modules/development_tools/src/fake
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/config/mkinstalldirs
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -345,6 +347,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/differential_equations/Makefile.in
+++ b/scilab/modules/differential_equations/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/differential_equations
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -563,6 +565,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/dynamic_link/Makefile.in
+++ b/scilab/modules/dynamic_link/Makefile.in
@@ -112,7 +112,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/dynamic_link
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -511,6 +513,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/elementary_functions/Makefile.in
+++ b/scilab/modules/elementary_functions/Makefile.in
@@ -112,7 +112,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_3 = java
 subdir = modules/elementary_functions
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -684,6 +686,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/elementary_functions/tests/benchmarks/bench_ceil.tst
+++ b/scilab/modules/elementary_functions/tests/benchmarks/bench_ceil.tst
@@ -1,16 +1,36 @@
-// =============================================================================
-// Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-// Copyright (C) 2007-2008 - INRIA
-//
-//  This file is distributed under the same license as the Scilab package.
-// =============================================================================
+// Balisc (https://github.com/rdbyk/balisc/)
+// Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
 
-//==============================================================================
-// Benchmark for ceil function
-//==============================================================================
+// <-- BENCH NB RUN : 5000 -->
 
-// <-- BENCH NB RUN : 10000 -->
+a1 = rand(1,1);
+a2 = rand(3,3);
+a3 = rand(10,10);
+a4 = rand(100,100);
+
+b1 = a1 + a1*%i;
+b2 = a2 + a2*%i;
+b3 = a3 + a3*%i;
+b4 = a4 + a4*%i;
 
 // <-- BENCH START -->
-a = ceil(1000 * rand(700,1,"u"));
+
+for i=1:100
+ ceil(a1);
+ ceil(b2);
+end
+
+for i=1:10
+  ceil(a2);
+  ceil(b2);
+end
+
+for i=1:3
+  ceil(a3);
+  ceil(b3);
+end
+
+ceil(a4);
+ceil(b4);
+
 // <-- BENCH END -->

--- a/scilab/modules/external_objects/Makefile.in
+++ b/scilab/modules/external_objects/Makefile.in
@@ -120,7 +120,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/external_objects
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -565,6 +567,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/external_objects_java/Makefile.in
+++ b/scilab/modules/external_objects_java/Makefile.in
@@ -120,7 +120,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/external_objects_java
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -528,6 +530,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/fftw/Makefile.in
+++ b/scilab/modules/fftw/Makefile.in
@@ -118,7 +118,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_2 = java
 subdir = modules/fftw
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -530,6 +532,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/fileio/Makefile.in
+++ b/scilab/modules/fileio/Makefile.in
@@ -111,7 +111,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/fileio
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -588,6 +590,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/functions/Makefile.in
+++ b/scilab/modules/functions/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/functions
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -464,6 +466,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/functions_manager/Makefile.in
+++ b/scilab/modules/functions_manager/Makefile.in
@@ -116,7 +116,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/functions_manager
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -499,6 +501,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/genetic_algorithms/Makefile.in
+++ b/scilab/modules/genetic_algorithms/Makefile.in
@@ -114,7 +114,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/genetic_algorithms
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -409,6 +411,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/graph/Makefile.in
+++ b/scilab/modules/graph/Makefile.in
@@ -116,7 +116,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/graph
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -410,6 +412,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/graphic_export/Makefile.in
+++ b/scilab/modules/graphic_export/Makefile.in
@@ -121,7 +121,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_3 = java
 subdir = modules/graphic_export
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -518,6 +520,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/graphic_objects/Makefile.in
+++ b/scilab/modules/graphic_objects/Makefile.in
@@ -121,7 +121,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @SWIG_TRUE@am__append_4 = swig
 subdir = modules/graphic_objects
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -553,6 +555,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/graphics/Makefile.in
+++ b/scilab/modules/graphics/Makefile.in
@@ -120,7 +120,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_2 = java
 subdir = modules/graphics
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -938,6 +940,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/gui/Makefile.in
+++ b/scilab/modules/gui/Makefile.in
@@ -125,7 +125,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_4 = java
 subdir = modules/gui
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -645,6 +647,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/hdf5/Makefile.in
+++ b/scilab/modules/hdf5/Makefile.in
@@ -116,7 +116,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/hdf5
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -554,6 +556,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/helptools/Makefile.in
+++ b/scilab/modules/helptools/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/helptools
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -496,6 +498,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/history_browser/Makefile.in
+++ b/scilab/modules/history_browser/Makefile.in
@@ -119,7 +119,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @GUI_TRUE@am__append_2 = libscihistory_browser.la
 subdir = modules/history_browser
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -509,6 +511,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/history_manager/Makefile.in
+++ b/scilab/modules/history_manager/Makefile.in
@@ -114,7 +114,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_2 = java
 subdir = modules/history_manager
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -514,6 +516,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/integer/Makefile.in
+++ b/scilab/modules/integer/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/integer
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -465,6 +467,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/interpolation/Makefile.in
+++ b/scilab/modules/interpolation/Makefile.in
@@ -113,7 +113,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/interpolation
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -516,6 +518,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/io/Makefile.in
+++ b/scilab/modules/io/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/io
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -503,6 +505,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/javasci/Makefile.in
+++ b/scilab/modules/javasci/Makefile.in
@@ -120,7 +120,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @JAVASCI_TRUE@@NEED_JAVA_TRUE@am__append_2 = java
 subdir = modules/javasci
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -472,6 +474,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@
@@ -1012,9 +1015,9 @@ maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
 	-test -z "$(BUILT_SOURCES)" || rm -f $(BUILT_SOURCES)
-@JAVASCI_FALSE@install-html-local:
 @JAVASCI_FALSE@install-data-local:
 @JAVASCI_FALSE@clean-local:
+@JAVASCI_FALSE@install-html-local:
 @JAVASCI_FALSE@distclean-local:
 clean: clean-am
 

--- a/scilab/modules/jvm/Makefile.in
+++ b/scilab/modules/jvm/Makefile.in
@@ -124,7 +124,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_3 = java
 subdir = modules/jvm
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -530,6 +532,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/linear_algebra/Makefile.in
+++ b/scilab/modules/linear_algebra/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/linear_algebra
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -537,6 +539,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/localization/Makefile.in
+++ b/scilab/modules/localization/Makefile.in
@@ -131,7 +131,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_6 = java
 subdir = modules/localization
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -539,6 +541,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/m2sci/Makefile.in
+++ b/scilab/modules/m2sci/Makefile.in
@@ -107,7 +107,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/m2sci
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -401,6 +403,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/matio/Makefile.in
+++ b/scilab/modules/matio/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/matio
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -531,6 +533,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/mexlib/Makefile.in
+++ b/scilab/modules/mexlib/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/mexlib
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -482,6 +484,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/modules_manager/Makefile.in
+++ b/scilab/modules/modules_manager/Makefile.in
@@ -107,7 +107,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/modules_manager
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -402,6 +404,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/mpi/Makefile.in
+++ b/scilab/modules/mpi/Makefile.in
@@ -118,7 +118,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/mpi
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -504,6 +506,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/optimization/Makefile.in
+++ b/scilab/modules/optimization/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/optimization
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -551,6 +553,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/output_stream/Makefile.in
+++ b/scilab/modules/output_stream/Makefile.in
@@ -120,7 +120,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/output_stream
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -539,6 +541,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/overloading/Makefile.in
+++ b/scilab/modules/overloading/Makefile.in
@@ -107,7 +107,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/overloading
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -402,6 +404,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/parallel/Makefile.in
+++ b/scilab/modules/parallel/Makefile.in
@@ -125,7 +125,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/parallel
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -480,6 +482,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/parameters/Makefile.in
+++ b/scilab/modules/parameters/Makefile.in
@@ -118,7 +118,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/parameters
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -470,6 +472,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/polynomials/Makefile.in
+++ b/scilab/modules/polynomials/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/polynomials
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -526,6 +528,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/prebuildjava/Makefile.in
+++ b/scilab/modules/prebuildjava/Makefile.in
@@ -115,7 +115,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/prebuildjava
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -379,6 +381,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/preferences/Makefile.in
+++ b/scilab/modules/preferences/Makefile.in
@@ -121,7 +121,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_4 = java
 subdir = modules/preferences
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -525,6 +527,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/randlib/Makefile.in
+++ b/scilab/modules/randlib/Makefile.in
@@ -111,7 +111,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/randlib
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -516,6 +518,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/renderer/Makefile.in
+++ b/scilab/modules/renderer/Makefile.in
@@ -123,7 +123,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_2 = java
 subdir = modules/renderer
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -474,6 +476,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/scicos/Makefile.in
+++ b/scilab/modules/scicos/Makefile.in
@@ -151,7 +151,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am \
 @OCAML_TRUE@@XCOS_TRUE@am__append_5 = .ml .mli .mll .mly .cmo .cmi .cmx
 subdir = modules/scicos
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -864,6 +866,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/scicos_blocks/Makefile.in
+++ b/scilab/modules/scicos_blocks/Makefile.in
@@ -125,7 +125,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_8 = java
 subdir = modules/scicos_blocks
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -887,6 +889,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/scinotes/Makefile.in
+++ b/scilab/modules/scinotes/Makefile.in
@@ -121,7 +121,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_4 = java
 subdir = modules/scinotes
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -516,6 +518,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/signal_processing/Makefile.in
+++ b/scilab/modules/signal_processing/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/signal_processing
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -538,6 +540,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/simulated_annealing/Makefile.in
+++ b/scilab/modules/simulated_annealing/Makefile.in
@@ -114,7 +114,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/simulated_annealing
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -409,6 +411,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/slint/Makefile.in
+++ b/scilab/modules/slint/Makefile.in
@@ -113,7 +113,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/slint
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -541,6 +543,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/sound/Makefile.in
+++ b/scilab/modules/sound/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/sound
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -457,6 +459,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/sparse/Makefile.in
+++ b/scilab/modules/sparse/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/sparse
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -529,6 +531,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/special_functions/Makefile.in
+++ b/scilab/modules/special_functions/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/special_functions
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -519,6 +521,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/spreadsheet/Makefile.in
+++ b/scilab/modules/spreadsheet/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/spreadsheet
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -505,6 +507,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/statistics/Makefile.in
+++ b/scilab/modules/statistics/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/statistics
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -520,6 +522,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/string/Makefile.in
+++ b/scilab/modules/string/Makefile.in
@@ -111,7 +111,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/string
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -547,6 +549,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/tclsci/Makefile.in
+++ b/scilab/modules/tclsci/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_2 = java
 subdir = modules/tclsci
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -547,6 +549,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/threads/Makefile.in
+++ b/scilab/modules/threads/Makefile.in
@@ -117,7 +117,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/threads
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -467,6 +469,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/time/Makefile.in
+++ b/scilab/modules/time/Makefile.in
@@ -110,7 +110,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/time
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -494,6 +496,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/types/Makefile.in
+++ b/scilab/modules/types/Makefile.in
@@ -124,7 +124,9 @@ check_PROGRAMS = testTypes$(EXEEXT)
 TESTS = testTypes$(EXEEXT)
 subdir = modules/types
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -521,6 +523,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/ui_data/Makefile.in
+++ b/scilab/modules/ui_data/Makefile.in
@@ -121,7 +121,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_4 = java
 subdir = modules/ui_data
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -520,6 +522,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/umfpack/Makefile.in
+++ b/scilab/modules/umfpack/Makefile.in
@@ -117,7 +117,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/umfpack
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -511,6 +513,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/windows_tools/Makefile.in
+++ b/scilab/modules/windows_tools/Makefile.in
@@ -109,7 +109,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/windows_tools
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -465,6 +467,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/xcos/Makefile.in
+++ b/scilab/modules/xcos/Makefile.in
@@ -123,7 +123,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_4 = java
 subdir = modules/xcos
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -530,6 +532,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@

--- a/scilab/modules/xml/Makefile.in
+++ b/scilab/modules/xml/Makefile.in
@@ -118,7 +118,9 @@ DIST_COMMON = $(top_srcdir)/Makefile.incl.am $(srcdir)/Makefile.in \
 @NEED_JAVA_TRUE@am__append_1 = java
 subdir = modules/xml
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+am__aclocal_m4_deps = $(top_srcdir)/m4/ax_check_x86_features.m4 \
+	$(top_srcdir)/m4/ax_cxx_compile_stdcxx_11.m4 \
+	$(top_srcdir)/m4/ax_gcc_x86_cpu_supports.m4 \
 	$(top_srcdir)/m4/backtrace.m4 $(top_srcdir)/m4/compiler.m4 \
 	$(top_srcdir)/m4/curl.m4 $(top_srcdir)/m4/docbook.m4 \
 	$(top_srcdir)/m4/doxygen.m4 $(top_srcdir)/m4/eigen.m4 \
@@ -527,6 +529,7 @@ VALGRIND_LIBS = @VALGRIND_LIBS@
 VERSION = @VERSION@
 WITH_OCAML = @WITH_OCAML@
 WITH_TKSCI = @WITH_TKSCI@
+X86_FEATURE_CFLAGS = @X86_FEATURE_CFLAGS@
 XCOS_ENABLE = @XCOS_ENABLE@
 XGETTEXT = @XGETTEXT@
 XGETTEXT_015 = @XGETTEXT_015@


### PR DESCRIPTION
- sets GCC compiler flags (`CFLAGS`, `CXXFLAGS`) 
- thus `Eigen3` dependant code is more efficient
