### PR TITLE
Cherry-picked implicitlist changes from last reverted PR

### DIFF
--- a/scilab/modules/ast/src/cpp/types/implicitlist.cpp
+++ b/scilab/modules/ast/src/cpp/types/implicitlist.cpp
@@ -233,19 +233,16 @@ bool ImplicitList::compute()
                 return true;
             }
 
-            double dblVal = dblStart; // temp value
-            double dblEps = NumericConstants::eps;
-            double dblPrec = 2 * std::max(fabs(dblStart), fabs(dblEnd)) * dblEps;
+            // compute list size
+            m_iSize = std::ceil(dblRange / dblStep);
 
-            while (dblStep * (dblVal - dblEnd) <= 0)
+            if (m_iSize < 0)
             {
-                m_iSize++;
-                dblVal = dblStart + m_iSize * dblStep;
+                m_iSize = 0;
             }
-
-            if (fabs(dblVal - dblEnd) < dblPrec)
+            else if (std::fabs(m_iSize * dblStep) <= fabs(dblRange))
             {
-                m_iSize++;
+                ++m_iSize;
             }
         }
         else //m_eOutType == ScilabInt

--- a/scilab/modules/ast/src/cpp/types/implicitlist.cpp
+++ b/scilab/modules/ast/src/cpp/types/implicitlist.cpp
@@ -211,33 +211,23 @@ bool ImplicitList::compute()
 
             m_pDblEnd = m_poEnd->getAs<Double>();
             double dblEnd	= m_pDblEnd->get(0);
-            // othe way to compute
+            
+            // handle finiteness of start, step, and end value
+            double dblRange = dblEnd - dblStart;
 
-            // nan value
-            if (ISNAN(dblStart) || ISNAN(dblStep) || ISNAN(dblEnd))
+            if (finite(dblStep) == 0 || finite(dblRange) == 0)
             {
-                m_iSize = -1;
-                m_bComputed = true;
-                return true;
-            }
-
-            // no finite values
-            if ( finite(dblStart) == 0 || finite(dblStep) == 0 || finite(dblEnd) == 0)
-            {
-                if ((dblStep > 0 && dblStart < dblEnd) ||
-                        (dblStep < 0 && dblStart > dblEnd))
+                if (isnan(dblStep) || isnan(dblRange) || std::signbit(dblStep) == std::signbit(dblRange))
                 {
-                    // return nan
                     m_iSize = -1;
                 }
-                // else return []
 
                 m_bComputed = true;
                 return true;
             }
 
-            // step null
-            if (dblStep == 0) // return []
+            // zero step => return []
+            if (dblStep == 0)
             {
                 m_bComputed = true;
                 return true;

--- a/scilab/modules/core/tests/nonreg_tests/issue_87.dia.ref
+++ b/scilab/modules/core/tests/nonreg_tests/issue_87.dia.ref
@@ -1,0 +1,22 @@
+// Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// <-- CLI SHELL MODE -->
+//
+// <-- Non-regression test for issue 87 -->
+//
+// <-- Github URL -->
+// https://github.com/rdbyk/balisc/issues/87
+//
+// <-- Short Description -->
+// Computation of implicit lists is inconsistent/wrong for floating
+// point arguments 
+// a < b < c
+a=nearfloat("pred",5);
+b=5;
+c=nearfloat("succ",5);
+assert_checkequal(1:a, [1,2,3,4]);
+assert_checkequal(1:b, [1,2,3,4,5]);
+assert_checkequal(1:c, [1,2,3,4,5]);
+assert_checkequal(a:-1:1, a-[0,1,2,3]);
+assert_checkequal(b:-1:1, b-[0,1,2,3,4]);
+assert_checkequal(c:-1:1, c-[0,1,2,3,4]);

--- a/scilab/modules/core/tests/nonreg_tests/issue_87.tst
+++ b/scilab/modules/core/tests/nonreg_tests/issue_87.tst
@@ -1,0 +1,24 @@
+// Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// <-- CLI SHELL MODE -->
+//
+// <-- Non-regression test for issue 87 -->
+//
+// <-- Github URL -->
+// https://github.com/rdbyk/balisc/issues/87
+//
+// <-- Short Description -->
+// Computation of implicit lists is inconsistent/wrong for floating
+// point arguments 
+
+// a < b < c
+a=nearfloat("pred",5);
+b=5;
+c=nearfloat("succ",5);
+
+assert_checkequal(1:a, [1,2,3,4]);
+assert_checkequal(1:b, [1,2,3,4,5]);
+assert_checkequal(1:c, [1,2,3,4,5]);
+assert_checkequal(a:-1:1, a-[0,1,2,3]);
+assert_checkequal(b:-1:1, b-[0,1,2,3,4]);
+assert_checkequal(c:-1:1, c-[0,1,2,3,4]);

--- a/scilab/modules/core/tests/unit_tests/colon.dia.ref
+++ b/scilab/modules/core/tests/unit_tests/colon.dia.ref
@@ -44,10 +44,10 @@ a=(1-0.9)*50
    5.
 computed=(1:a)
  computed  = 
-   1.   2.   3.   4.   5.
-expected = [1 2 3 4 5]
+   1.   2.   3.   4.
+expected = [1 2 3 4]
  expected  = 
-   1.   2.   3.   4.   5.
+   1.   2.   3.   4.
 if norm(expected-computed)>100*%eps then bugmes();quit;end
 // With start, step, stop reals
 step=(1-0.9)*20

--- a/scilab/modules/core/tests/unit_tests/colon.tst
+++ b/scilab/modules/core/tests/unit_tests/colon.tst
@@ -26,7 +26,7 @@ if expected<>computed then pause,end
 // With start, step, stop reals
 a=(1-0.9)*50
 computed=(1:a)
-expected = [1 2 3 4 5]
+expected = [1 2 3 4]
 if norm(expected-computed)>100*%eps then pause,end
 // With start, step, stop reals
 step=(1-0.9)*20


### PR DESCRIPTION
- this (re)fixes #87 
- improves speed of implicit list computations
- execution speed of` for i=a:b:c,...,end ` loop is increased
