### PR TITLE
Decrease Overhead of "checkRef"

### DIFF
--- a/scilab/modules/api_scilab/src/cpp/template/api_boolean.hpp
+++ b/scilab/modules/api_scilab/src/cpp/template/api_boolean.hpp
@@ -1,16 +1,16 @@
 /*
-* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-* Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- *
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * 
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
  * This file was originally licensed under the terms of the CeCILL v2.1,
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*/
+ */
 
 #include "gatewaystruct.hxx"
 #include "bool.hxx"
@@ -131,7 +131,7 @@ scilabStatus API_PROTO(setBooleanArray)(scilabEnv env, scilabVar var, const int*
     }
 #endif
 
-    bool bset = b->set(vals) != nullptr;
+    bool bset = b->set(vals);
 #ifdef __API_SCILAB_SAFE__
     if (bset == false)
     {

--- a/scilab/modules/api_scilab/src/cpp/template/api_cell.hpp
+++ b/scilab/modules/api_scilab/src/cpp/template/api_cell.hpp
@@ -1,8 +1,8 @@
 /*
-* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-* Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,7 +10,7 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*/
+ */
 
 #include "gatewaystruct.hxx"
 #include "cell.hxx"
@@ -117,7 +117,7 @@ scilabStatus API_PROTO(setCellValue)(scilabEnv env, scilabVar var, int* index, s
     }
 #endif
     int i = c->getIndex(index);
-    bool bset = c->set(i, (types::InternalType*)val) != nullptr;
+    bool bset = c->set(i, (types::InternalType*)val);
 #ifdef __API_SCILAB_SAFE__
     if (bset == false)
     {
@@ -140,7 +140,7 @@ scilabStatus API_PROTO(setCell2dValue)(scilabEnv env, scilabVar var, int row, in
     }
 #endif
     int i = c->getIndex(index);
-    bool bset = c->set(i, (types::InternalType*)val) != nullptr;
+    bool bset = c->set(i, (types::InternalType*)val);
 #ifdef __API_SCILAB_SAFE__
     if (bset == false)
     {

--- a/scilab/modules/api_scilab/src/cpp/template/api_handle.hpp
+++ b/scilab/modules/api_scilab/src/cpp/template/api_handle.hpp
@@ -1,8 +1,8 @@
 /*
-* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-* Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,7 +10,7 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*/
+ */
 
 #include "gatewaystruct.hxx"
 #include "graphichandle.hxx"
@@ -112,7 +112,7 @@ scilabStatus API_PROTO(setHandleArray)(scilabEnv env, scilabVar var, const long 
     }
 #endif
 
-    bool bset = h->set(vals) != nullptr;
+    bool bset = h->set(vals);
 #ifdef __API_SCILAB_SAFE__
     if (bset == false)
     {

--- a/scilab/modules/api_scilab/src/cpp/template/api_list.hpp
+++ b/scilab/modules/api_scilab/src/cpp/template/api_list.hpp
@@ -1,8 +1,8 @@
 /*
-* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-* Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,7 +10,7 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*/
+ */
 
 #include "gatewaystruct.hxx"
 #include "list.hxx"
@@ -98,7 +98,7 @@ scilabStatus API_PROTO(setListItem)(scilabEnv env, scilabVar var, int index, sci
     }
 #endif
 
-    bool ret = l->set(index, (types::InternalType*)val) != nullptr;
+    bool ret = l->set(index, (types::InternalType*)val);
     return ret ? STATUS_OK : STATUS_ERROR;
 }
 
@@ -153,7 +153,7 @@ scilabStatus API_PROTO(setTListField)(scilabEnv env, scilabVar var, const wchar_
         fields->set(fields->getSize() - 1, field);
     }
 
-    bool ret = l->set(field, (types::InternalType*)val) != nullptr;
+    bool ret = l->set(field, (types::InternalType*)val);
     return ret ? STATUS_OK : STATUS_ERROR;
 }
 
@@ -206,7 +206,7 @@ scilabStatus API_PROTO(setMListField)(scilabEnv env, scilabVar var, const wchar_
         fields->set(fields->getSize() - 1, field);
     }
 
-    bool ret = l->set(field, (types::InternalType*)val) != nullptr;
+    bool ret = l->set(field, (types::InternalType*)val);
     return ret ? STATUS_OK : STATUS_ERROR;
 }
 

--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -422,7 +422,7 @@ public :
 
     virtual ArrayOf<T>* insert(typed_list* _pArgs, InternalType* _pSource);
     virtual ArrayOf<T>* append(int _iRows, int _iCols, InternalType* _poSource);
-    virtual ArrayOf<T>* resize(int* _piDims, int _iDims);
+    virtual bool resize(int* _piDims, int _iDims);
 
     // return a GenericType because of [] wich is a types::Double (can't be a ArrayOf<char>)
     virtual GenericType* remove(typed_list* _pArgs);
@@ -444,7 +444,7 @@ public :
     virtual bool reshape(int* _piDims, int _iDims);
 
 
-    virtual ArrayOf<T>* resize(int _iNewRows, int _iNewCols)
+    virtual bool resize(int _iNewRows, int _iNewCols)
     {
         int piDims[2] = {_iNewRows, _iNewCols};
         return resize(piDims, 2);

--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -372,6 +372,7 @@ public :
     virtual ArrayOf<T>* insert(typed_list* _pArgs, InternalType* _pSource);
     virtual bool append(int _iRows, int _iCols, InternalType* _poSource);
     virtual bool resize(int* _piDims, int _iDims);
+    ArrayOf<T>* resizeClone(int* _piDims, int _iDims);
 
     // return a GenericType because of [] wich is a types::Double (can't be a ArrayOf<char>)
     virtual GenericType* remove(typed_list* _pArgs);

--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -372,7 +372,6 @@ public :
     virtual ArrayOf<T>* insert(typed_list* _pArgs, InternalType* _pSource);
     virtual bool append(int _iRows, int _iCols, InternalType* _poSource);
     virtual bool resize(int* _piDims, int _iDims);
-    ArrayOf<T>* resizeClone(int* _piDims, int _iDims);
 
     // return a GenericType because of [] wich is a types::Double (can't be a ArrayOf<char>)
     virtual GenericType* remove(typed_list* _pArgs);

--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -435,13 +435,13 @@ public :
     virtual int getInvokeNbIn();
     virtual int getInvokeNbOut();
 
-    virtual ArrayOf<T>* reshape(int _iNewRows, int _iNewCols)
+    virtual bool reshape(int _iNewRows, int _iNewCols)
     {
         int piDims[2] = {_iNewRows, _iNewCols};
         return reshape(piDims, 2);
     }
 
-    virtual ArrayOf<T>* reshape(int* _piDims, int _iDims);
+    virtual bool reshape(int* _piDims, int _iDims);
 
 
     virtual ArrayOf<T>* resize(int _iNewRows, int _iNewCols)

--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -412,7 +412,7 @@ public :
     }
 
     virtual ArrayOf<T>* insert(typed_list* _pArgs, InternalType* _pSource);
-    virtual ArrayOf<T>* append(int _iRows, int _iCols, InternalType* _poSource);
+    virtual bool append(int _iRows, int _iCols, InternalType* _poSource);
     virtual bool resize(int* _piDims, int _iDims);
 
     // return a GenericType because of [] wich is a types::Double (can't be a ArrayOf<char>)

--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -215,15 +215,8 @@ public :
         deleteData(tNullVal);
     }
 
-    virtual ArrayOf<T>* setComplex(bool _bComplex)
+    virtual void setComplex(bool _bComplex)
     {
-        typedef ArrayOf<T>* (ArrayOf<T>::*setcplx_t)(bool);
-        ArrayOf<T>* pIT = checkRef(this, (setcplx_t)&ArrayOf<T>::setComplex, _bComplex);
-        if (pIT != this)
-        {
-            return pIT;
-        }
-
         if (_bComplex == false)
         {
             if (m_pImgData != NULL)
@@ -239,8 +232,6 @@ public :
                 memset(m_pImgData, 0x00, sizeof(T) * m_iSize);
             }
         }
-
-        return this;
     }
 
     virtual ArrayOf<T>* set(int _iPos, const T _data)

--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -234,42 +234,28 @@ public :
         }
     }
 
-    virtual ArrayOf<T>* set(int _iPos, const T _data)
+    virtual bool set(int _iPos, const T _data)
     {
         if (m_pRealData == NULL || _iPos >= m_iSize)
         {
-            return NULL;
-        }
-
-        typedef ArrayOf<T>* (ArrayOf<T>::*set_t)(int, T);
-        ArrayOf<T>* pIT = checkRef(this, (set_t)&ArrayOf<T>::set, _iPos, _data);
-        if (pIT != this)
-        {
-            return pIT;
+            return false;
         }
 
         deleteData(m_pRealData[_iPos]);
         m_pRealData[_iPos] = copyValue(_data);
-        return this;
+        return true;
     }
 
-    virtual ArrayOf<T>* set(int _iRows, int _iCols, const T _data)
+    virtual bool set(int _iRows, int _iCols, const T _data)
     {
         return set(_iCols * getRows() + _iRows, _data);
     }
 
-    virtual ArrayOf<T>* set(T* _pdata)
+    virtual bool set(T* _pdata)
     {
         if (m_pRealData == NULL)
         {
-            return NULL;
-        }
-
-        typedef ArrayOf<T>* (ArrayOf<T>::*set_t)(T*);
-        ArrayOf<T>* pIT = checkRef(this, (set_t)&ArrayOf<T>::set, _pdata);
-        if (pIT != this)
-        {
-            return pIT;
+            return false;
         }
 
         for (int i = 0 ; i < m_iSize ; i++)
@@ -277,21 +263,14 @@ public :
             deleteData(m_pRealData[i]);
             m_pRealData[i] = copyValue(_pdata[i]);
         }
-        return this;
+        return true;
     }
 
-    virtual ArrayOf<T>* set(const T* _pdata)
+    virtual bool set(const T* _pdata)
     {
         if (m_pRealData == NULL)
         {
-            return NULL;
-        }
-
-        typedef ArrayOf<T>* (ArrayOf<T>::*set_t)(const T*);
-        ArrayOf<T>* pIT = checkRef(this, (set_t)&ArrayOf<T>::set, _pdata);
-        if (pIT != this)
-        {
-            return pIT;
+            return false;
         }
 
         for (int i = 0 ; i < m_iSize ; i++)
@@ -300,7 +279,7 @@ public :
             m_pRealData[i] = copyValue(_pdata[i]);
         }
 
-        return this;
+        return true;
     }
 
     inline T* get() const

--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -302,42 +302,28 @@ public :
     }
 
     /*internal function to manage img part*/
-    ArrayOf<T>* setImg(int _iPos, T _data)
+    bool setImg(int _iPos, T _data)
     {
         if (m_pImgData == NULL || _iPos >= m_iSize)
         {
-            return NULL;
-        }
-
-        typedef ArrayOf<T>* (ArrayOf<T>::*setimg_t)(int, T);
-        ArrayOf<T>* pIT = checkRef(this, (setimg_t)&ArrayOf<T>::setImg, _iPos, _data);
-        if (pIT != this)
-        {
-            return pIT;
+            return false;
         }
 
         m_pImgData[_iPos] = copyValue(_data);
-        return this;
+        return true;
     }
 
 
-    ArrayOf<T>* setImg(int _iRows, int _iCols, T _data)
+    bool setImg(int _iRows, int _iCols, T _data)
     {
         return setImg(_iCols * getRows() + _iRows, copyValue(_data));
     }
 
-    ArrayOf<T>* setImg(T* _pdata)
+    bool setImg(T* _pdata)
     {
         if (m_pImgData == NULL)
         {
-            return NULL;
-        }
-
-        typedef ArrayOf<T>* (ArrayOf<T>::*setimg_t)(T*);
-        ArrayOf<T>* pIT = checkRef(this, (setimg_t)&ArrayOf<T>::setImg, _pdata);
-        if (pIT != this)
-        {
-            return pIT;
+            return false;
         }
 
         for (int i = 0 ; i < m_iSize ; i++)
@@ -345,22 +331,15 @@ public :
             m_pImgData[i] = copyValue(_pdata[i]);
         }
 
-        return this;
+        return true;
     }
 
 
-    ArrayOf<T>* setImg(const T* _pdata)
+    bool setImg(const T* _pdata)
     {
         if (m_pImgData == NULL)
         {
-            return NULL;
-        }
-
-        typedef ArrayOf<T>* (ArrayOf<T>::*setimg_t)(const T*);
-        ArrayOf<T>* pIT = checkRef(this, (setimg_t)&ArrayOf<T>::setImg, _pdata);
-        if (pIT != this)
-        {
-            return pIT;
+            return false;
         }
 
         for (int i = 0 ; i < m_iSize ; i++)
@@ -368,7 +347,7 @@ public :
             m_pImgData[i] = copyValue(_pdata[i]);
         }
 
-        return this;
+        return true;
     }
 
     inline T* getImg() const

--- a/scilab/modules/ast/includes/types/bool.hxx
+++ b/scilab/modules/ast/includes/types/bool.hxx
@@ -1,8 +1,8 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 // This code is separated in bool.hxx
 // but will be inlined in arrayof.hxx
@@ -53,8 +53,8 @@ public:
 
 
     /*zero or one set filler*/
-    Bool*                   setFalse();
-    Bool*                   setTrue();
+    void setFalse();
+    void setTrue();
 
     /*Config management*/
     void                    whoAmI();

--- a/scilab/modules/ast/includes/types/cell.hxx
+++ b/scilab/modules/ast/includes/types/cell.hxx
@@ -1,9 +1,9 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
-*  Copyright (C) 2011 - DIGITEO - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
+ * Copyright (C) 2011 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyrigth (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -11,8 +11,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 
 //#ifndef __ARRAYOF_HXX__
@@ -68,11 +68,11 @@ public :
     */
     Cell*               clone();
 
-    Cell*               set(int _iRows, int _iCols, InternalType* _pIT);
-    Cell*               set(int _iRows, int _iCols, const InternalType* _pIT);
-    Cell*               set(int _iIndex, InternalType* _pIT);
-    Cell*               set(int _iIndex, const InternalType* _pIT);
-    Cell*               set(InternalType** _pIT);
+    bool set(int _iRows, int _iCols, InternalType* _pIT);
+    bool set(int _iRows, int _iCols, const InternalType* _pIT);
+    bool set(int _iIndex, InternalType* _pIT);
+    bool set(int _iIndex, const InternalType* _pIT);
+    bool set(InternalType** _pIT);
 
     bool                operator==(const InternalType& it);
     bool                operator!=(const InternalType& it);

--- a/scilab/modules/ast/includes/types/double.hxx
+++ b/scilab/modules/ast/includes/types/double.hxx
@@ -66,7 +66,7 @@ public :
     Double*                     clone();
     void fillFromCol(int _iCols, Double *_poSource);
     void fillFromRow(int _iRows, Double *_poSource);
-    Double*                     append(int _iRows, int _iCols, InternalType* _poSource);
+    bool append(int _iRows, int _iCols, InternalType* _poSource);
 
     //bool                        append(int _iRows, int _iCols, Double *_poSource);
 

--- a/scilab/modules/ast/includes/types/double.hxx
+++ b/scilab/modules/ast/includes/types/double.hxx
@@ -269,41 +269,27 @@ public :
 
     virtual ast::Exp*           getExp(const Location& loc);
 
-    virtual Double* set(int _iPos, const double _data)
+    virtual bool set(int _iPos, const double _data)
     {
         if (_iPos >= m_iSize)
         {
-            return NULL;
-        }
-
-        typedef Double* (Double::*set_t)(int, double);
-        Double* pIT = checkRef(this, (set_t)&Double::set, _iPos, _data);
-        if (pIT != this)
-        {
-            return pIT;
+            return false;
         }
 
         m_pRealData[_iPos] = _data;
-        return this;
+        return true;
     }
 
-    virtual Double* set(int _iRows, int _iCols, const double _data)
+    virtual bool set(int _iRows, int _iCols, const double _data)
     {
         return set(_iCols * m_iRows + _iRows, _data);
     }
 
-    virtual Double* set(double* _pdata)
+    virtual bool set(double* _pdata)
     {
         if (m_pRealData == NULL)
         {
-            return NULL;
-        }
-
-        typedef Double* (Double::*set_t)(double*);
-        Double* pIT = checkRef(this, (set_t)&Double::set, _pdata);
-        if (pIT != this)
-        {
-            return pIT;
+            return false;
         }
 
         for (int i = 0; i < m_iSize; i++)
@@ -311,21 +297,14 @@ public :
             m_pRealData[i] = _pdata[i];
         }
 
-        return this;
+        return true;
     }
 
-    virtual Double* set(const double* _pdata)
+    virtual bool set(const double* _pdata)
     {
         if (m_pRealData == NULL)
         {
-            return NULL;
-        }
-
-        typedef Double* (Double::*set_t)(const double*);
-        Double* pIT = checkRef(this, (set_t)&Double::set, _pdata);
-        if (pIT != this)
-        {
-            return pIT;
+            return false;
         }
 
         for (int i = 0; i < m_iSize; i++)
@@ -333,7 +312,7 @@ public :
             m_pRealData[i] = _pdata[i];
         }
 
-        return this;
+        return true;
     }
 
     virtual bool isNativeType() override

--- a/scilab/modules/ast/includes/types/internal.hxx
+++ b/scilab/modules/ast/includes/types/internal.hxx
@@ -244,7 +244,15 @@ public :
         return _pIT;
     }
 
-
+    template <typename T>
+    T* copy(T* _pIT)
+    {
+        if (getRef() > 1)
+        {
+            return _pIT->clone()->template getAs<T>();
+        }
+        return _pIT;
+    }
 
 #ifdef _SCILAB_DEBUGREF_
     inline void _killme(const char * f, int l)

--- a/scilab/modules/ast/includes/types/internal.hxx
+++ b/scilab/modules/ast/includes/types/internal.hxx
@@ -244,14 +244,14 @@ public :
         return _pIT;
     }
 
-    template <typename T>
-    T* copy(T* _pIT)
+    template <class T>
+    inline T* copyAs(void)
     {
         if (getRef() > 1)
         {
-            return _pIT->clone()->template getAs<T>();
+            return static_cast<T*>(this->clone());
         }
-        return _pIT;
+        return static_cast<T*>(this);
     }
 
 #ifdef _SCILAB_DEBUGREF_

--- a/scilab/modules/ast/includes/types/list.hxx
+++ b/scilab/modules/ast/includes/types/list.hxx
@@ -1,8 +1,8 @@
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -51,7 +51,7 @@ public :
     ** append(InternalType *_typedValue)
     ** Append the given value to the end of the List
     */
-    List*                           append(InternalType *_typedValue);
+    bool append(InternalType *_typedValue);
 
     /**
     ** Clone

--- a/scilab/modules/ast/includes/types/list.hxx
+++ b/scilab/modules/ast/includes/types/list.hxx
@@ -117,6 +117,7 @@ public :
 
     virtual InternalType*           get(const int _iIndex);
     virtual bool set(const int _iIndex, InternalType* _pIT);
+    virtual List* setClone(const int _iIndex, InternalType* _pIT);
 
     /* return type as string ( double, int, cell, list, ... )*/
     virtual std::wstring            getTypeStr() const

--- a/scilab/modules/ast/includes/types/list.hxx
+++ b/scilab/modules/ast/includes/types/list.hxx
@@ -116,7 +116,7 @@ public :
     }
 
     virtual InternalType*           get(const int _iIndex);
-    virtual List*                   set(const int _iIndex, InternalType* _pIT);
+    virtual bool set(const int _iIndex, InternalType* _pIT);
 
     /* return type as string ( double, int, cell, list, ... )*/
     virtual std::wstring            getTypeStr() const

--- a/scilab/modules/ast/includes/types/polynom.hxx
+++ b/scilab/modules/ast/includes/types/polynom.hxx
@@ -50,8 +50,8 @@ public :
     // FIXME : Should not return NULL
     Polynom*                clone();
 
-    Polynom*                setCoef(int _iRows, int _iCols, Double *_pdblCoef);
-    Polynom*                setCoef(int _iIdx, Double *_pdblCoef);
+    bool setCoef(int _iRows, int _iCols, Double *_pdblCoef);
+    bool setCoef(int _iIdx, Double *_pdblCoef);
 
     virtual void setComplex(bool _bComplex);
 
@@ -85,7 +85,7 @@ public :
     Double*                 evaluate(Double* _pdblValue);
     void                    updateRank(void);
     Double*                 getCoef(void);
-    Polynom*                setCoef(Double *_pCoef);
+    bool setCoef(Double *_pCoef);
     Double*                 extractCoef(int _iRank);
     bool                    insertCoef(int _iRank, Double* _pCoef);
     void                    setZeros();

--- a/scilab/modules/ast/includes/types/polynom.hxx
+++ b/scilab/modules/ast/includes/types/polynom.hxx
@@ -91,9 +91,9 @@ public :
     void                    setZeros();
     Polynom*                insert(typed_list* _pArgs, InternalType* _pSource);
 
-    Polynom*                set(int _iPos, SinglePoly* _pS);
-    Polynom*                set(int _iRows, int _iCols, SinglePoly* _pS);
-    Polynom*                set(SinglePoly** _pS);
+    bool set(int _iPos, SinglePoly* _pS);
+    bool set(int _iRows, int _iCols, SinglePoly* _pS);
+    bool set(SinglePoly** _pS);
 
     std::wstring            getRowString(int* _piDims, int _iDims, bool _bComplex);
     std::wstring            getColString(int* _piDims, int _iDims, bool _bComplex);

--- a/scilab/modules/ast/includes/types/polynom.hxx
+++ b/scilab/modules/ast/includes/types/polynom.hxx
@@ -1,8 +1,8 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyrigth (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 // This code is separated in matrixpoly.hxx
 // but will be inlined in arrayof.hxx
@@ -53,7 +53,7 @@ public :
     Polynom*                setCoef(int _iRows, int _iCols, Double *_pdblCoef);
     Polynom*                setCoef(int _iIdx, Double *_pdblCoef);
 
-    virtual Polynom*        setComplex(bool _bComplex);
+    virtual void setComplex(bool _bComplex);
 
     inline ScilabType       getType(void)
     {

--- a/scilab/modules/ast/includes/types/sparse.hxx
+++ b/scilab/modules/ast/includes/types/sparse.hxx
@@ -185,7 +185,7 @@ struct EXTERN_AST Sparse : GenericType
        @param _iCols col to append from
        @param _poSource src data to append
      */
-    Sparse* append(int r, int c, types::Sparse SPARSE_CONST* src);
+    bool append(int r, int c, types::Sparse SPARSE_CONST* src);
 
     /*
       extract a submatrix
@@ -525,7 +525,7 @@ struct EXTERN_AST SparseBool : GenericType
     bool reshape(int* _piNewDims, int _iNewDims);
     bool reshape(int _iNewRows, int _iNewCols);
     SparseBool* insert(typed_list* _pArgs, InternalType* _pSource);
-    SparseBool* append(int _iRows, int _iCols, SparseBool SPARSE_CONST* _poSource);
+    bool append(int _iRows, int _iCols, SparseBool SPARSE_CONST* _poSource);
 
     GenericType* remove(typed_list* _pArgs);
     GenericType* insertNew(typed_list* _pArgs);

--- a/scilab/modules/ast/includes/types/sparse.hxx
+++ b/scilab/modules/ast/includes/types/sparse.hxx
@@ -82,14 +82,14 @@ struct EXTERN_AST Sparse : GenericType
     void finalize();
 
     /*data management member function defined for compatibility with the Double API*/
-    Sparse* set(int _iRows, int _iCols, double _dblReal, bool _bFinalize = true);
-    Sparse* set(int _iIndex, double _dblReal, bool _bFinalize = true)
+    bool set(int _iRows, int _iCols, double _dblReal, bool _bFinalize = true);
+    bool set(int _iIndex, double _dblReal, bool _bFinalize = true)
     {
         return set(_iIndex % m_iRows, _iIndex / m_iRows, _dblReal, _bFinalize);
     }
 
-    Sparse* set(int _iRows, int _iCols, std::complex<double> v, bool _bFinalize = true);
-    Sparse* set(int _iIndex, std::complex<double> v, bool _bFinalize = true)
+    bool set(int _iRows, int _iCols, std::complex<double> v, bool _bFinalize = true);
+    bool set(int _iIndex, std::complex<double> v, bool _bFinalize = true)
     {
         return set(_iIndex % m_iRows, _iIndex / m_iRows, v, _bFinalize);
     }
@@ -620,8 +620,8 @@ struct EXTERN_AST SparseBool : GenericType
         return get(_iIndex % m_iRows, _iIndex / m_iRows);
     }
 
-    SparseBool* set(int r, int c, bool b, bool _bFinalize = true) SPARSE_CONST;
-    SparseBool* set(int _iIndex, bool b, bool _bFinalize = true) SPARSE_CONST
+    bool set(int r, int c, bool b, bool _bFinalize = true) SPARSE_CONST;
+    bool set(int _iIndex, bool b, bool _bFinalize = true) SPARSE_CONST
     {
         return set(_iIndex % m_iRows, _iIndex / m_iRows, b, _bFinalize);
     }

--- a/scilab/modules/ast/includes/types/sparse.hxx
+++ b/scilab/modules/ast/includes/types/sparse.hxx
@@ -154,7 +154,7 @@ struct EXTERN_AST Sparse : GenericType
        @param _iNewCols new minimum nb of cols
        @return true upon succes, false otherwise.
      */
-    Sparse* resize(int _iNewRows, int _iNewCols);
+    bool resize(int _iNewRows, int _iNewCols);
     /* post condition: new total size must be equal to the old size.
                        Two dimensions maximum.
 
@@ -521,7 +521,7 @@ struct EXTERN_AST SparseBool : GenericType
     /* Config management and GenericType methods overrides */
     SparseBool* clone(void);
 
-    SparseBool* resize(int _iNewRows, int _iNewCols);
+    bool resize(int _iNewRows, int _iNewCols);
     bool reshape(int* _piNewDims, int _iNewDims);
     bool reshape(int _iNewRows, int _iNewCols);
     SparseBool* insert(typed_list* _pArgs, InternalType* _pSource);

--- a/scilab/modules/ast/includes/types/sparse.hxx
+++ b/scilab/modules/ast/includes/types/sparse.hxx
@@ -1,8 +1,8 @@
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2010-2010 - DIGITEO - Bernard Hugueney
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2010-2010 - DIGITEO - Bernard Hugueney
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -164,8 +164,8 @@ struct EXTERN_AST Sparse : GenericType
        @param _iNewDims new size for each dimension
        @return true upon succes, false otherwise.
     */
-    Sparse* reshape(int* _piNewDims, int _iNewDims);
-    Sparse* reshape(int _iNewRows, int _iNewCols);
+    bool reshape(int* _piNewDims, int _iNewDims);
+    bool reshape(int _iNewRows, int _iNewCols);
     /*
       insert _iSeqCount elements from _poSource at coords given by _piSeqCoord (max in _piMaxDim).
       coords are considered 1D if _bAsVector, 2D otherwise.
@@ -522,8 +522,8 @@ struct EXTERN_AST SparseBool : GenericType
     SparseBool* clone(void);
 
     SparseBool* resize(int _iNewRows, int _iNewCols);
-    SparseBool* reshape(int* _piNewDims, int _iNewDims);
-    SparseBool* reshape(int _iNewRows, int _iNewCols);
+    bool reshape(int* _piNewDims, int _iNewDims);
+    bool reshape(int _iNewRows, int _iNewCols);
     SparseBool* insert(typed_list* _pArgs, InternalType* _pSource);
     SparseBool* append(int _iRows, int _iCols, SparseBool SPARSE_CONST* _poSource);
 

--- a/scilab/modules/ast/includes/types/string.hxx
+++ b/scilab/modules/ast/includes/types/string.hxx
@@ -51,13 +51,13 @@ public :
     virtual String* set_(int _iPos, const wchar_t* _pwstData);
     virtual String* set_(int _iRows, int _iCols, const wchar_t* _pwstData);
 
-    virtual String*         set(int _iPos, const wchar_t* _pwstData);
-    virtual String*         set(int _iRows, int _iCols, const wchar_t* _pwstData);
-    virtual String*         set(const wchar_t* const* _pwstData);
+    virtual bool set(int _iPos, const wchar_t* _pwstData);
+    virtual bool set(int _iRows, int _iCols, const wchar_t* _pwstData);
+    virtual bool set(const wchar_t* const* _pwstData);
 
-    virtual String*         set(int _iPos, const char* _pcData);
-    virtual String*         set(int _iRows, int _iCols, const char* _pcData);
-    virtual String*         set(const char* const* _pstrData);
+    virtual bool set(int _iPos, const char* _pcData);
+    virtual bool set(int _iRows, int _iCols, const char* _pcData);
+    virtual bool set(const char* const* _pstrData);
 
     bool                    operator==(const InternalType& it);
     bool                    operator!=(const InternalType& it);

--- a/scilab/modules/ast/includes/types/string.hxx
+++ b/scilab/modules/ast/includes/types/string.hxx
@@ -48,8 +48,8 @@ public :
 
     void                    whoAmI();
 
-    virtual String* set_(int _iPos, const wchar_t* _pwstData);
-    virtual String* set_(int _iRows, int _iCols, const wchar_t* _pwstData);
+    void set_(int _iPos, const wchar_t* _pwstData);
+    void set_(int _iRows, int _iCols, const wchar_t* _pwstData);
 
     virtual bool set(int _iPos, const wchar_t* _pwstData);
     virtual bool set(int _iRows, int _iCols, const wchar_t* _pwstData);

--- a/scilab/modules/ast/includes/types/struct.hxx
+++ b/scilab/modules/ast/includes/types/struct.hxx
@@ -106,9 +106,9 @@ public :
     bool                        subMatrixToString(std::wostringstream& ostr, int* _piDims, int _iDims) override;
     String*                     getFieldNames();
     bool                        exists(const std::wstring& _sKey);
-    Struct*                     addField(const std::wstring& _sKey);
-    Struct*                     addFieldFront(const std::wstring& _sKey);
-    Struct*                     removeField(const std::wstring& _sKey);
+    void addField(const std::wstring& _sKey);
+    void addFieldFront(const std::wstring& _sKey);
+    void removeField(const std::wstring& _sKey);
     bool                        toString(std::wostringstream& ostr);
     List*                       extractFieldWithoutClone(const std::wstring& _wstField);
     std::vector<InternalType*>  extractFields(std::vector<std::wstring> _wstFields);

--- a/scilab/modules/ast/includes/types/struct.hxx
+++ b/scilab/modules/ast/includes/types/struct.hxx
@@ -69,11 +69,11 @@ public :
     */
     Struct*                     clone();
 
-    Struct*                     set(int _iRows, int _iCols, SingleStruct* _pIT);
-    Struct*                     set(int _iRows, int _iCols, const SingleStruct* _pIT);
-    Struct*                     set(int _iIndex, SingleStruct* _pIT);
-    Struct*                     set(int _iIndex, const SingleStruct* _pIT);
-    Struct*                     set(SingleStruct** _pIT);
+    bool set(int _iRows, int _iCols, SingleStruct* _pIT);
+    bool set(int _iRows, int _iCols, const SingleStruct* _pIT);
+    bool set(int _iIndex, SingleStruct* _pIT);
+    bool set(int _iIndex, const SingleStruct* _pIT);
+    bool set(SingleStruct** _pIT);
 
     bool                        operator==(const InternalType& it);
     bool                        operator!=(const InternalType& it);

--- a/scilab/modules/ast/includes/types/struct.hxx
+++ b/scilab/modules/ast/includes/types/struct.hxx
@@ -1,8 +1,8 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2011 - DIGITEO - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2011 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyrigth (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 #ifndef __STRUCT_HXX__
 #define __STRUCT_HXX__
@@ -115,8 +115,8 @@ public :
     std::vector<InternalType*>  extractFields(typed_list* _pArgs);
     InternalType *              extractField(const std::wstring& wstField);
 
-    Struct*                     resize(int* _piDims, int _iDims);
-    Struct*                     resize(int _iNewRows, int _iNewCols);
+    bool resize(int* _piDims, int _iDims);
+    bool resize(int _iNewRows, int _iNewCols);
 
     /*specials functions to disable clone operation during copydata*/
     InternalType*               insertWithoutClone(typed_list* _pArgs, InternalType* _pSource);

--- a/scilab/modules/ast/includes/types/tlist.hxx
+++ b/scilab/modules/ast/includes/types/tlist.hxx
@@ -55,6 +55,9 @@ public :
     bool set(const std::wstring& _sKey, InternalType* _pIT);
     bool set(const int _iIndex, InternalType* _pIT);
 
+    TList* setClone(const std::wstring& _sKey, InternalType* _pIT);
+    TList* setClone(const int _iIndex, InternalType* _pIT);
+
     using List::extract; // to avoid this extract to hide extract in list
     bool                            extract(const std::wstring& name, InternalType *& out);
 

--- a/scilab/modules/ast/includes/types/tlist.hxx
+++ b/scilab/modules/ast/includes/types/tlist.hxx
@@ -1,8 +1,8 @@
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2010-2010 - DIGITEO - Antoine ELIAS
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2010-2010 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -52,8 +52,8 @@ public :
     bool                            exists(const std::wstring& _sKey);
     InternalType*                   getField(const std::wstring& _sKey);
     int                             getIndexFromString(const std::wstring& _sKey);
-    TList*                          set(const std::wstring& _sKey, InternalType* _pIT);
-    TList*                          set(const int _iIndex, InternalType* _pIT);
+    bool set(const std::wstring& _sKey, InternalType* _pIT);
+    bool set(const int _iIndex, InternalType* _pIT);
 
     using List::extract; // to avoid this extract to hide extract in list
     bool                            extract(const std::wstring& name, InternalType *& out);

--- a/scilab/modules/ast/includes/types/types.hxx
+++ b/scilab/modules/ast/includes/types/types.hxx
@@ -178,6 +178,13 @@ public :
         return NULL;
     }
 
+    virtual GenericType* resizeClone(int* /*_piDims*/, int /*_iDims*/);
+
+    virtual GenericType* resizeClone(int _iNewRows, int _iNewCols)
+    {
+        int piDims[2] = {_iNewRows, _iNewCols};
+        return resizeClone(piDims, 2);
+    }
 };
 
 }

--- a/scilab/modules/ast/includes/types/types.hxx
+++ b/scilab/modules/ast/includes/types/types.hxx
@@ -143,14 +143,14 @@ public :
         return NULL;
     }
 
-    virtual GenericType*        reshape(int* /*_piDims*/, int /*_iDims*/)
+    virtual bool reshape(int* /*_piDims*/, int /*_iDims*/)
     {
-        return NULL;
+        return false;
     }
 
-    virtual GenericType*        reshape(int /*_iNewRows*/, int /*_iNewCols*/)
+    virtual bool reshape(int /*_iNewRows*/, int /*_iNewCols*/)
     {
-        return NULL;
+        return false;
     }
 
     virtual GenericType*        insert(typed_list* /*_pArgs*/, InternalType* /*_pSource*/)

--- a/scilab/modules/ast/includes/types/types.hxx
+++ b/scilab/modules/ast/includes/types/types.hxx
@@ -133,14 +133,14 @@ public :
         return NULL;
     }
 
-    virtual GenericType*        resize(int* /*_piDims*/, int /*_iDims*/)
+    virtual bool resize(int* /*_piDims*/, int /*_iDims*/)
     {
-        return NULL;
+        return false;
     }
 
-    virtual GenericType*        resize(int /*_iNewRows*/, int /*_iNewCols*/)
+    virtual bool resize(int /*_iNewRows*/, int /*_iNewCols*/)
     {
-        return NULL;
+        return false;
     }
 
     virtual bool reshape(int* /*_piDims*/, int /*_iDims*/)

--- a/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
+++ b/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
@@ -995,7 +995,11 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                     // copy current struct (if necessary it gets cloned!)
                     pStruct = pStruct->copyAs<types::Struct>();
                     // resize current struct
-                    pStruct->resize(pEH->getArgsDimsArray(), pEH->getArgsDims());
+                    // FIXME: is this check really needed?
+                    if (pStruct->resize(pEH->getArgsDimsArray(), pEH->getArgsDims()) == false)
+                    {
+                        pStruct = NULL;
+                    }
                     pEH->setCurrent(pStruct);
                 }
 
@@ -1102,7 +1106,12 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         int iNewSize = pEH->getSizeFromArgs();
                         if (pTL->getSize() < iNewSize)
                         {
-                            pTL = pTL->set(iNewSize - 1, new types::ListUndefined());
+                            pTL = pTL->copyAs<types::TList>();
+                            // FIXME: is this check really needed?
+                            if (pTL->set(iNewSize - 1, new types::ListUndefined()) == false)
+                            {
+                                pTL = NULL;
+                            }
                             pEH->setCurrent(pTL);
                         }
 
@@ -1258,7 +1267,12 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                             int iNewSize = pEH->getSizeFromArgs();
                             if (pL->getSize() < iNewSize)
                             {
-                                pL = pL->set(iNewSize - 1, new types::ListUndefined());
+                                pL = pL->copyAs<types::List>();
+                                // FIXME: is this check really needed?
+                                if(pL->set(iNewSize - 1, new types::ListUndefined()) == false)
+                                {
+                                    pL = NULL;
+                                }
                                 pEH->setCurrent(pL);
                             }
 
@@ -1447,7 +1461,11 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                                 // copy current Cell
                                 pCell = pCell->copyAs<types::GenericType>();
                                 // resize current Cell
-                                pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims());
+                                // FIXME: is this check really needed?
+                                if (pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims()) == false)
+                                {
+                                    pCell = NULL;
+                                }
                                 pEH->setCurrent(pCell);
                             }
 
@@ -1474,7 +1492,11 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                                 // copy current Cell
                                 pCell = pCell->copyAs<types::GenericType>();
                                 // resize current Cell
-                                pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims());
+                                // FIXME: is this check really needed?
+                                if (pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims()) == false)
+                                {
+                                    pCell = NULL;
+                                }
                                 pEH->setCurrent(pCell->getAs<types::Cell>());
                             }
 
@@ -1719,7 +1741,12 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         types::TList* pTL = pParent->getAs<types::TList>();
                         if (pParentArgs)
                         {
-                            pTL = pTL->set(pEH->getWhereReinsert(), pEH->getCurrent());
+                            pTL = pTL->copyAs<types::TList>();
+                            // FIXME: is this check really needed?
+                            if (pTL->set(pEH->getWhereReinsert(), pEH->getCurrent()) == false)
+                            {
+                                pTL = NULL;
+                            }
                             pEHParent->setCurrent(pTL);
                             evalFields.pop_back();
                             delete pEH;
@@ -1729,7 +1756,12 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         {
                             if (pTL->exists(pEH->getExpAsString()))
                             {
-                                pTL = pTL->set(pEH->getExpAsString(), pEH->getCurrent());
+                                pTL = pTL->copyAs<types::TList>();
+                                // FIXME: is this check really needed?
+                                if (pTL->set(pEH->getExpAsString(), pEH->getCurrent()) == false)
+                                {
+                                    pTL = NULL;
+                                }
                                 pEHParent->setCurrent(pTL);
                                 evalFields.pop_back();
                                 delete pEH;
@@ -2185,7 +2217,9 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
 
                     if (pTL->exists(pS->get(0)))
                     {
-                        pRet = pTL->set(pS->get(0), _pInsert);
+                        pRet = pTL->copyAs<types::InternalType>();
+                        // FIXME: is this check really needed?
+                        pRet = pTL->set(pS->get(0), _pInsert) ? pTL : NULL;
                     }
                     else
                     {

--- a/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
+++ b/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
@@ -992,14 +992,8 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         throw ast::InternalError(os.str(), 999, _pExp->getLocation());
                     }
 
-                    // copy current struct (if necessary it gets cloned!)
-                    pStruct = pStruct->copyAs<types::Struct>();
                     // resize current struct
-                    // FIXME: is this check really needed?
-                    if (pStruct->resize(pEH->getArgsDimsArray(), pEH->getArgsDims()) == false)
-                    {
-                        pStruct = NULL;
-                    }
+                    pStruct = pStruct->resizeClone(pEH->getArgsDimsArray(), pEH->getArgsDims())->getAs<types::Struct>();;
                     pEH->setCurrent(pStruct);
                 }
 
@@ -1458,14 +1452,8 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                                     throw ast::InternalError(os.str(), 999, _pExp->getLocation());
                                 }
 
-                                // copy current Cell
-                                pCell = pCell->copyAs<types::GenericType>();
                                 // resize current Cell
-                                // FIXME: is this check really needed?
-                                if (pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims()) == false)
-                                {
-                                    pCell = NULL;
-                                }
+                                pCell = pCell->resizeClone(pEH->getArgsDimsArray(), pEH->getArgsDims())->getAs<types::Cell>();
                                 pEH->setCurrent(pCell);
                             }
 
@@ -1489,14 +1477,9 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                                     os << _W("Invalid index.\n");
                                     throw ast::InternalError(os.str(), 999, _pExp->getLocation());
                                 }
-                                // copy current Cell
-                                pCell = pCell->copyAs<types::GenericType>();
+
                                 // resize current Cell
-                                // FIXME: is this check really needed?
-                                if (pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims()) == false)
-                                {
-                                    pCell = NULL;
-                                }
+                                pCell = pCell->resizeClone(pEH->getArgsDimsArray(), pEH->getArgsDims())->getAs<types::Cell>();
                                 pEH->setCurrent(pCell->getAs<types::Cell>());
                             }
 

--- a/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
+++ b/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
@@ -1100,12 +1100,7 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         int iNewSize = pEH->getSizeFromArgs();
                         if (pTL->getSize() < iNewSize)
                         {
-                            pTL = pTL->copyAs<types::TList>();
-                            // FIXME: is this check really needed?
-                            if (pTL->set(iNewSize - 1, new types::ListUndefined()) == false)
-                            {
-                                pTL = NULL;
-                            }
+                            pTL = pTL->setClone(iNewSize - 1, new types::ListUndefined())->getAs<types::TList>();
                             pEH->setCurrent(pTL);
                         }
 
@@ -1261,12 +1256,7 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                             int iNewSize = pEH->getSizeFromArgs();
                             if (pL->getSize() < iNewSize)
                             {
-                                pL = pL->copyAs<types::List>();
-                                // FIXME: is this check really needed?
-                                if(pL->set(iNewSize - 1, new types::ListUndefined()) == false)
-                                {
-                                    pL = NULL;
-                                }
+                                pL= pL->setClone(iNewSize - 1, new types::ListUndefined());
                                 pEH->setCurrent(pL);
                             }
 
@@ -1724,12 +1714,7 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         types::TList* pTL = pParent->getAs<types::TList>();
                         if (pParentArgs)
                         {
-                            pTL = pTL->copyAs<types::TList>();
-                            // FIXME: is this check really needed?
-                            if (pTL->set(pEH->getWhereReinsert(), pEH->getCurrent()) == false)
-                            {
-                                pTL = NULL;
-                            }
+                            pTL = pTL->setClone(pEH->getWhereReinsert(), pEH->getCurrent())->getAs<types::TList>();
                             pEHParent->setCurrent(pTL);
                             evalFields.pop_back();
                             delete pEH;

--- a/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
+++ b/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
@@ -1100,7 +1100,7 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         int iNewSize = pEH->getSizeFromArgs();
                         if (pTL->getSize() < iNewSize)
                         {
-                            pTL = pTL->setClone(iNewSize - 1, new types::ListUndefined())->getAs<types::TList>();
+                            pTL = pTL->setClone(iNewSize - 1, new types::ListUndefined());
                             pEH->setCurrent(pTL);
                         }
 
@@ -1714,7 +1714,7 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         types::TList* pTL = pParent->getAs<types::TList>();
                         if (pParentArgs)
                         {
-                            pTL = pTL->setClone(pEH->getWhereReinsert(), pEH->getCurrent())->getAs<types::TList>();
+                            pTL = pTL->setClone(pEH->getWhereReinsert(), pEH->getCurrent());
                             pEHParent->setCurrent(pTL);
                             evalFields.pop_back();
                             delete pEH;
@@ -1722,14 +1722,10 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         }
                         else
                         {
+                            // FIXME: use local var for pEH->getExpAsString() ?
                             if (pTL->exists(pEH->getExpAsString()))
                             {
-                                pTL = pTL->copyAs<types::TList>();
-                                // FIXME: is this check really needed?
-                                if (pTL->set(pEH->getExpAsString(), pEH->getCurrent()) == false)
-                                {
-                                    pTL = NULL;
-                                }
+                                pTL = pTL->setClone(pEH->getExpAsString(), pEH->getCurrent());
                                 pEHParent->setCurrent(pTL);
                                 evalFields.pop_back();
                                 delete pEH;
@@ -2185,9 +2181,7 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
 
                     if (pTL->exists(pS->get(0)))
                     {
-                        pRet = pTL->copyAs<types::InternalType>();
-                        // FIXME: is this check really needed?
-                        pRet = pTL->set(pS->get(0), _pInsert) ? pTL : NULL;
+                        pRet = pTL->setClone(pS->get(0), _pInsert)->getAs<types::InternalType>();
                     }
                     else
                     {

--- a/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
+++ b/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
@@ -992,8 +992,10 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         throw ast::InternalError(os.str(), 999, _pExp->getLocation());
                     }
 
+                    // copy current struct (if necessary it gets cloned!)
+                    pStruct = pStruct->copyAs<types::Struct>();
                     // resize current struct
-                    pStruct = pStruct->resize(pEH->getArgsDimsArray(), pEH->getArgsDims());
+                    pStruct->resize(pEH->getArgsDimsArray(), pEH->getArgsDims());
                     pEH->setCurrent(pStruct);
                 }
 
@@ -1441,8 +1443,10 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                                     throw ast::InternalError(os.str(), 999, _pExp->getLocation());
                                 }
 
+                                // copy current Cell
+                                pCell = pCell->copyAs<types::GenericType>();
                                 // resize current Cell
-                                pCell = pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims());
+                                pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims());
                                 pEH->setCurrent(pCell);
                             }
 
@@ -1466,10 +1470,11 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                                     os << _W("Invalid index.\n");
                                     throw ast::InternalError(os.str(), 999, _pExp->getLocation());
                                 }
-
+                                // copy current Cell
+                                pCell = pCell->copyAs<types::GenericType>();
                                 // resize current Cell
-                                pCell = pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims())->getAs<types::Cell>();
-                                pEH->setCurrent(pCell);
+                                pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims());
+                                pEH->setCurrent(pCell->getAs<types::Cell>());
                             }
 
                             types::InternalType* pIT = pCell->extract(pEH->getArgs());

--- a/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
+++ b/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
@@ -1002,7 +1002,8 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                 // create field in parent if it not exist
                 if (pStruct->exists(pwcsFieldname) == false)
                 {
-                    pStruct = pStruct->addField(pwcsFieldname);
+                    pStruct = pStruct->copyAs<types::Struct>();
+                    pStruct->addField(pwcsFieldname);
                     pEH->setCurrent(pStruct);
                 }
 
@@ -2067,13 +2068,15 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
                 if (_pInsert->isListDelete())
                 {
                     /* Remove a field */
-                    pStruct = pStruct->removeField(pS->get(0));
+                    pStruct = pStruct->copyAs<types::Struct>();
+                    pStruct->removeField(pS->get(0));
                 }
                 else
                 {
                     /* Add a field */
                     int size = pStruct->getSize();
-                    pStruct = pStruct->addField(pS->get(0));
+                    pStruct = pStruct->copyAs<types::Struct>();
+                    pStruct->addField(pS->get(0));
                     for (int i = 0; i < size; i++)
                     {
                         pStruct->get(i)->set(pS->get(0), _pInsert);

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -89,7 +89,7 @@ ArrayOf<T>* ArrayOf<T>::insert(typed_list* _pArgs, InternalType* _pSource)
             }
             else
             {
-                if (set(index, *pRealData) != NULL)
+                if (set(index, *pRealData) == true)
                 {
                     return this;
                 }
@@ -142,7 +142,7 @@ ArrayOf<T>* ArrayOf<T>::insert(typed_list* _pArgs, InternalType* _pSource)
                 {
                     for (int i : indexes)
                     {
-                        if (set(i, *pRealData) == NULL)
+                        if (set(i, *pRealData) == false)
                         {
                             status = false;
                             break;
@@ -170,7 +170,7 @@ ArrayOf<T>* ArrayOf<T>::insert(typed_list* _pArgs, InternalType* _pSource)
                 {
                     for (int i : indexes)
                     {
-                        if (set(i, *pRealData) == NULL)
+                        if (set(i, *pRealData) == false)
                         {
                             status = false;
                             break;

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -1382,19 +1382,12 @@ GenericType* ArrayOf<T>::extract(typed_list* _pArgs)
 }
 
 template <typename T>
-ArrayOf<T>* ArrayOf<T>::reshape(int* _piDims, int _iDims)
+bool ArrayOf<T>::reshape(int* _piDims, int _iDims)
 {
-    typedef ArrayOf<T>* (ArrayOf<T>::*reshape_t)(int*, int);
-    ArrayOf<T>* pIT = checkRef(this, (reshape_t)&ArrayOf<T>::reshape, _piDims, _iDims);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     int iNewSize = get_max_size(_piDims, _iDims);
     if (iNewSize != m_iSize)
     {
-        return NULL;
+        return false;
     }
 
     for (int i = 0 ; i < _iDims ; i++)
@@ -1422,7 +1415,7 @@ ArrayOf<T>* ArrayOf<T>::reshape(int* _piDims, int _iDims)
     m_iSize = iNewSize;
     m_iDims = _iDims;
 
-    return this;
+    return true;
 }
 
 template <typename T>

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -338,15 +338,7 @@ ArrayOf<T>* ArrayOf<T>::insert(typed_list* _pArgs, InternalType* _pSource)
     //before resize, check input dimension
     if (bNeedToResize)
     {
-        ArrayOf<T>* pTemp = resize(piNewDims, iNewDims);
-        if (pTemp == NULL)
-        {
-            delete[] piCountDim;
-            delete[] piMaxDim;
-            //free pArg content
-            cleanIndexesArguments(_pArgs, &pArg);
-            return NULL;
-        }
+        resize(piNewDims, iNewDims);
     }
     else
     {

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -1650,25 +1650,6 @@ bool ArrayOf<T>::resize(int* _piDims, int _iDims)
 }
 
 template <typename T>
-ArrayOf<T>* ArrayOf<T>::resizeClone(int* _piDims, int _iDims)
-{
-    if (getRef() > 1)
-    {
-        ArrayOf<T>* pClone = clone()->getAs<ArrayOf<T>>();
-
-        if (pClone->resize(_piDims, _iDims) == false)
-        {
-            pClone->killMe();
-            return NULL;
-        }
-
-        return pClone;
-    }
-
-    return resize(_piDims, _iDims) ? this : NULL;
-}
-
-template <typename T>
 bool ArrayOf<T>::isTrue()
 {
     return type_traits::isTrue<T>(m_iSize, m_pRealData);

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -721,14 +721,8 @@ GenericType* ArrayOf<T>::insertNew(typed_list* _pArgs)
 }
 
 template <typename T>
-ArrayOf<T>* ArrayOf<T>::append(int _iRows, int _iCols, InternalType* _poSource)
+bool ArrayOf<T>::append(int _iRows, int _iCols, InternalType* _poSource)
 {
-    ArrayOf<T>* pIT = checkRef(this, &ArrayOf::append, _iRows, _iCols, _poSource);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     ArrayOf * pGT = _poSource->getAs<ArrayOf>();
     int iRows = pGT->getRows();
     int iCols = pGT->getCols();
@@ -736,7 +730,7 @@ ArrayOf<T>* ArrayOf<T>::append(int _iRows, int _iCols, InternalType* _poSource)
     //insert without resize
     if (iRows + _iRows > m_iRows || iCols + _iCols > m_iCols)
     {
-        return NULL;
+        return false;
     }
 
     //Update complexity if necessary
@@ -774,7 +768,7 @@ ArrayOf<T>* ArrayOf<T>::append(int _iRows, int _iCols, InternalType* _poSource)
         }
     }
 
-    return this;
+    return true;
 }
 
 template <typename T>

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -338,7 +338,15 @@ ArrayOf<T>* ArrayOf<T>::insert(typed_list* _pArgs, InternalType* _pSource)
     //before resize, check input dimension
     if (bNeedToResize)
     {
-        resize(piNewDims, iNewDims);
+        // FIXME: do we actually perform a resize here?
+        if (resize(piNewDims, iNewDims) == false)
+        {
+            delete[] piCountDim;
+            delete[] piMaxDim;
+            //free pArg content
+            cleanIndexesArguments(_pArgs, &pArg);
+            return NULL;
+        }
     }
     else
     {

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -1642,6 +1642,25 @@ bool ArrayOf<T>::resize(int* _piDims, int _iDims)
 }
 
 template <typename T>
+ArrayOf<T>* ArrayOf<T>::resizeClone(int* _piDims, int _iDims)
+{
+    if (getRef() > 1)
+    {
+        ArrayOf<T>* pClone = clone()->getAs<ArrayOf<T>>();
+
+        if (pClone->resize(_piDims, _iDims) == false)
+        {
+            pClone->killMe();
+            return NULL;
+        }
+
+        return pClone;
+    }
+
+    return resize(_piDims, _iDims) ? this : NULL;
+}
+
+template <typename T>
 bool ArrayOf<T>::isTrue()
 {
     return type_traits::isTrue<T>(m_iSize, m_pRealData);

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -1419,19 +1419,12 @@ bool ArrayOf<T>::reshape(int* _piDims, int _iDims)
 }
 
 template <typename T>
-ArrayOf<T>* ArrayOf<T>::resize(int* _piDims, int _iDims)
+bool ArrayOf<T>::resize(int* _piDims, int _iDims)
 {
-    typedef ArrayOf<T>* (ArrayOf<T>::*resize_t)(int*, int);
-    ArrayOf<T>* pIT = checkRef(this, (resize_t)&ArrayOf::resize, _piDims, _iDims);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     if (_iDims == m_iDims && memcmp(m_piDims, _piDims, sizeof(int) * m_iDims) == 0)
     {
         //nothing to do
-        return this;
+        return true;
     }
 
     //alloc new data array
@@ -1659,7 +1652,7 @@ ArrayOf<T>* ArrayOf<T>::resize(int* _piDims, int _iDims)
     m_iRows = m_piDims[0];
     m_iCols = m_piDims[1];
     m_iSize = iNewSize;
-    return this;
+    return true;
 }
 
 template <typename T>

--- a/scilab/modules/ast/src/cpp/types/bool.cpp
+++ b/scilab/modules/ast/src/cpp/types/bool.cpp
@@ -91,38 +91,22 @@ void Bool::whoAmI()
     std::cout << "types::Bool";
 }
 
-Bool* Bool::setFalse()
+void Bool::setFalse()
 {
-    Bool* pb = checkRef(this, &Bool::setFalse);
-    if (pb != this)
-    {
-        return pb;
-    }
-
     int size = getSize();
     for (int i = 0 ; i < size ; i++)
     {
         m_pRealData[i] = 0;
     }
-
-    return this;
 }
 
-Bool* Bool::setTrue()
+void Bool::setTrue()
 {
-    Bool* pb = checkRef(this, &Bool::setTrue);
-    if (pb != this)
-    {
-        return pb;
-    }
-
     int size = getSize();
     for (int i = 0; i < size; i++)
     {
         m_pRealData[i] = 1;
     }
-
-    return this;
 }
 
 bool Bool::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_iDims*/)

--- a/scilab/modules/ast/src/cpp/types/cell.cpp
+++ b/scilab/modules/ast/src/cpp/types/cell.cpp
@@ -139,42 +139,35 @@ bool Cell::transpose(InternalType *& out)
     return false;
 }
 
-Cell* Cell::set(int _iRows, int _iCols, InternalType* _pIT)
+bool Cell::set(int _iRows, int _iCols, InternalType* _pIT)
 {
     if (_iRows < getRows() && _iCols < getCols())
     {
         return set(_iCols * getRows() + _iRows, _pIT);
     }
-    return NULL;
+    return false;
 }
 
-Cell* Cell::set(int _iRows, int _iCols, const InternalType* _pIT)
+bool Cell::set(int _iRows, int _iCols, const InternalType* _pIT)
 {
     if (_iRows < getRows() && _iCols < getCols())
     {
         return set(_iCols * getRows() + _iRows, _pIT);
     }
-    return NULL;
+    return false;
 }
 
-Cell* Cell::set(int _iIndex, InternalType* _pIT)
+bool Cell::set(int _iIndex, InternalType* _pIT)
 {
     if (_iIndex >= m_iSize)
     {
-        return NULL;
+        return false;
     }
 
     // corner case when inserting twice
     if (m_pRealData[_iIndex] == _pIT)
     {
-        return this;
-    }
-
-    typedef Cell* (Cell::*set_t)(int, InternalType*);
-    Cell* pIT = checkRef(this, (set_t)&Cell::set, _iIndex, _pIT);
-    if (pIT != this)
-    {
-        return pIT;
+        return true;
     }
 
     if (m_pRealData[_iIndex] != NULL)
@@ -185,21 +178,14 @@ Cell* Cell::set(int _iIndex, InternalType* _pIT)
 
     _pIT->IncreaseRef();
     m_pRealData[_iIndex] = _pIT;
-    return this;
+    return true;
 }
 
-Cell* Cell::set(int _iIndex, const InternalType* _pIT)
+bool Cell::set(int _iIndex, const InternalType* _pIT)
 {
     if (_iIndex >= m_iSize)
     {
-        return NULL;
-    }
-
-    typedef Cell* (Cell::*set_t)(int, const InternalType*);
-    Cell* pIT = checkRef(this, (set_t)&Cell::set, _iIndex, _pIT);
-    if (pIT != this)
-    {
-        return pIT;
+        return false;
     }
 
     if (m_pRealData[_iIndex] != NULL)
@@ -211,23 +197,16 @@ Cell* Cell::set(int _iIndex, const InternalType* _pIT)
     const_cast<InternalType*>(_pIT)->IncreaseRef();
     m_pRealData[_iIndex] = const_cast<InternalType*>(_pIT);
 
-    return this;
+    return true;
 }
 
-Cell* Cell::set(InternalType** _pIT)
+bool Cell::set(InternalType** _pIT)
 {
-    typedef Cell* (Cell::*set_t)(InternalType**);
-    Cell* pIT = checkRef(this, (set_t)&Cell::set, _pIT);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     for (int i = 0; i < m_iSize; i++)
     {
         if (i >= m_iSize)
         {
-            return NULL;
+            return false;
         }
 
         if (m_pRealData[i] != NULL)
@@ -240,7 +219,7 @@ Cell* Cell::set(InternalType** _pIT)
         m_pRealData[i] = _pIT[i];
     }
 
-    return this;
+    return true;
 }
 
 /**

--- a/scilab/modules/ast/src/cpp/types/double.cpp
+++ b/scilab/modules/ast/src/cpp/types/double.cpp
@@ -906,14 +906,8 @@ double* Double::allocData(int _iSize)
     }
 }
 
-Double* Double::append(int _iRows, int _iCols, InternalType* _poSource)
+bool Double::append(int _iRows, int _iCols, InternalType* _poSource)
 {
-    Double* pIT = checkRef(this, &Double::append, _iRows, _iCols, _poSource);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     Double* pD = _poSource->getAs<Double>();
     int iRows = pD->getRows();
     int iCols = pD->getCols();
@@ -922,7 +916,7 @@ Double* Double::append(int _iRows, int _iCols, InternalType* _poSource)
     //insert without resize
     if (iRows + _iRows > m_iRows || iCols + _iCols > m_iCols)
     {
-        return NULL;
+        return false;
     }
 
     //Update complexity if necessary
@@ -1054,7 +1048,7 @@ Double* Double::append(int _iRows, int _iCols, InternalType* _poSource)
             }
         }
     }
-    return this;
+    return true;
 }
 
 void Double::convertToInteger()

--- a/scilab/modules/ast/src/cpp/types/list.cpp
+++ b/scilab/modules/ast/src/cpp/types/list.cpp
@@ -1,7 +1,6 @@
 /*
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
- *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
  * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
@@ -100,18 +99,12 @@ int List::getSize() const
 ** append(InternalType *_typedValue)
 ** Append the given value to the end of the List
 */
-List* List::append(InternalType *_typedValue)
+bool List::append(InternalType *_typedValue)
 {
-    List* pIT = checkRef(this, &List::append, _typedValue);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     _typedValue->IncreaseRef();
     m_plData->push_back(_typedValue);
     m_iSize = static_cast<int>(m_plData->size());
-    return this;
+    return true;
 }
 
 /**

--- a/scilab/modules/ast/src/cpp/types/list.cpp
+++ b/scilab/modules/ast/src/cpp/types/list.cpp
@@ -395,4 +395,22 @@ bool List::operator==(const InternalType& it)
     return true;
 }
 
+List* List::setClone(const int _iIndex, InternalType* _pIT)
+{
+    if (getRef() > 1)
+    {
+        List* pClone = clone();
+
+        if (pClone->set(_iIndex, _pIT) == false)
+        {
+            pClone->killMe();
+            return NULL;
+        }
+
+        return pClone;
+    }
+
+    return set(_iIndex, _pIT) ? this : NULL;
+}
+
 }

--- a/scilab/modules/ast/src/cpp/types/list.cpp
+++ b/scilab/modules/ast/src/cpp/types/list.cpp
@@ -331,17 +331,11 @@ InternalType* List::get(const int _iIndex)
     return NULL;
 }
 
-List* List::set(const int _iIndex, InternalType* _pIT)
+bool List::set(const int _iIndex, InternalType* _pIT)
 {
     if (_iIndex < 0)
     {
-        return NULL;
-    }
-
-    List* pIT = checkRef(this, &List::set, _iIndex, _pIT);
-    if (pIT != this)
-    {
-        return pIT;
+        return false;
     }
 
     while ((int)m_plData->size() < _iIndex)
@@ -373,7 +367,7 @@ List* List::set(const int _iIndex, InternalType* _pIT)
         }
     }
 
-    return this;
+    return true;
 }
 
 bool List::operator==(const InternalType& it)

--- a/scilab/modules/ast/src/cpp/types/polynom.cpp
+++ b/scilab/modules/ast/src/cpp/types/polynom.cpp
@@ -82,21 +82,14 @@ void Polynom::createPoly(const std::wstring& _szVarName, int _iDims, const int* 
 #endif
 }
 
-Polynom* Polynom::set(int _iPos, SinglePoly* _pS)
+bool Polynom::set(int _iPos, SinglePoly* _pS)
 {
     if (m_pRealData == NULL || _iPos >= m_iSize)
     {
-        return NULL;
+        return false;
     }
 
-    typedef Polynom* (Polynom::*set_t)(int, SinglePoly*);
-    Polynom* pIT = checkRef(this, (set_t)&Polynom::set, _iPos, _pS);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
-    if (m_pRealData[_iPos])
+    if (m_pRealData[_iPos]) // FIXME: is this check needed ?
     {
         delete m_pRealData[_iPos];
     }
@@ -113,29 +106,22 @@ Polynom* Polynom::set(int _iPos, SinglePoly* _pS)
         m_pRealData[_iPos]->setComplex(true);
     }
 
-    return this;
+    return true;
 }
 
-Polynom* Polynom::set(int _iRows, int _iCols, SinglePoly* _pS)
+bool Polynom::set(int _iRows, int _iCols, SinglePoly* _pS)
 {
     return set(_iCols * getRows() + _iRows, _pS);
 }
 
-Polynom* Polynom::set(SinglePoly** _pS)
+bool Polynom::set(SinglePoly** _pS)
 {
-    typedef Polynom* (Polynom::*set_t)(SinglePoly**);
-    Polynom* pIT = checkRef(this, (set_t)&Polynom::set, _pS);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     for (int i = 0 ; i < m_iSize ; i++)
     {
         set(i, _pS[i]);
     }
 
-    return this;
+    return true;
 }
 
 Polynom* Polynom::setCoef(int _iRows, int _iCols, Double *_pdblCoef)

--- a/scilab/modules/ast/src/cpp/types/polynom.cpp
+++ b/scilab/modules/ast/src/cpp/types/polynom.cpp
@@ -124,32 +124,25 @@ bool Polynom::set(SinglePoly** _pS)
     return true;
 }
 
-Polynom* Polynom::setCoef(int _iRows, int _iCols, Double *_pdblCoef)
+bool Polynom::setCoef(int _iRows, int _iCols, Double *_pdblCoef)
 {
     int piDims[] = {_iRows, _iCols};
     int iPos = getIndex(piDims);
     return setCoef(iPos, _pdblCoef);
 }
 
-Polynom* Polynom::setCoef(int _iIdx, Double *_pdblCoef)
+bool Polynom::setCoef(int _iIdx, Double *_pdblCoef)
 {
     if (_iIdx > m_iSize)
     {
-        return NULL;
-    }
-
-    typedef Polynom* (Polynom::*setCoef_t)(int, Double*);
-    Polynom* pIT = checkRef(this, (setCoef_t)&Polynom::setCoef, _iIdx, _pdblCoef);
-    if (pIT != this)
-    {
-        return pIT;
+        return false;
     }
 
     /*Get old SinglePoly*/
     m_pRealData[_iIdx]->setRank(_pdblCoef->getSize() - 1);
     m_pRealData[_iIdx]->setCoef(_pdblCoef);
 
-    return this;
+    return true;
 }
 
 void Polynom::setZeros()
@@ -390,15 +383,8 @@ Double* Polynom::getCoef(void)
     return pCoef;
 }
 
-Polynom* Polynom::setCoef(Double *_pCoef)
+bool Polynom::setCoef(Double *_pCoef)
 {
-    typedef Polynom* (Polynom::*setCoef_t)(Double*);
-    Polynom* pIT = checkRef(this, (setCoef_t)&Polynom::setCoef, _pCoef);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     setComplex(_pCoef->isComplex());
     double *pR = _pCoef->getReal();
 
@@ -434,7 +420,7 @@ Polynom* Polynom::setCoef(Double *_pCoef)
         }
     }
 
-    return this;
+    return true;
 }
 
 bool Polynom::subMatrixToString(std::wostringstream& ostr, int* _piDims, int _iDims)

--- a/scilab/modules/ast/src/cpp/types/polynom.cpp
+++ b/scilab/modules/ast/src/cpp/types/polynom.cpp
@@ -229,26 +229,15 @@ bool Polynom::isComplex()
     return false;
 }
 
-Polynom* Polynom::setComplex(bool _bComplex)
+void Polynom::setComplex(bool _bComplex)
 {
-    if (_bComplex == isComplex())
+    if (isComplex() != _bComplex)
     {
-        return this;
+        for (int i = 0 ; i < getSize() ; i++)
+        {
+            get(i)->setComplex(_bComplex);
+        }
     }
-
-    typedef Polynom* (Polynom::*setcplx_t)(bool);
-    Polynom* pIT = checkRef(this, (setcplx_t)&Polynom::setComplex, _bComplex);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
-    for (int i = 0 ; i < getSize() ; i++)
-    {
-        get(i)->setComplex(_bComplex);
-    }
-
-    return this;
 }
 
 Polynom* Polynom::clone()

--- a/scilab/modules/ast/src/cpp/types/sparse.cpp
+++ b/scilab/modules/ast/src/cpp/types/sparse.cpp
@@ -614,18 +614,11 @@ void Sparse::fill(Double& dest, int r, int c) SPARSE_CONST
     }
 }
 
-Sparse* Sparse::set(int _iRows, int _iCols, std::complex<double> v, bool _bFinalize)
+bool Sparse::set(int _iRows, int _iCols, std::complex<double> v, bool _bFinalize)
 {
     if (_iRows >= getRows() || _iCols >= getCols())
     {
-        return NULL;
-    }
-
-    typedef Sparse* (Sparse::*set_t)(int, int, std::complex<double>, bool);
-    Sparse* pIT = checkRef(this, (set_t)&Sparse::set, _iRows, _iCols, v, _bFinalize);
-    if (pIT != this)
-    {
-        return pIT;
+        return false;
     }
 
     if (matrixReal)
@@ -651,21 +644,14 @@ Sparse* Sparse::set(int _iRows, int _iCols, std::complex<double> v, bool _bFinal
     {
         finalize();
     }
-    return this;
+    return true;
 }
 
-Sparse* Sparse::set(int _iRows, int _iCols, double _dblReal, bool _bFinalize)
+bool Sparse::set(int _iRows, int _iCols, double _dblReal, bool _bFinalize)
 {
     if (_iRows >= getRows() || _iCols >= getCols())
     {
-        return NULL;
-    }
-
-    typedef Sparse* (Sparse::*set_t)(int, int, double, bool);
-    Sparse* pIT = checkRef(this, (set_t)&Sparse::set, _iRows, _iCols, _dblReal, _bFinalize);
-    if (pIT != this)
-    {
-        return pIT;
+        return false;
     }
 
     if (matrixReal)
@@ -693,7 +679,7 @@ Sparse* Sparse::set(int _iRows, int _iCols, double _dblReal, bool _bFinalize)
         finalize();
     }
 
-    return this;
+    return true;
 }
 
 void Sparse::finalize()
@@ -4268,15 +4254,8 @@ bool SparseBool::get(int r, int c) SPARSE_CONST
     return matrixBool->coeff(r, c);
 }
 
-SparseBool* SparseBool::set(int _iRows, int _iCols, bool _bVal, bool _bFinalize) SPARSE_CONST
+bool SparseBool::set(int _iRows, int _iCols, bool _bVal, bool _bFinalize) SPARSE_CONST
 {
-    typedef SparseBool* (SparseBool::*set_t)(int, int, bool, bool);
-    SparseBool* pIT = checkRef(this, (set_t)&SparseBool::set, _iRows, _iCols, _bVal, _bFinalize);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     if (matrixBool->isCompressed() && matrixBool->coeff(_iRows, _iCols) == false)
     {
         matrixBool->reserve(1);
@@ -4289,7 +4268,7 @@ SparseBool* SparseBool::set(int _iRows, int _iCols, bool _bVal, bool _bFinalize)
         finalize();
     }
 
-    return this;
+    return true;
 }
 
 void SparseBool::fill(Bool& dest, int r, int c) SPARSE_CONST

--- a/scilab/modules/ast/src/cpp/types/sparse.cpp
+++ b/scilab/modules/ast/src/cpp/types/sparse.cpp
@@ -823,19 +823,12 @@ bool Sparse::toString(std::wostringstream& ostr)
     return true;
 }
 
-Sparse* Sparse::resize(int _iNewRows, int _iNewCols)
+bool Sparse::resize(int _iNewRows, int _iNewCols)
 {
-    typedef Sparse* (Sparse::*resize_t)(int, int);
-    Sparse* pIT = checkRef(this, (resize_t)&Sparse::resize, _iNewRows, _iNewCols);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     if (_iNewRows <= getRows() && _iNewCols <= getCols())
     {
         //nothing to do: hence we do NOT fail
-        return this;
+        return true;
     }
 
     Sparse* res = NULL;
@@ -918,7 +911,7 @@ Sparse* Sparse::resize(int _iNewRows, int _iNewCols)
     {
         res = NULL;
     }
-    return res;
+    return (bool)res;
 }
 // TODO decide if a complex matrix with 0 imag can be == to a real matrix
 // not true for dense (cf double.cpp)
@@ -3264,19 +3257,12 @@ SparseBool* SparseBool::clone(void)
     return new SparseBool(*this);
 }
 
-SparseBool* SparseBool::resize(int _iNewRows, int _iNewCols)
+bool SparseBool::resize(int _iNewRows, int _iNewCols)
 {
-    typedef SparseBool* (SparseBool::*resize_t)(int, int);
-    SparseBool* pIT = checkRef(this, (resize_t)&SparseBool::resize, _iNewRows, _iNewCols);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     if (_iNewRows <= getRows() && _iNewCols <= getCols())
     {
         //nothing to do: hence we do NOT fail
-        return this;
+        return true;
     }
 
     SparseBool* res = NULL;
@@ -3318,7 +3304,7 @@ SparseBool* SparseBool::resize(int _iNewRows, int _iNewCols)
     {
         res = NULL;
     }
-    return res;
+    return (bool)res;
 }
 
 SparseBool* SparseBool::insert(typed_list* _pArgs, SparseBool* _pSource)

--- a/scilab/modules/ast/src/cpp/types/sparse.cpp
+++ b/scilab/modules/ast/src/cpp/types/sparse.cpp
@@ -1174,7 +1174,7 @@ Sparse* Sparse::insert(typed_list* _pArgs, InternalType* _pSource)
     //now you are sure to be able to insert values
     if (bNeedToResize)
     {
-        if (resize(iNewRows, iNewCols) == NULL)
+        if (resize(iNewRows, iNewCols) == false)
         {
             //free pArg content
             cleanIndexesArguments(_pArgs, &pArg);
@@ -1597,7 +1597,7 @@ Sparse* Sparse::insert(typed_list* _pArgs, Sparse* _pSource)
     //now you are sure to be able to insert values
     if (bNeedToResize)
     {
-        if (resize(iNewRows, iNewCols) == NULL)
+        if (resize(iNewRows, iNewCols) == false)
         {
             //free pArg content
             cleanIndexesArguments(_pArgs, &pArg);
@@ -3369,7 +3369,7 @@ SparseBool* SparseBool::insert(typed_list* _pArgs, SparseBool* _pSource)
     //now you are sure to be able to insert values
     if (bNeedToResize)
     {
-        if (resize(iNewRows, iNewCols) == NULL)
+        if (resize(iNewRows, iNewCols) == false)
         {
             //free pArg content
             cleanIndexesArguments(_pArgs, &pArg);
@@ -3520,7 +3520,7 @@ SparseBool* SparseBool::insert(typed_list* _pArgs, InternalType* _pSource)
     //now you are sure to be able to insert values
     if (bNeedToResize)
     {
-        if (resize(iNewRows, iNewCols) == NULL)
+        if (resize(iNewRows, iNewCols) == false)
         {
             //free pArg content
             cleanIndexesArguments(_pArgs, &pArg);

--- a/scilab/modules/ast/src/cpp/types/sparse.cpp
+++ b/scilab/modules/ast/src/cpp/types/sparse.cpp
@@ -2985,9 +2985,8 @@ SparseBool* Sparse::newEqualTo(Sparse &o)
     return ret;
 }
 
-Sparse* Sparse::reshape(int* _piDims, int _iDims)
+bool Sparse::reshape(int* _piDims, int _iDims)
 {
-    Sparse* pSp = NULL;
     int iCols = 1;
 
     if (_iDims == 2)
@@ -2997,24 +2996,17 @@ Sparse* Sparse::reshape(int* _piDims, int _iDims)
 
     if (_iDims <= 2)
     {
-        pSp = reshape(_piDims[0], iCols);
+        return reshape(_piDims[0], iCols);
     }
 
-    return pSp;
+    return false;
 }
 
-Sparse* Sparse::reshape(int _iNewRows, int _iNewCols)
+bool Sparse::reshape(int _iNewRows, int _iNewCols)
 {
-    typedef Sparse* (Sparse::*reshape_t)(int, int);
-    Sparse* pIT = checkRef(this, (reshape_t)&Sparse::reshape, _iNewRows, _iNewCols);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     if (_iNewRows * _iNewCols != getRows() * getCols())
     {
-        return NULL;
+        return false;
     }
 
     Sparse* res = NULL;
@@ -3102,7 +3094,7 @@ Sparse* Sparse::reshape(int _iNewRows, int _iNewCols)
     {
         res = NULL;
     }
-    return res;
+    return (bool)res;
 }
 
 //    SparseBool* SparseBool::new
@@ -4430,9 +4422,8 @@ SparseBool* SparseBool::newLogicalAnd(SparseBool const&o) const
     return cwiseOp<std::logical_and>(*this, o);
 }
 
-SparseBool* SparseBool::reshape(int* _piDims, int _iDims)
+bool SparseBool::reshape(int* _piDims, int _iDims)
 {
-    SparseBool* pSpBool = NULL;
     int iCols = 1;
 
     if (_iDims == 2)
@@ -4442,24 +4433,17 @@ SparseBool* SparseBool::reshape(int* _piDims, int _iDims)
 
     if (_iDims <= 2)
     {
-        pSpBool = reshape(_piDims[0], iCols);
+        return reshape(_piDims[0], iCols);
     }
 
-    return pSpBool;
+    return false;
 }
 
-SparseBool* SparseBool::reshape(int _iNewRows, int _iNewCols)
+bool SparseBool::reshape(int _iNewRows, int _iNewCols)
 {
-    typedef SparseBool* (SparseBool::*reshape_t)(int, int);
-    SparseBool* pIT = checkRef(this, (reshape_t)&SparseBool::reshape, _iNewRows, _iNewCols);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     if (_iNewRows * _iNewCols != getRows() * getCols())
     {
-        return NULL;
+        return false;
     }
 
     SparseBool* res = NULL;
@@ -4505,7 +4489,7 @@ SparseBool* SparseBool::reshape(int _iNewRows, int _iNewCols)
     {
         res = NULL;
     }
-    return res;
+    return (bool)res;
 }
 
 bool SparseBool::transpose(InternalType *& out)

--- a/scilab/modules/ast/src/cpp/types/sparse.cpp
+++ b/scilab/modules/ast/src/cpp/types/sparse.cpp
@@ -1925,14 +1925,8 @@ GenericType* Sparse::remove(typed_list* _pArgs)
     return pOut;
 }
 
-Sparse* Sparse::append(int r, int c, types::Sparse SPARSE_CONST* src)
+bool Sparse::append(int r, int c, types::Sparse SPARSE_CONST* src)
 {
-    Sparse* pIT = checkRef(this, &Sparse::append, r, c, src);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     //        std::wcerr << L"to a sparse of size"<<getRows() << L","<<getCols() << L" should append @"<<r << L","<<c<< "a sparse:"<< src->toString(32,80)<<std::endl;
     if (src->isComplex())
     {
@@ -1956,7 +1950,7 @@ Sparse* Sparse::append(int r, int c, types::Sparse SPARSE_CONST* src)
 
     finalize();
 
-    return this; // realloc is meaningless for sparse matrices
+    return true; // realloc is meaningless for sparse matrices
 }
 
 /*
@@ -3818,17 +3812,11 @@ GenericType* SparseBool::remove(typed_list* _pArgs)
     return pOut;
 }
 
-SparseBool* SparseBool::append(int r, int c, SparseBool SPARSE_CONST* src)
+bool SparseBool::append(int r, int c, SparseBool SPARSE_CONST* src)
 {
-    SparseBool* pIT = checkRef(this, &SparseBool::append, r, c, src);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     doAppend(*src, r, c, *matrixBool);
     finalize();
-    return this;
+    return true;
 }
 
 GenericType* SparseBool::insertNew(typed_list* _pArgs)

--- a/scilab/modules/ast/src/cpp/types/string.cpp
+++ b/scilab/modules/ast/src/cpp/types/string.cpp
@@ -626,7 +626,7 @@ String* String::set_(int _iRows, int _iCols, const wchar_t* _pwstData)
     return set_(_iCols * getRows() + _iRows, _pwstData);
 }
 
-String* String::set(int _iRows, int _iCols, const wchar_t* _pwstData)
+bool String::set(int _iRows, int _iCols, const wchar_t* _pwstData)
 {
     return set(_iCols * getRows() + _iRows, _pwstData);
 }

--- a/scilab/modules/ast/src/cpp/types/string.cpp
+++ b/scilab/modules/ast/src/cpp/types/string.cpp
@@ -609,21 +609,16 @@ String* String::set_(int _iPos, const wchar_t* _pwstData)
     return this;
 }
 
-String* String::set(int _iPos, const wchar_t* _pwstData)
+bool String::set(int _iPos, const wchar_t* _pwstData)
 {
     if (m_pRealData == NULL || _iPos >= m_iSize)
     {
-        return NULL;
+        return false;
     }
 
-    typedef String* (String::*set_t)(int, const wchar_t*);
-    String* pIT = checkRef(this, (set_t)&String::set_, _iPos, _pwstData);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
-    return set_(_iPos, _pwstData);
+    deleteString(_iPos);
+    m_pRealData[_iPos] = copyValue(_pwstData);
+    return true;
 }
 
 String* String::set_(int _iRows, int _iCols, const wchar_t* _pwstData)
@@ -636,17 +631,11 @@ String* String::set(int _iRows, int _iCols, const wchar_t* _pwstData)
     return set(_iCols * getRows() + _iRows, _pwstData);
 }
 
-String* String::set(const wchar_t* const* _pwstData)
+bool String::set(const wchar_t* const* _pwstData)
 {
-    typedef String* (String::*set_t)(const wchar_t * const*);
-    String* pIT = checkRef(this, (set_t)&String::set, _pwstData);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     int i = m_iSize;
 
+    // FIXME: check m_pRealData more effeciently?
     while (i && m_pRealData)
     {
         --i;
@@ -656,47 +645,40 @@ String* String::set(const wchar_t* const* _pwstData)
 
     if (i)
     {
-        return NULL;
+        return false;
     }
     else
     {
-        return this;
+        return true;
     }
 }
 
-String* String::set(int _iPos, const char* _pcData)
+bool String::set(int _iPos, const char* _pcData)
 {
     wchar_t* w = to_wide_string(_pcData);
-    String* ret = set(_iPos, w);
+    bool ret = set(_iPos, w);
     FREE(w);
     return ret;
 }
 
-String* String::set(int _iRows, int _iCols, const char* _pcData)
+bool String::set(int _iRows, int _iCols, const char* _pcData)
 {
     return set(_iCols * getRows() + _iRows, _pcData);
 }
 
-String* String::set(const char* const* _pstrData)
+bool String::set(const char* const* _pstrData)
 {
-    typedef String* (String::*set_t)(const char * const*);
-    String* pIT = checkRef(this, (set_t)&String::set, _pstrData);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     int i = m_iSize;
 
     while (i-- && set(i, _pstrData[i]));
 
     if (++i) // revert decrement
     {
-        return NULL;
+        return false;
     }
     else
     {
-        return this;
+        return true;
     }
 }
 

--- a/scilab/modules/ast/src/cpp/types/string.cpp
+++ b/scilab/modules/ast/src/cpp/types/string.cpp
@@ -602,11 +602,10 @@ void String::deleteData(wchar_t* data)
     }
 }
 
-String* String::set_(int _iPos, const wchar_t* _pwstData)
+void String::set_(int _iPos, const wchar_t* _pwstData)
 {
     deleteString(_iPos);
     m_pRealData[_iPos] = copyValue(_pwstData);
-    return this;
 }
 
 bool String::set(int _iPos, const wchar_t* _pwstData)
@@ -621,9 +620,9 @@ bool String::set(int _iPos, const wchar_t* _pwstData)
     return true;
 }
 
-String* String::set_(int _iRows, int _iCols, const wchar_t* _pwstData)
+void String::set_(int _iRows, int _iCols, const wchar_t* _pwstData)
 {
-    return set_(_iCols * getRows() + _iRows, _pwstData);
+    set_(_iCols * getRows() + _iRows, _pwstData);
 }
 
 bool String::set(int _iRows, int _iCols, const wchar_t* _pwstData)

--- a/scilab/modules/ast/src/cpp/types/struct.cpp
+++ b/scilab/modules/ast/src/cpp/types/struct.cpp
@@ -427,14 +427,8 @@ bool Struct::subMatrixToString(std::wostringstream& /*ostr*/, int* /*_piDims*/, 
     return true;
 }
 
-Struct* Struct::addField(const std::wstring& _sKey)
+void Struct::addField(const std::wstring& _sKey)
 {
-    Struct* pIT = checkRef(this, &Struct::addField, _sKey);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     if (getSize() == 0)
     {
         //change dimension to 1x1 and add field
@@ -445,18 +439,10 @@ Struct* Struct::addField(const std::wstring& _sKey)
     {
         get(i)->addField(_sKey);
     }
-
-    return this;
 }
 
-Struct* Struct::addFieldFront(const std::wstring& _sKey)
+void Struct::addFieldFront(const std::wstring& _sKey)
 {
-    Struct* pIT = checkRef(this, &Struct::addFieldFront, _sKey);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     if (getSize() == 0)
     {
         //change dimension to 1x1 and add field
@@ -467,24 +453,14 @@ Struct* Struct::addFieldFront(const std::wstring& _sKey)
     {
         get(i)->addFieldFront(_sKey);
     }
-
-    return this;
 }
 
-Struct* Struct::removeField(const std::wstring& _sKey)
+void Struct::removeField(const std::wstring& _sKey)
 {
-    Struct* pIT = checkRef(this, &Struct::removeField, _sKey);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     for (int j = 0; j < getSize(); j++)
     {
         get(j)->removeField(_sKey);
     }
-
-    return this;
 }
 
 bool Struct::toString(std::wostringstream& ostr)

--- a/scilab/modules/ast/src/cpp/types/struct.cpp
+++ b/scilab/modules/ast/src/cpp/types/struct.cpp
@@ -694,21 +694,14 @@ std::vector<InternalType*> Struct::extractFields(typed_list* _pArgs)
     return ResultList;
 }
 
-Struct* Struct::resize(int _iNewRows, int _iNewCols)
+bool Struct::resize(int _iNewRows, int _iNewCols)
 {
     int piDims[2] = {_iNewRows, _iNewCols};
     return resize(piDims, 2);
 }
 
-Struct* Struct::resize(int* _piDims, int _iDims)
+bool Struct::resize(int* _piDims, int _iDims)
 {
-    typedef Struct* (Struct::*resize_t)(int*, int);
-    Struct* pIT = checkRef(this, (resize_t)&Struct::resize, _piDims, _iDims);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     m_bDisableCloneInCopyValue = true;
     Struct* pSRes = ArrayOf<SingleStruct*>::resize(_piDims, _iDims)->getAs<Struct>();
     m_bDisableCloneInCopyValue = false;
@@ -727,7 +720,7 @@ Struct* Struct::resize(int* _piDims, int _iDims)
         pFields->killMe();
     }
 
-    return pSRes;
+    return (bool)pSRes;
 }
 
 InternalType* Struct::insertWithoutClone(typed_list* _pArgs, InternalType* _pSource)

--- a/scilab/modules/ast/src/cpp/types/struct.cpp
+++ b/scilab/modules/ast/src/cpp/types/struct.cpp
@@ -703,24 +703,22 @@ bool Struct::resize(int _iNewRows, int _iNewCols)
 bool Struct::resize(int* _piDims, int _iDims)
 {
     m_bDisableCloneInCopyValue = true;
-    Struct* pSRes = ArrayOf<SingleStruct*>::resize(_piDims, _iDims)->getAs<Struct>();
+    ArrayOf<SingleStruct*>::resize(_piDims, _iDims);
     m_bDisableCloneInCopyValue = false;
-    if (pSRes)
-    {
-        // insert field(s) only in new element(s) of current struct
-        String* pFields = getFieldNames();
-        for (int iterField = 0; iterField < pFields->getSize(); iterField++)
-        {
-            for (int iterStruct = 0; iterStruct < getSize(); iterStruct++)
-            {
-                get(iterStruct)->addField(pFields->get(iterField));
-            }
-        }
 
-        pFields->killMe();
+    // insert field(s) only in new element(s) of current struct
+    String* pFields = getFieldNames();
+    for (int iterField = 0; iterField < pFields->getSize(); iterField++)
+    {
+        for (int iterStruct = 0; iterStruct < getSize(); iterStruct++)
+        {
+            get(iterStruct)->addField(pFields->get(iterField));
+        }
     }
 
-    return (bool)pSRes;
+    pFields->killMe();
+
+    return true;
 }
 
 InternalType* Struct::insertWithoutClone(typed_list* _pArgs, InternalType* _pSource)

--- a/scilab/modules/ast/src/cpp/types/struct.cpp
+++ b/scilab/modules/ast/src/cpp/types/struct.cpp
@@ -203,38 +203,31 @@ bool Struct::invoke(typed_list & in, optional_list & opt, int _iRetCount, typed_
     return ArrayOf<SingleStruct*>::invoke(in, opt, _iRetCount, out, e);
 }
 
-Struct* Struct::set(int _iRows, int _iCols, SingleStruct* _pIT)
+bool Struct::set(int _iRows, int _iCols, SingleStruct* _pIT)
 {
     if (_iRows < getRows() && _iCols < getCols())
     {
         return set(_iCols * getRows() + _iRows, _pIT);
     }
-    return NULL;
+    return false;
 }
 
-Struct* Struct::set(int _iRows, int _iCols, const SingleStruct* _pIT)
+bool Struct::set(int _iRows, int _iCols, const SingleStruct* _pIT)
 {
     if (_iRows < getRows() && _iCols < getCols())
     {
         return set(_iCols * getRows() + _iRows, _pIT);
     }
-    return NULL;
+    return false;
 }
 
-Struct* Struct::set(int _iIndex, SingleStruct* _pIT)
+bool Struct::set(int _iIndex, SingleStruct* _pIT)
 {
-    typedef Struct* (Struct::*set_t)(int, SingleStruct*);
-    Struct* pIT = checkRef(this, (set_t)&Struct::set, _iIndex, _pIT);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     if (_iIndex < getSize())
     {
         if (m_bDisableCloneInCopyValue && m_pRealData[_iIndex] == _pIT)
         {
-            return this;
+            return true;
         }
 
         InternalType* pOld = m_pRealData[_iIndex];
@@ -252,20 +245,13 @@ Struct* Struct::set(int _iIndex, SingleStruct* _pIT)
             pOld->killMe();
         }
 
-        return this;
+        return true;
     }
-    return NULL;
+    return false;
 }
 
-Struct* Struct::set(int _iIndex, const SingleStruct* _pIT)
+bool Struct::set(int _iIndex, const SingleStruct* _pIT)
 {
-    typedef Struct* (Struct::*set_t)(int, const SingleStruct*);
-    Struct* pIT = checkRef(this, (set_t)&Struct::set, _iIndex, _pIT);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     if (_iIndex < getSize())
     {
         InternalType* pOld = m_pRealData[_iIndex];
@@ -278,28 +264,21 @@ Struct* Struct::set(int _iIndex, const SingleStruct* _pIT)
             pOld->killMe();
         }
 
-        return this;
+        return true;
     }
-    return NULL;
+    return false;
 }
 
-Struct* Struct::set(SingleStruct** _pIT)
+bool Struct::set(SingleStruct** _pIT)
 {
-    typedef Struct* (Struct::*set_t)(SingleStruct**);
-    Struct* pIT = checkRef(this, (set_t)&Struct::set, _pIT);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     for (int i = 0 ; i < getSize() ; i++)
     {
-        if (set(i, _pIT[i]) == NULL)
+        if (set(i, _pIT[i]) == false)
         {
-            return NULL;
+            return false;
         }
     }
-    return this;
+    return true;
 }
 
 String* Struct::getFieldNames()

--- a/scilab/modules/ast/src/cpp/types/tlist.cpp
+++ b/scilab/modules/ast/src/cpp/types/tlist.cpp
@@ -283,12 +283,12 @@ std::wstring TList::getShortTypeStr() const
     return getTypeStr();
 }
 
-TList* TList::set(const std::wstring& _sKey, InternalType* _pIT)
+bool TList::set(const std::wstring& _sKey, InternalType* _pIT)
 {
     return List::set(getIndexFromString(_sKey), _pIT)->getAs<TList>();
 }
 
-TList* TList::set(const int _iIndex, InternalType* _pIT)
+bool TList::set(const int _iIndex, InternalType* _pIT)
 {
     return List::set(_iIndex, _pIT)->getAs<TList>();
 }

--- a/scilab/modules/ast/src/cpp/types/tlist.cpp
+++ b/scilab/modules/ast/src/cpp/types/tlist.cpp
@@ -293,6 +293,16 @@ bool TList::set(const int _iIndex, InternalType* _pIT)
     return List::set(_iIndex, _pIT);
 }
 
+TList* TList::setClone(const std::wstring& _sKey, InternalType* _pIT)
+{
+    return List::setClone(getIndexFromString(_sKey), _pIT)->getAs<types::TList>();
+}
+
+TList* TList::setClone(const int _iIndex, InternalType* _pIT)
+{
+    return List::setClone(_iIndex, _pIT)->getAs<types::TList>();
+}
+
 String* TList::getFieldNames() const
 {
     return (*m_plData)[0]->getAs<types::String>();

--- a/scilab/modules/ast/src/cpp/types/tlist.cpp
+++ b/scilab/modules/ast/src/cpp/types/tlist.cpp
@@ -285,12 +285,12 @@ std::wstring TList::getShortTypeStr() const
 
 bool TList::set(const std::wstring& _sKey, InternalType* _pIT)
 {
-    return List::set(getIndexFromString(_sKey), _pIT)->getAs<TList>();
+    return List::set(getIndexFromString(_sKey), _pIT);
 }
 
 bool TList::set(const int _iIndex, InternalType* _pIT)
 {
-    return List::set(_iIndex, _pIT)->getAs<TList>();
+    return List::set(_iIndex, _pIT);
 }
 
 String* TList::getFieldNames() const

--- a/scilab/modules/ast/src/cpp/types/types.cpp
+++ b/scilab/modules/ast/src/cpp/types/types.cpp
@@ -66,4 +66,23 @@ int GenericType::getVarMaxDim(int _iCurrentDim, int _iMaxDim)
         return getSize();
     }
 }
+
+GenericType* GenericType::resizeClone(int* _piDims, int _iDims)
+{
+    if (getRef() > 1)
+    {
+        GenericType* pClone = clone();
+
+        if (pClone->resize(_piDims, _iDims) == false)
+        {
+            pClone->killMe();
+            return NULL;
+        }
+
+        return pClone;
+    }
+
+    return resize(_piDims, _iDims) ? this : NULL;
+}
+
 }

--- a/scilab/modules/data_structures/sci_gateway/cpp/sci_setfield.cpp
+++ b/scilab/modules/data_structures/sci_gateway/cpp/sci_setfield.cpp
@@ -1,8 +1,8 @@
 /*
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2013 - Scilab Enterprises - Antoine Elias
- *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -69,11 +69,9 @@ types::Function::ReturnValue sci_setfield(types::typed_list &in, int _iRetCount,
             return types::Function::Error;
         }
 
-        types::TList* pT = pL->getAs<types::TList>();
-
+        types::TList* pRet = pL->copyAs<types::TList>();
         std::wstring stField = pS->get(0);
-        types::TList* pRet = pT->set(stField, pData);
-        if (pRet == nullptr)
+        if (pRet->set(stField, pData) == false)
         {
             Scierror(999, _("%s: Invalid index.\n"), "setfield");
             return types::Function::Error;

--- a/scilab/modules/data_structures/sci_gateway/cpp/sci_setfield.cpp
+++ b/scilab/modules/data_structures/sci_gateway/cpp/sci_setfield.cpp
@@ -69,9 +69,10 @@ types::Function::ReturnValue sci_setfield(types::typed_list &in, int _iRetCount,
             return types::Function::Error;
         }
 
-        types::TList* pRet = pL->copyAs<types::TList>();
+        types::TList* pT = pL->getAs<types::TList>();
         std::wstring stField = pS->get(0);
-        if (pRet->set(stField, pData) == false)
+        types::TList* pRet = pT->setClone(stField, pData);
+        if (pRet == nullptr)
         {
             Scierror(999, _("%s: Invalid index.\n"), "setfield");
             return types::Function::Error;

--- a/scilab/modules/mexlib/src/cpp/mexlib.cpp
+++ b/scilab/modules/mexlib/src/cpp/mexlib.cpp
@@ -1,11 +1,11 @@
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2011-2011 - Gsoc 2011 - Iuri SILVIO
- *  Copyright (C) 2011-2011 - DIGITEO - Bruno JOFRET
- *  Copyright (C) 2011 - DIGITEO - Antoine ELIAS
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2011-2011 - Gsoc 2011 - Iuri SILVIO
+ * Copyright (C) 2011-2011 - DIGITEO - Bruno JOFRET
+ * Copyright (C) 2011 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- *  Copyright (C) 2017 - Gsoc 2017 - Siddhartha Gairola
+ * Copyright (C) 2017 - Gsoc 2017 - Siddhartha Gairola
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -1567,7 +1567,9 @@ int mxAddField(mxArray *ptr, const char *fieldname)
 
     types::Struct *pa = (types::Struct*)ptr->ptr;
     wchar_t *wfieldname = to_wide_string(fieldname);
-    ptr->ptr = (int*)pa->addField(wfieldname);
+    pa = pa->copyAs<types::Struct>();
+    pa->addField(wfieldname);
+    ptr->ptr = (int*)pa;
     FREE(wfieldname);
     return mxGetFieldNumber(ptr, fieldname);
 }

--- a/scilab/modules/mexlib/src/cpp/mexlib.cpp
+++ b/scilab/modules/mexlib/src/cpp/mexlib.cpp
@@ -1006,8 +1006,8 @@ void mxSetM(mxArray *ptr, int M)
         return;
     }
 
-    types::GenericType *res = pIT->copyAs<types::GenericType>();
-    res->resize(M, res->getCols());
+    types::GenericType* pGT = pIT->getAs<types::GenericType>();
+    types::InternalType* res = pGT->resizeClone(M, pGT->getCols());
 
     ptr->ptr = (int*)res;
 }
@@ -1032,8 +1032,8 @@ void mxSetN(mxArray *ptr, int N)
         return;
     }
 
-    types::GenericType* res = pIT->copyAs<types::GenericType>();
-    res->resize(res->getRows(), N);
+    types::GenericType* pGT = pIT->getAs<types::GenericType>();
+    types::InternalType* res = pGT->resizeClone(pGT->getRows(), N);
 
     ptr->ptr = (int*)res;
 }

--- a/scilab/modules/mexlib/src/cpp/mexlib.cpp
+++ b/scilab/modules/mexlib/src/cpp/mexlib.cpp
@@ -63,6 +63,7 @@
 #include "printvisitor.hxx"
 
 #include "types.hxx"
+#include "internal.hxx"
 #include "int.hxx"
 #include "double.hxx"
 #include "bool.hxx"
@@ -1005,9 +1006,9 @@ void mxSetM(mxArray *ptr, int M)
         return;
     }
 
-    types::GenericType *pGT = pIT->getAs<types::GenericType>();
+    types::GenericType *res = pIT->copyAs<types::GenericType>();
+    res->resize(M, res->getCols());
 
-    types::InternalType* res = pGT->resize(M, pGT->getCols());
     ptr->ptr = (int*)res;
 }
 
@@ -1031,9 +1032,9 @@ void mxSetN(mxArray *ptr, int N)
         return;
     }
 
-    types::GenericType * pGT = pIT->getAs<types::GenericType>();
+    types::GenericType* res = pIT->copyAs<types::GenericType>();
+    res->resize(res->getRows(), N);
 
-    types::InternalType* res = pGT->resize(pGT->getRows(), N);
     ptr->ptr = (int*)res;
 }
 


### PR DESCRIPTION
- This addresses #137 partially
- `checkRef` is still present in `insert` member function(s)