### PR TITLE
Revert "Decrease Overhead of "checkRef""

### DIFF
--- a/scilab/modules/api_scilab/src/cpp/template/api_boolean.hpp
+++ b/scilab/modules/api_scilab/src/cpp/template/api_boolean.hpp
@@ -1,16 +1,16 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
+* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+* Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
+*
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
- * 
+ *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
  * This file was originally licensed under the terms of the CeCILL v2.1,
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
- */
+*/
 
 #include "gatewaystruct.hxx"
 #include "bool.hxx"
@@ -131,7 +131,7 @@ scilabStatus API_PROTO(setBooleanArray)(scilabEnv env, scilabVar var, const int*
     }
 #endif
 
-    bool bset = b->set(vals);
+    bool bset = b->set(vals) != nullptr;
 #ifdef __API_SCILAB_SAFE__
     if (bset == false)
     {

--- a/scilab/modules/api_scilab/src/cpp/template/api_cell.hpp
+++ b/scilab/modules/api_scilab/src/cpp/template/api_cell.hpp
@@ -1,8 +1,8 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
+* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+* Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
+*
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,7 +10,7 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
- */
+*/
 
 #include "gatewaystruct.hxx"
 #include "cell.hxx"
@@ -117,7 +117,7 @@ scilabStatus API_PROTO(setCellValue)(scilabEnv env, scilabVar var, int* index, s
     }
 #endif
     int i = c->getIndex(index);
-    bool bset = c->set(i, (types::InternalType*)val);
+    bool bset = c->set(i, (types::InternalType*)val) != nullptr;
 #ifdef __API_SCILAB_SAFE__
     if (bset == false)
     {
@@ -140,7 +140,7 @@ scilabStatus API_PROTO(setCell2dValue)(scilabEnv env, scilabVar var, int row, in
     }
 #endif
     int i = c->getIndex(index);
-    bool bset = c->set(i, (types::InternalType*)val);
+    bool bset = c->set(i, (types::InternalType*)val) != nullptr;
 #ifdef __API_SCILAB_SAFE__
     if (bset == false)
     {

--- a/scilab/modules/api_scilab/src/cpp/template/api_handle.hpp
+++ b/scilab/modules/api_scilab/src/cpp/template/api_handle.hpp
@@ -1,8 +1,8 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
+* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+* Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
+*
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,7 +10,7 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
- */
+*/
 
 #include "gatewaystruct.hxx"
 #include "graphichandle.hxx"
@@ -112,7 +112,7 @@ scilabStatus API_PROTO(setHandleArray)(scilabEnv env, scilabVar var, const long 
     }
 #endif
 
-    bool bset = h->set(vals);
+    bool bset = h->set(vals) != nullptr;
 #ifdef __API_SCILAB_SAFE__
     if (bset == false)
     {

--- a/scilab/modules/api_scilab/src/cpp/template/api_list.hpp
+++ b/scilab/modules/api_scilab/src/cpp/template/api_list.hpp
@@ -1,8 +1,8 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
+* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+* Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
+*
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,7 +10,7 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
- */
+*/
 
 #include "gatewaystruct.hxx"
 #include "list.hxx"
@@ -98,7 +98,7 @@ scilabStatus API_PROTO(setListItem)(scilabEnv env, scilabVar var, int index, sci
     }
 #endif
 
-    bool ret = l->set(index, (types::InternalType*)val);
+    bool ret = l->set(index, (types::InternalType*)val) != nullptr;
     return ret ? STATUS_OK : STATUS_ERROR;
 }
 
@@ -153,7 +153,7 @@ scilabStatus API_PROTO(setTListField)(scilabEnv env, scilabVar var, const wchar_
         fields->set(fields->getSize() - 1, field);
     }
 
-    bool ret = l->set(field, (types::InternalType*)val);
+    bool ret = l->set(field, (types::InternalType*)val) != nullptr;
     return ret ? STATUS_OK : STATUS_ERROR;
 }
 
@@ -206,7 +206,7 @@ scilabStatus API_PROTO(setMListField)(scilabEnv env, scilabVar var, const wchar_
         fields->set(fields->getSize() - 1, field);
     }
 
-    bool ret = l->set(field, (types::InternalType*)val);
+    bool ret = l->set(field, (types::InternalType*)val) != nullptr;
     return ret ? STATUS_OK : STATUS_ERROR;
 }
 

--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -215,8 +215,15 @@ public :
         deleteData(tNullVal);
     }
 
-    virtual void setComplex(bool _bComplex)
+    virtual ArrayOf<T>* setComplex(bool _bComplex)
     {
+        typedef ArrayOf<T>* (ArrayOf<T>::*setcplx_t)(bool);
+        ArrayOf<T>* pIT = checkRef(this, (setcplx_t)&ArrayOf<T>::setComplex, _bComplex);
+        if (pIT != this)
+        {
+            return pIT;
+        }
+
         if (_bComplex == false)
         {
             if (m_pImgData != NULL)
@@ -232,30 +239,46 @@ public :
                 memset(m_pImgData, 0x00, sizeof(T) * m_iSize);
             }
         }
+
+        return this;
     }
 
-    virtual bool set(int _iPos, const T _data)
+    virtual ArrayOf<T>* set(int _iPos, const T _data)
     {
         if (m_pRealData == NULL || _iPos >= m_iSize)
         {
-            return false;
+            return NULL;
+        }
+
+        typedef ArrayOf<T>* (ArrayOf<T>::*set_t)(int, T);
+        ArrayOf<T>* pIT = checkRef(this, (set_t)&ArrayOf<T>::set, _iPos, _data);
+        if (pIT != this)
+        {
+            return pIT;
         }
 
         deleteData(m_pRealData[_iPos]);
         m_pRealData[_iPos] = copyValue(_data);
-        return true;
+        return this;
     }
 
-    virtual bool set(int _iRows, int _iCols, const T _data)
+    virtual ArrayOf<T>* set(int _iRows, int _iCols, const T _data)
     {
         return set(_iCols * getRows() + _iRows, _data);
     }
 
-    virtual bool set(T* _pdata)
+    virtual ArrayOf<T>* set(T* _pdata)
     {
         if (m_pRealData == NULL)
         {
-            return false;
+            return NULL;
+        }
+
+        typedef ArrayOf<T>* (ArrayOf<T>::*set_t)(T*);
+        ArrayOf<T>* pIT = checkRef(this, (set_t)&ArrayOf<T>::set, _pdata);
+        if (pIT != this)
+        {
+            return pIT;
         }
 
         for (int i = 0 ; i < m_iSize ; i++)
@@ -263,14 +286,21 @@ public :
             deleteData(m_pRealData[i]);
             m_pRealData[i] = copyValue(_pdata[i]);
         }
-        return true;
+        return this;
     }
 
-    virtual bool set(const T* _pdata)
+    virtual ArrayOf<T>* set(const T* _pdata)
     {
         if (m_pRealData == NULL)
         {
-            return false;
+            return NULL;
+        }
+
+        typedef ArrayOf<T>* (ArrayOf<T>::*set_t)(const T*);
+        ArrayOf<T>* pIT = checkRef(this, (set_t)&ArrayOf<T>::set, _pdata);
+        if (pIT != this)
+        {
+            return pIT;
         }
 
         for (int i = 0 ; i < m_iSize ; i++)
@@ -279,7 +309,7 @@ public :
             m_pRealData[i] = copyValue(_pdata[i]);
         }
 
-        return true;
+        return this;
     }
 
     inline T* get() const
@@ -302,28 +332,42 @@ public :
     }
 
     /*internal function to manage img part*/
-    bool setImg(int _iPos, T _data)
+    ArrayOf<T>* setImg(int _iPos, T _data)
     {
         if (m_pImgData == NULL || _iPos >= m_iSize)
         {
-            return false;
+            return NULL;
+        }
+
+        typedef ArrayOf<T>* (ArrayOf<T>::*setimg_t)(int, T);
+        ArrayOf<T>* pIT = checkRef(this, (setimg_t)&ArrayOf<T>::setImg, _iPos, _data);
+        if (pIT != this)
+        {
+            return pIT;
         }
 
         m_pImgData[_iPos] = copyValue(_data);
-        return true;
+        return this;
     }
 
 
-    bool setImg(int _iRows, int _iCols, T _data)
+    ArrayOf<T>* setImg(int _iRows, int _iCols, T _data)
     {
         return setImg(_iCols * getRows() + _iRows, copyValue(_data));
     }
 
-    bool setImg(T* _pdata)
+    ArrayOf<T>* setImg(T* _pdata)
     {
         if (m_pImgData == NULL)
         {
-            return false;
+            return NULL;
+        }
+
+        typedef ArrayOf<T>* (ArrayOf<T>::*setimg_t)(T*);
+        ArrayOf<T>* pIT = checkRef(this, (setimg_t)&ArrayOf<T>::setImg, _pdata);
+        if (pIT != this)
+        {
+            return pIT;
         }
 
         for (int i = 0 ; i < m_iSize ; i++)
@@ -331,15 +375,22 @@ public :
             m_pImgData[i] = copyValue(_pdata[i]);
         }
 
-        return true;
+        return this;
     }
 
 
-    bool setImg(const T* _pdata)
+    ArrayOf<T>* setImg(const T* _pdata)
     {
         if (m_pImgData == NULL)
         {
-            return false;
+            return NULL;
+        }
+
+        typedef ArrayOf<T>* (ArrayOf<T>::*setimg_t)(const T*);
+        ArrayOf<T>* pIT = checkRef(this, (setimg_t)&ArrayOf<T>::setImg, _pdata);
+        if (pIT != this)
+        {
+            return pIT;
         }
 
         for (int i = 0 ; i < m_iSize ; i++)
@@ -347,7 +398,7 @@ public :
             m_pImgData[i] = copyValue(_pdata[i]);
         }
 
-        return true;
+        return this;
     }
 
     inline T* getImg() const
@@ -370,8 +421,8 @@ public :
     }
 
     virtual ArrayOf<T>* insert(typed_list* _pArgs, InternalType* _pSource);
-    virtual bool append(int _iRows, int _iCols, InternalType* _poSource);
-    virtual bool resize(int* _piDims, int _iDims);
+    virtual ArrayOf<T>* append(int _iRows, int _iCols, InternalType* _poSource);
+    virtual ArrayOf<T>* resize(int* _piDims, int _iDims);
 
     // return a GenericType because of [] wich is a types::Double (can't be a ArrayOf<char>)
     virtual GenericType* remove(typed_list* _pArgs);
@@ -384,16 +435,16 @@ public :
     virtual int getInvokeNbIn();
     virtual int getInvokeNbOut();
 
-    virtual bool reshape(int _iNewRows, int _iNewCols)
+    virtual ArrayOf<T>* reshape(int _iNewRows, int _iNewCols)
     {
         int piDims[2] = {_iNewRows, _iNewCols};
         return reshape(piDims, 2);
     }
 
-    virtual bool reshape(int* _piDims, int _iDims);
+    virtual ArrayOf<T>* reshape(int* _piDims, int _iDims);
 
 
-    virtual bool resize(int _iNewRows, int _iNewCols)
+    virtual ArrayOf<T>* resize(int _iNewRows, int _iNewCols)
     {
         int piDims[2] = {_iNewRows, _iNewCols};
         return resize(piDims, 2);

--- a/scilab/modules/ast/includes/types/bool.hxx
+++ b/scilab/modules/ast/includes/types/bool.hxx
@@ -1,8 +1,8 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
+*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+*  Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
+*
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
- *
- */
+*
+*/
 
 // This code is separated in bool.hxx
 // but will be inlined in arrayof.hxx
@@ -53,8 +53,8 @@ public:
 
 
     /*zero or one set filler*/
-    void setFalse();
-    void setTrue();
+    Bool*                   setFalse();
+    Bool*                   setTrue();
 
     /*Config management*/
     void                    whoAmI();

--- a/scilab/modules/ast/includes/types/cell.hxx
+++ b/scilab/modules/ast/includes/types/cell.hxx
@@ -1,9 +1,9 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
- * Copyright (C) 2011 - DIGITEO - Antoine ELIAS
+*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+*  Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
+*  Copyright (C) 2011 - DIGITEO - Antoine ELIAS
+*
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyrigth (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -11,8 +11,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
- *
- */
+*
+*/
 
 
 //#ifndef __ARRAYOF_HXX__
@@ -68,11 +68,11 @@ public :
     */
     Cell*               clone();
 
-    bool set(int _iRows, int _iCols, InternalType* _pIT);
-    bool set(int _iRows, int _iCols, const InternalType* _pIT);
-    bool set(int _iIndex, InternalType* _pIT);
-    bool set(int _iIndex, const InternalType* _pIT);
-    bool set(InternalType** _pIT);
+    Cell*               set(int _iRows, int _iCols, InternalType* _pIT);
+    Cell*               set(int _iRows, int _iCols, const InternalType* _pIT);
+    Cell*               set(int _iIndex, InternalType* _pIT);
+    Cell*               set(int _iIndex, const InternalType* _pIT);
+    Cell*               set(InternalType** _pIT);
 
     bool                operator==(const InternalType& it);
     bool                operator!=(const InternalType& it);

--- a/scilab/modules/ast/includes/types/double.hxx
+++ b/scilab/modules/ast/includes/types/double.hxx
@@ -66,7 +66,7 @@ public :
     Double*                     clone();
     void fillFromCol(int _iCols, Double *_poSource);
     void fillFromRow(int _iRows, Double *_poSource);
-    bool append(int _iRows, int _iCols, InternalType* _poSource);
+    Double*                     append(int _iRows, int _iCols, InternalType* _poSource);
 
     //bool                        append(int _iRows, int _iCols, Double *_poSource);
 
@@ -269,27 +269,41 @@ public :
 
     virtual ast::Exp*           getExp(const Location& loc);
 
-    virtual bool set(int _iPos, const double _data)
+    virtual Double* set(int _iPos, const double _data)
     {
         if (_iPos >= m_iSize)
         {
-            return false;
+            return NULL;
+        }
+
+        typedef Double* (Double::*set_t)(int, double);
+        Double* pIT = checkRef(this, (set_t)&Double::set, _iPos, _data);
+        if (pIT != this)
+        {
+            return pIT;
         }
 
         m_pRealData[_iPos] = _data;
-        return true;
+        return this;
     }
 
-    virtual bool set(int _iRows, int _iCols, const double _data)
+    virtual Double* set(int _iRows, int _iCols, const double _data)
     {
         return set(_iCols * m_iRows + _iRows, _data);
     }
 
-    virtual bool set(double* _pdata)
+    virtual Double* set(double* _pdata)
     {
         if (m_pRealData == NULL)
         {
-            return false;
+            return NULL;
+        }
+
+        typedef Double* (Double::*set_t)(double*);
+        Double* pIT = checkRef(this, (set_t)&Double::set, _pdata);
+        if (pIT != this)
+        {
+            return pIT;
         }
 
         for (int i = 0; i < m_iSize; i++)
@@ -297,14 +311,21 @@ public :
             m_pRealData[i] = _pdata[i];
         }
 
-        return true;
+        return this;
     }
 
-    virtual bool set(const double* _pdata)
+    virtual Double* set(const double* _pdata)
     {
         if (m_pRealData == NULL)
         {
-            return false;
+            return NULL;
+        }
+
+        typedef Double* (Double::*set_t)(const double*);
+        Double* pIT = checkRef(this, (set_t)&Double::set, _pdata);
+        if (pIT != this)
+        {
+            return pIT;
         }
 
         for (int i = 0; i < m_iSize; i++)
@@ -312,7 +333,7 @@ public :
             m_pRealData[i] = _pdata[i];
         }
 
-        return true;
+        return this;
     }
 
     virtual bool isNativeType() override

--- a/scilab/modules/ast/includes/types/internal.hxx
+++ b/scilab/modules/ast/includes/types/internal.hxx
@@ -244,15 +244,7 @@ public :
         return _pIT;
     }
 
-    template <class T>
-    inline T* copyAs(void)
-    {
-        if (getRef() > 1)
-        {
-            return static_cast<T*>(this->clone());
-        }
-        return static_cast<T*>(this);
-    }
+
 
 #ifdef _SCILAB_DEBUGREF_
     inline void _killme(const char * f, int l)

--- a/scilab/modules/ast/includes/types/list.hxx
+++ b/scilab/modules/ast/includes/types/list.hxx
@@ -1,8 +1,8 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
+ *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ *  Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
+ *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -51,7 +51,7 @@ public :
     ** append(InternalType *_typedValue)
     ** Append the given value to the end of the List
     */
-    bool append(InternalType *_typedValue);
+    List*                           append(InternalType *_typedValue);
 
     /**
     ** Clone
@@ -116,8 +116,7 @@ public :
     }
 
     virtual InternalType*           get(const int _iIndex);
-    virtual bool set(const int _iIndex, InternalType* _pIT);
-    virtual List* setClone(const int _iIndex, InternalType* _pIT);
+    virtual List*                   set(const int _iIndex, InternalType* _pIT);
 
     /* return type as string ( double, int, cell, list, ... )*/
     virtual std::wstring            getTypeStr() const

--- a/scilab/modules/ast/includes/types/polynom.hxx
+++ b/scilab/modules/ast/includes/types/polynom.hxx
@@ -1,8 +1,8 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
+*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+*  Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
+*
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyrigth (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
- *
- */
+*
+*/
 
 // This code is separated in matrixpoly.hxx
 // but will be inlined in arrayof.hxx
@@ -50,10 +50,10 @@ public :
     // FIXME : Should not return NULL
     Polynom*                clone();
 
-    bool setCoef(int _iRows, int _iCols, Double *_pdblCoef);
-    bool setCoef(int _iIdx, Double *_pdblCoef);
+    Polynom*                setCoef(int _iRows, int _iCols, Double *_pdblCoef);
+    Polynom*                setCoef(int _iIdx, Double *_pdblCoef);
 
-    virtual void setComplex(bool _bComplex);
+    virtual Polynom*        setComplex(bool _bComplex);
 
     inline ScilabType       getType(void)
     {
@@ -85,15 +85,15 @@ public :
     Double*                 evaluate(Double* _pdblValue);
     void                    updateRank(void);
     Double*                 getCoef(void);
-    bool setCoef(Double *_pCoef);
+    Polynom*                setCoef(Double *_pCoef);
     Double*                 extractCoef(int _iRank);
     bool                    insertCoef(int _iRank, Double* _pCoef);
     void                    setZeros();
     Polynom*                insert(typed_list* _pArgs, InternalType* _pSource);
 
-    bool set(int _iPos, SinglePoly* _pS);
-    bool set(int _iRows, int _iCols, SinglePoly* _pS);
-    bool set(SinglePoly** _pS);
+    Polynom*                set(int _iPos, SinglePoly* _pS);
+    Polynom*                set(int _iRows, int _iCols, SinglePoly* _pS);
+    Polynom*                set(SinglePoly** _pS);
 
     std::wstring            getRowString(int* _piDims, int _iDims, bool _bComplex);
     std::wstring            getColString(int* _piDims, int _iDims, bool _bComplex);

--- a/scilab/modules/ast/includes/types/sparse.hxx
+++ b/scilab/modules/ast/includes/types/sparse.hxx
@@ -1,8 +1,8 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2010-2010 - DIGITEO - Bernard Hugueney
+ *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ *  Copyright (C) 2010-2010 - DIGITEO - Bernard Hugueney
+ *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -82,14 +82,14 @@ struct EXTERN_AST Sparse : GenericType
     void finalize();
 
     /*data management member function defined for compatibility with the Double API*/
-    bool set(int _iRows, int _iCols, double _dblReal, bool _bFinalize = true);
-    bool set(int _iIndex, double _dblReal, bool _bFinalize = true)
+    Sparse* set(int _iRows, int _iCols, double _dblReal, bool _bFinalize = true);
+    Sparse* set(int _iIndex, double _dblReal, bool _bFinalize = true)
     {
         return set(_iIndex % m_iRows, _iIndex / m_iRows, _dblReal, _bFinalize);
     }
 
-    bool set(int _iRows, int _iCols, std::complex<double> v, bool _bFinalize = true);
-    bool set(int _iIndex, std::complex<double> v, bool _bFinalize = true)
+    Sparse* set(int _iRows, int _iCols, std::complex<double> v, bool _bFinalize = true);
+    Sparse* set(int _iIndex, std::complex<double> v, bool _bFinalize = true)
     {
         return set(_iIndex % m_iRows, _iIndex / m_iRows, v, _bFinalize);
     }
@@ -154,7 +154,7 @@ struct EXTERN_AST Sparse : GenericType
        @param _iNewCols new minimum nb of cols
        @return true upon succes, false otherwise.
      */
-    bool resize(int _iNewRows, int _iNewCols);
+    Sparse* resize(int _iNewRows, int _iNewCols);
     /* post condition: new total size must be equal to the old size.
                        Two dimensions maximum.
 
@@ -164,8 +164,8 @@ struct EXTERN_AST Sparse : GenericType
        @param _iNewDims new size for each dimension
        @return true upon succes, false otherwise.
     */
-    bool reshape(int* _piNewDims, int _iNewDims);
-    bool reshape(int _iNewRows, int _iNewCols);
+    Sparse* reshape(int* _piNewDims, int _iNewDims);
+    Sparse* reshape(int _iNewRows, int _iNewCols);
     /*
       insert _iSeqCount elements from _poSource at coords given by _piSeqCoord (max in _piMaxDim).
       coords are considered 1D if _bAsVector, 2D otherwise.
@@ -185,7 +185,7 @@ struct EXTERN_AST Sparse : GenericType
        @param _iCols col to append from
        @param _poSource src data to append
      */
-    bool append(int r, int c, types::Sparse SPARSE_CONST* src);
+    Sparse* append(int r, int c, types::Sparse SPARSE_CONST* src);
 
     /*
       extract a submatrix
@@ -521,11 +521,11 @@ struct EXTERN_AST SparseBool : GenericType
     /* Config management and GenericType methods overrides */
     SparseBool* clone(void);
 
-    bool resize(int _iNewRows, int _iNewCols);
-    bool reshape(int* _piNewDims, int _iNewDims);
-    bool reshape(int _iNewRows, int _iNewCols);
+    SparseBool* resize(int _iNewRows, int _iNewCols);
+    SparseBool* reshape(int* _piNewDims, int _iNewDims);
+    SparseBool* reshape(int _iNewRows, int _iNewCols);
     SparseBool* insert(typed_list* _pArgs, InternalType* _pSource);
-    bool append(int _iRows, int _iCols, SparseBool SPARSE_CONST* _poSource);
+    SparseBool* append(int _iRows, int _iCols, SparseBool SPARSE_CONST* _poSource);
 
     GenericType* remove(typed_list* _pArgs);
     GenericType* insertNew(typed_list* _pArgs);
@@ -620,8 +620,8 @@ struct EXTERN_AST SparseBool : GenericType
         return get(_iIndex % m_iRows, _iIndex / m_iRows);
     }
 
-    bool set(int r, int c, bool b, bool _bFinalize = true) SPARSE_CONST;
-    bool set(int _iIndex, bool b, bool _bFinalize = true) SPARSE_CONST
+    SparseBool* set(int r, int c, bool b, bool _bFinalize = true) SPARSE_CONST;
+    SparseBool* set(int _iIndex, bool b, bool _bFinalize = true) SPARSE_CONST
     {
         return set(_iIndex % m_iRows, _iIndex / m_iRows, b, _bFinalize);
     }

--- a/scilab/modules/ast/includes/types/string.hxx
+++ b/scilab/modules/ast/includes/types/string.hxx
@@ -48,16 +48,16 @@ public :
 
     void                    whoAmI();
 
-    void set_(int _iPos, const wchar_t* _pwstData);
-    void set_(int _iRows, int _iCols, const wchar_t* _pwstData);
+    virtual String* set_(int _iPos, const wchar_t* _pwstData);
+    virtual String* set_(int _iRows, int _iCols, const wchar_t* _pwstData);
 
-    virtual bool set(int _iPos, const wchar_t* _pwstData);
-    virtual bool set(int _iRows, int _iCols, const wchar_t* _pwstData);
-    virtual bool set(const wchar_t* const* _pwstData);
+    virtual String*         set(int _iPos, const wchar_t* _pwstData);
+    virtual String*         set(int _iRows, int _iCols, const wchar_t* _pwstData);
+    virtual String*         set(const wchar_t* const* _pwstData);
 
-    virtual bool set(int _iPos, const char* _pcData);
-    virtual bool set(int _iRows, int _iCols, const char* _pcData);
-    virtual bool set(const char* const* _pstrData);
+    virtual String*         set(int _iPos, const char* _pcData);
+    virtual String*         set(int _iRows, int _iCols, const char* _pcData);
+    virtual String*         set(const char* const* _pstrData);
 
     bool                    operator==(const InternalType& it);
     bool                    operator!=(const InternalType& it);

--- a/scilab/modules/ast/includes/types/struct.hxx
+++ b/scilab/modules/ast/includes/types/struct.hxx
@@ -1,8 +1,8 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2011 - DIGITEO - Antoine ELIAS
+*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+*  Copyright (C) 2011 - DIGITEO - Antoine ELIAS
+*
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyrigth (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
- *
- */
+*
+*/
 
 #ifndef __STRUCT_HXX__
 #define __STRUCT_HXX__
@@ -69,11 +69,11 @@ public :
     */
     Struct*                     clone();
 
-    bool set(int _iRows, int _iCols, SingleStruct* _pIT);
-    bool set(int _iRows, int _iCols, const SingleStruct* _pIT);
-    bool set(int _iIndex, SingleStruct* _pIT);
-    bool set(int _iIndex, const SingleStruct* _pIT);
-    bool set(SingleStruct** _pIT);
+    Struct*                     set(int _iRows, int _iCols, SingleStruct* _pIT);
+    Struct*                     set(int _iRows, int _iCols, const SingleStruct* _pIT);
+    Struct*                     set(int _iIndex, SingleStruct* _pIT);
+    Struct*                     set(int _iIndex, const SingleStruct* _pIT);
+    Struct*                     set(SingleStruct** _pIT);
 
     bool                        operator==(const InternalType& it);
     bool                        operator!=(const InternalType& it);
@@ -106,17 +106,17 @@ public :
     bool                        subMatrixToString(std::wostringstream& ostr, int* _piDims, int _iDims) override;
     String*                     getFieldNames();
     bool                        exists(const std::wstring& _sKey);
-    void addField(const std::wstring& _sKey);
-    void addFieldFront(const std::wstring& _sKey);
-    void removeField(const std::wstring& _sKey);
+    Struct*                     addField(const std::wstring& _sKey);
+    Struct*                     addFieldFront(const std::wstring& _sKey);
+    Struct*                     removeField(const std::wstring& _sKey);
     bool                        toString(std::wostringstream& ostr);
     List*                       extractFieldWithoutClone(const std::wstring& _wstField);
     std::vector<InternalType*>  extractFields(std::vector<std::wstring> _wstFields);
     std::vector<InternalType*>  extractFields(typed_list* _pArgs);
     InternalType *              extractField(const std::wstring& wstField);
 
-    bool resize(int* _piDims, int _iDims);
-    bool resize(int _iNewRows, int _iNewCols);
+    Struct*                     resize(int* _piDims, int _iDims);
+    Struct*                     resize(int _iNewRows, int _iNewCols);
 
     /*specials functions to disable clone operation during copydata*/
     InternalType*               insertWithoutClone(typed_list* _pArgs, InternalType* _pSource);

--- a/scilab/modules/ast/includes/types/tlist.hxx
+++ b/scilab/modules/ast/includes/types/tlist.hxx
@@ -1,8 +1,8 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2010-2010 - DIGITEO - Antoine ELIAS
+ *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ *  Copyright (C) 2010-2010 - DIGITEO - Antoine ELIAS
+ *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -52,11 +52,8 @@ public :
     bool                            exists(const std::wstring& _sKey);
     InternalType*                   getField(const std::wstring& _sKey);
     int                             getIndexFromString(const std::wstring& _sKey);
-    bool set(const std::wstring& _sKey, InternalType* _pIT);
-    bool set(const int _iIndex, InternalType* _pIT);
-
-    TList* setClone(const std::wstring& _sKey, InternalType* _pIT);
-    TList* setClone(const int _iIndex, InternalType* _pIT);
+    TList*                          set(const std::wstring& _sKey, InternalType* _pIT);
+    TList*                          set(const int _iIndex, InternalType* _pIT);
 
     using List::extract; // to avoid this extract to hide extract in list
     bool                            extract(const std::wstring& name, InternalType *& out);

--- a/scilab/modules/ast/includes/types/types.hxx
+++ b/scilab/modules/ast/includes/types/types.hxx
@@ -133,24 +133,24 @@ public :
         return NULL;
     }
 
-    virtual bool resize(int* /*_piDims*/, int /*_iDims*/)
+    virtual GenericType*        resize(int* /*_piDims*/, int /*_iDims*/)
     {
-        return false;
+        return NULL;
     }
 
-    virtual bool resize(int /*_iNewRows*/, int /*_iNewCols*/)
+    virtual GenericType*        resize(int /*_iNewRows*/, int /*_iNewCols*/)
     {
-        return false;
+        return NULL;
     }
 
-    virtual bool reshape(int* /*_piDims*/, int /*_iDims*/)
+    virtual GenericType*        reshape(int* /*_piDims*/, int /*_iDims*/)
     {
-        return false;
+        return NULL;
     }
 
-    virtual bool reshape(int /*_iNewRows*/, int /*_iNewCols*/)
+    virtual GenericType*        reshape(int /*_iNewRows*/, int /*_iNewCols*/)
     {
-        return false;
+        return NULL;
     }
 
     virtual GenericType*        insert(typed_list* /*_pArgs*/, InternalType* /*_pSource*/)
@@ -178,13 +178,6 @@ public :
         return NULL;
     }
 
-    virtual GenericType* resizeClone(int* /*_piDims*/, int /*_iDims*/);
-
-    virtual GenericType* resizeClone(int _iNewRows, int _iNewCols)
-    {
-        int piDims[2] = {_iNewRows, _iNewCols};
-        return resizeClone(piDims, 2);
-    }
 };
 
 }

--- a/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
+++ b/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
@@ -993,15 +993,14 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                     }
 
                     // resize current struct
-                    pStruct = pStruct->resizeClone(pEH->getArgsDimsArray(), pEH->getArgsDims())->getAs<types::Struct>();;
+                    pStruct = pStruct->resize(pEH->getArgsDimsArray(), pEH->getArgsDims());
                     pEH->setCurrent(pStruct);
                 }
 
                 // create field in parent if it not exist
                 if (pStruct->exists(pwcsFieldname) == false)
                 {
-                    pStruct = pStruct->copyAs<types::Struct>();
-                    pStruct->addField(pwcsFieldname);
+                    pStruct = pStruct->addField(pwcsFieldname);
                     pEH->setCurrent(pStruct);
                 }
 
@@ -1100,7 +1099,7 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         int iNewSize = pEH->getSizeFromArgs();
                         if (pTL->getSize() < iNewSize)
                         {
-                            pTL = pTL->setClone(iNewSize - 1, new types::ListUndefined());
+                            pTL = pTL->set(iNewSize - 1, new types::ListUndefined());
                             pEH->setCurrent(pTL);
                         }
 
@@ -1256,7 +1255,7 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                             int iNewSize = pEH->getSizeFromArgs();
                             if (pL->getSize() < iNewSize)
                             {
-                                pL= pL->setClone(iNewSize - 1, new types::ListUndefined());
+                                pL = pL->set(iNewSize - 1, new types::ListUndefined());
                                 pEH->setCurrent(pL);
                             }
 
@@ -1443,7 +1442,7 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                                 }
 
                                 // resize current Cell
-                                pCell = pCell->resizeClone(pEH->getArgsDimsArray(), pEH->getArgsDims())->getAs<types::Cell>();
+                                pCell = pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims());
                                 pEH->setCurrent(pCell);
                             }
 
@@ -1469,8 +1468,8 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                                 }
 
                                 // resize current Cell
-                                pCell = pCell->resizeClone(pEH->getArgsDimsArray(), pEH->getArgsDims())->getAs<types::Cell>();
-                                pEH->setCurrent(pCell->getAs<types::Cell>());
+                                pCell = pCell->resize(pEH->getArgsDimsArray(), pEH->getArgsDims())->getAs<types::Cell>();
+                                pEH->setCurrent(pCell);
                             }
 
                             types::InternalType* pIT = pCell->extract(pEH->getArgs());
@@ -1714,7 +1713,7 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         types::TList* pTL = pParent->getAs<types::TList>();
                         if (pParentArgs)
                         {
-                            pTL = pTL->setClone(pEH->getWhereReinsert(), pEH->getCurrent());
+                            pTL = pTL->set(pEH->getWhereReinsert(), pEH->getCurrent());
                             pEHParent->setCurrent(pTL);
                             evalFields.pop_back();
                             delete pEH;
@@ -1722,10 +1721,9 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                         }
                         else
                         {
-                            // FIXME: use local var for pEH->getExpAsString() ?
                             if (pTL->exists(pEH->getExpAsString()))
                             {
-                                pTL = pTL->setClone(pEH->getExpAsString(), pEH->getCurrent());
+                                pTL = pTL->set(pEH->getExpAsString(), pEH->getCurrent());
                                 pEHParent->setCurrent(pTL);
                                 evalFields.pop_back();
                                 delete pEH;
@@ -2064,15 +2062,13 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
                 if (_pInsert->isListDelete())
                 {
                     /* Remove a field */
-                    pStruct = pStruct->copyAs<types::Struct>();
-                    pStruct->removeField(pS->get(0));
+                    pStruct = pStruct->removeField(pS->get(0));
                 }
                 else
                 {
                     /* Add a field */
                     int size = pStruct->getSize();
-                    pStruct = pStruct->copyAs<types::Struct>();
-                    pStruct->addField(pS->get(0));
+                    pStruct = pStruct->addField(pS->get(0));
                     for (int i = 0; i < size; i++)
                     {
                         pStruct->get(i)->set(pS->get(0), _pInsert);
@@ -2181,7 +2177,7 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
 
                     if (pTL->exists(pS->get(0)))
                     {
-                        pRet = pTL->setClone(pS->get(0), _pInsert)->getAs<types::InternalType>();
+                        pRet = pTL->set(pS->get(0), _pInsert);
                     }
                     else
                     {

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -89,7 +89,7 @@ ArrayOf<T>* ArrayOf<T>::insert(typed_list* _pArgs, InternalType* _pSource)
             }
             else
             {
-                if (set(index, *pRealData) == true)
+                if (set(index, *pRealData) != NULL)
                 {
                     return this;
                 }
@@ -142,7 +142,7 @@ ArrayOf<T>* ArrayOf<T>::insert(typed_list* _pArgs, InternalType* _pSource)
                 {
                     for (int i : indexes)
                     {
-                        if (set(i, *pRealData) == false)
+                        if (set(i, *pRealData) == NULL)
                         {
                             status = false;
                             break;
@@ -170,7 +170,7 @@ ArrayOf<T>* ArrayOf<T>::insert(typed_list* _pArgs, InternalType* _pSource)
                 {
                     for (int i : indexes)
                     {
-                        if (set(i, *pRealData) == false)
+                        if (set(i, *pRealData) == NULL)
                         {
                             status = false;
                             break;
@@ -338,8 +338,8 @@ ArrayOf<T>* ArrayOf<T>::insert(typed_list* _pArgs, InternalType* _pSource)
     //before resize, check input dimension
     if (bNeedToResize)
     {
-        // FIXME: do we actually perform a resize here?
-        if (resize(piNewDims, iNewDims) == false)
+        ArrayOf<T>* pTemp = resize(piNewDims, iNewDims);
+        if (pTemp == NULL)
         {
             delete[] piCountDim;
             delete[] piMaxDim;
@@ -729,8 +729,14 @@ GenericType* ArrayOf<T>::insertNew(typed_list* _pArgs)
 }
 
 template <typename T>
-bool ArrayOf<T>::append(int _iRows, int _iCols, InternalType* _poSource)
+ArrayOf<T>* ArrayOf<T>::append(int _iRows, int _iCols, InternalType* _poSource)
 {
+    ArrayOf<T>* pIT = checkRef(this, &ArrayOf::append, _iRows, _iCols, _poSource);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     ArrayOf * pGT = _poSource->getAs<ArrayOf>();
     int iRows = pGT->getRows();
     int iCols = pGT->getCols();
@@ -738,7 +744,7 @@ bool ArrayOf<T>::append(int _iRows, int _iCols, InternalType* _poSource)
     //insert without resize
     if (iRows + _iRows > m_iRows || iCols + _iCols > m_iCols)
     {
-        return false;
+        return NULL;
     }
 
     //Update complexity if necessary
@@ -776,7 +782,7 @@ bool ArrayOf<T>::append(int _iRows, int _iCols, InternalType* _poSource)
         }
     }
 
-    return true;
+    return this;
 }
 
 template <typename T>
@@ -1376,12 +1382,19 @@ GenericType* ArrayOf<T>::extract(typed_list* _pArgs)
 }
 
 template <typename T>
-bool ArrayOf<T>::reshape(int* _piDims, int _iDims)
+ArrayOf<T>* ArrayOf<T>::reshape(int* _piDims, int _iDims)
 {
+    typedef ArrayOf<T>* (ArrayOf<T>::*reshape_t)(int*, int);
+    ArrayOf<T>* pIT = checkRef(this, (reshape_t)&ArrayOf<T>::reshape, _piDims, _iDims);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     int iNewSize = get_max_size(_piDims, _iDims);
     if (iNewSize != m_iSize)
     {
-        return false;
+        return NULL;
     }
 
     for (int i = 0 ; i < _iDims ; i++)
@@ -1409,16 +1422,23 @@ bool ArrayOf<T>::reshape(int* _piDims, int _iDims)
     m_iSize = iNewSize;
     m_iDims = _iDims;
 
-    return true;
+    return this;
 }
 
 template <typename T>
-bool ArrayOf<T>::resize(int* _piDims, int _iDims)
+ArrayOf<T>* ArrayOf<T>::resize(int* _piDims, int _iDims)
 {
+    typedef ArrayOf<T>* (ArrayOf<T>::*resize_t)(int*, int);
+    ArrayOf<T>* pIT = checkRef(this, (resize_t)&ArrayOf::resize, _piDims, _iDims);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     if (_iDims == m_iDims && memcmp(m_piDims, _piDims, sizeof(int) * m_iDims) == 0)
     {
         //nothing to do
-        return true;
+        return this;
     }
 
     //alloc new data array
@@ -1646,7 +1666,7 @@ bool ArrayOf<T>::resize(int* _piDims, int _iDims)
     m_iRows = m_piDims[0];
     m_iCols = m_piDims[1];
     m_iSize = iNewSize;
-    return true;
+    return this;
 }
 
 template <typename T>

--- a/scilab/modules/ast/src/cpp/types/bool.cpp
+++ b/scilab/modules/ast/src/cpp/types/bool.cpp
@@ -91,22 +91,38 @@ void Bool::whoAmI()
     std::cout << "types::Bool";
 }
 
-void Bool::setFalse()
+Bool* Bool::setFalse()
 {
+    Bool* pb = checkRef(this, &Bool::setFalse);
+    if (pb != this)
+    {
+        return pb;
+    }
+
     int size = getSize();
     for (int i = 0 ; i < size ; i++)
     {
         m_pRealData[i] = 0;
     }
+
+    return this;
 }
 
-void Bool::setTrue()
+Bool* Bool::setTrue()
 {
+    Bool* pb = checkRef(this, &Bool::setTrue);
+    if (pb != this)
+    {
+        return pb;
+    }
+
     int size = getSize();
     for (int i = 0; i < size; i++)
     {
         m_pRealData[i] = 1;
     }
+
+    return this;
 }
 
 bool Bool::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_iDims*/)

--- a/scilab/modules/ast/src/cpp/types/cell.cpp
+++ b/scilab/modules/ast/src/cpp/types/cell.cpp
@@ -139,35 +139,42 @@ bool Cell::transpose(InternalType *& out)
     return false;
 }
 
-bool Cell::set(int _iRows, int _iCols, InternalType* _pIT)
+Cell* Cell::set(int _iRows, int _iCols, InternalType* _pIT)
 {
     if (_iRows < getRows() && _iCols < getCols())
     {
         return set(_iCols * getRows() + _iRows, _pIT);
     }
-    return false;
+    return NULL;
 }
 
-bool Cell::set(int _iRows, int _iCols, const InternalType* _pIT)
+Cell* Cell::set(int _iRows, int _iCols, const InternalType* _pIT)
 {
     if (_iRows < getRows() && _iCols < getCols())
     {
         return set(_iCols * getRows() + _iRows, _pIT);
     }
-    return false;
+    return NULL;
 }
 
-bool Cell::set(int _iIndex, InternalType* _pIT)
+Cell* Cell::set(int _iIndex, InternalType* _pIT)
 {
     if (_iIndex >= m_iSize)
     {
-        return false;
+        return NULL;
     }
 
     // corner case when inserting twice
     if (m_pRealData[_iIndex] == _pIT)
     {
-        return true;
+        return this;
+    }
+
+    typedef Cell* (Cell::*set_t)(int, InternalType*);
+    Cell* pIT = checkRef(this, (set_t)&Cell::set, _iIndex, _pIT);
+    if (pIT != this)
+    {
+        return pIT;
     }
 
     if (m_pRealData[_iIndex] != NULL)
@@ -178,14 +185,21 @@ bool Cell::set(int _iIndex, InternalType* _pIT)
 
     _pIT->IncreaseRef();
     m_pRealData[_iIndex] = _pIT;
-    return true;
+    return this;
 }
 
-bool Cell::set(int _iIndex, const InternalType* _pIT)
+Cell* Cell::set(int _iIndex, const InternalType* _pIT)
 {
     if (_iIndex >= m_iSize)
     {
-        return false;
+        return NULL;
+    }
+
+    typedef Cell* (Cell::*set_t)(int, const InternalType*);
+    Cell* pIT = checkRef(this, (set_t)&Cell::set, _iIndex, _pIT);
+    if (pIT != this)
+    {
+        return pIT;
     }
 
     if (m_pRealData[_iIndex] != NULL)
@@ -197,16 +211,23 @@ bool Cell::set(int _iIndex, const InternalType* _pIT)
     const_cast<InternalType*>(_pIT)->IncreaseRef();
     m_pRealData[_iIndex] = const_cast<InternalType*>(_pIT);
 
-    return true;
+    return this;
 }
 
-bool Cell::set(InternalType** _pIT)
+Cell* Cell::set(InternalType** _pIT)
 {
+    typedef Cell* (Cell::*set_t)(InternalType**);
+    Cell* pIT = checkRef(this, (set_t)&Cell::set, _pIT);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     for (int i = 0; i < m_iSize; i++)
     {
         if (i >= m_iSize)
         {
-            return false;
+            return NULL;
         }
 
         if (m_pRealData[i] != NULL)
@@ -219,7 +240,7 @@ bool Cell::set(InternalType** _pIT)
         m_pRealData[i] = _pIT[i];
     }
 
-    return true;
+    return this;
 }
 
 /**

--- a/scilab/modules/ast/src/cpp/types/double.cpp
+++ b/scilab/modules/ast/src/cpp/types/double.cpp
@@ -906,8 +906,14 @@ double* Double::allocData(int _iSize)
     }
 }
 
-bool Double::append(int _iRows, int _iCols, InternalType* _poSource)
+Double* Double::append(int _iRows, int _iCols, InternalType* _poSource)
 {
+    Double* pIT = checkRef(this, &Double::append, _iRows, _iCols, _poSource);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     Double* pD = _poSource->getAs<Double>();
     int iRows = pD->getRows();
     int iCols = pD->getCols();
@@ -916,7 +922,7 @@ bool Double::append(int _iRows, int _iCols, InternalType* _poSource)
     //insert without resize
     if (iRows + _iRows > m_iRows || iCols + _iCols > m_iCols)
     {
-        return false;
+        return NULL;
     }
 
     //Update complexity if necessary
@@ -1048,7 +1054,7 @@ bool Double::append(int _iRows, int _iCols, InternalType* _poSource)
             }
         }
     }
-    return true;
+    return this;
 }
 
 void Double::convertToInteger()

--- a/scilab/modules/ast/src/cpp/types/list.cpp
+++ b/scilab/modules/ast/src/cpp/types/list.cpp
@@ -1,6 +1,7 @@
 /*
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
+ *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
  * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
@@ -99,12 +100,18 @@ int List::getSize() const
 ** append(InternalType *_typedValue)
 ** Append the given value to the end of the List
 */
-bool List::append(InternalType *_typedValue)
+List* List::append(InternalType *_typedValue)
 {
+    List* pIT = checkRef(this, &List::append, _typedValue);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     _typedValue->IncreaseRef();
     m_plData->push_back(_typedValue);
     m_iSize = static_cast<int>(m_plData->size());
-    return true;
+    return this;
 }
 
 /**
@@ -331,11 +338,17 @@ InternalType* List::get(const int _iIndex)
     return NULL;
 }
 
-bool List::set(const int _iIndex, InternalType* _pIT)
+List* List::set(const int _iIndex, InternalType* _pIT)
 {
     if (_iIndex < 0)
     {
-        return false;
+        return NULL;
+    }
+
+    List* pIT = checkRef(this, &List::set, _iIndex, _pIT);
+    if (pIT != this)
+    {
+        return pIT;
     }
 
     while ((int)m_plData->size() < _iIndex)
@@ -367,7 +380,7 @@ bool List::set(const int _iIndex, InternalType* _pIT)
         }
     }
 
-    return true;
+    return this;
 }
 
 bool List::operator==(const InternalType& it)
@@ -393,24 +406,6 @@ bool List::operator==(const InternalType& it)
     }
 
     return true;
-}
-
-List* List::setClone(const int _iIndex, InternalType* _pIT)
-{
-    if (getRef() > 1)
-    {
-        List* pClone = clone();
-
-        if (pClone->set(_iIndex, _pIT) == false)
-        {
-            pClone->killMe();
-            return NULL;
-        }
-
-        return pClone;
-    }
-
-    return set(_iIndex, _pIT) ? this : NULL;
 }
 
 }

--- a/scilab/modules/ast/src/cpp/types/polynom.cpp
+++ b/scilab/modules/ast/src/cpp/types/polynom.cpp
@@ -82,14 +82,21 @@ void Polynom::createPoly(const std::wstring& _szVarName, int _iDims, const int* 
 #endif
 }
 
-bool Polynom::set(int _iPos, SinglePoly* _pS)
+Polynom* Polynom::set(int _iPos, SinglePoly* _pS)
 {
     if (m_pRealData == NULL || _iPos >= m_iSize)
     {
-        return false;
+        return NULL;
     }
 
-    if (m_pRealData[_iPos]) // FIXME: is this check needed ?
+    typedef Polynom* (Polynom::*set_t)(int, SinglePoly*);
+    Polynom* pIT = checkRef(this, (set_t)&Polynom::set, _iPos, _pS);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
+    if (m_pRealData[_iPos])
     {
         delete m_pRealData[_iPos];
     }
@@ -106,43 +113,57 @@ bool Polynom::set(int _iPos, SinglePoly* _pS)
         m_pRealData[_iPos]->setComplex(true);
     }
 
-    return true;
+    return this;
 }
 
-bool Polynom::set(int _iRows, int _iCols, SinglePoly* _pS)
+Polynom* Polynom::set(int _iRows, int _iCols, SinglePoly* _pS)
 {
     return set(_iCols * getRows() + _iRows, _pS);
 }
 
-bool Polynom::set(SinglePoly** _pS)
+Polynom* Polynom::set(SinglePoly** _pS)
 {
+    typedef Polynom* (Polynom::*set_t)(SinglePoly**);
+    Polynom* pIT = checkRef(this, (set_t)&Polynom::set, _pS);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     for (int i = 0 ; i < m_iSize ; i++)
     {
         set(i, _pS[i]);
     }
 
-    return true;
+    return this;
 }
 
-bool Polynom::setCoef(int _iRows, int _iCols, Double *_pdblCoef)
+Polynom* Polynom::setCoef(int _iRows, int _iCols, Double *_pdblCoef)
 {
     int piDims[] = {_iRows, _iCols};
     int iPos = getIndex(piDims);
     return setCoef(iPos, _pdblCoef);
 }
 
-bool Polynom::setCoef(int _iIdx, Double *_pdblCoef)
+Polynom* Polynom::setCoef(int _iIdx, Double *_pdblCoef)
 {
     if (_iIdx > m_iSize)
     {
-        return false;
+        return NULL;
+    }
+
+    typedef Polynom* (Polynom::*setCoef_t)(int, Double*);
+    Polynom* pIT = checkRef(this, (setCoef_t)&Polynom::setCoef, _iIdx, _pdblCoef);
+    if (pIT != this)
+    {
+        return pIT;
     }
 
     /*Get old SinglePoly*/
     m_pRealData[_iIdx]->setRank(_pdblCoef->getSize() - 1);
     m_pRealData[_iIdx]->setCoef(_pdblCoef);
 
-    return true;
+    return this;
 }
 
 void Polynom::setZeros()
@@ -208,15 +229,26 @@ bool Polynom::isComplex()
     return false;
 }
 
-void Polynom::setComplex(bool _bComplex)
+Polynom* Polynom::setComplex(bool _bComplex)
 {
-    if (isComplex() != _bComplex)
+    if (_bComplex == isComplex())
     {
-        for (int i = 0 ; i < getSize() ; i++)
-        {
-            get(i)->setComplex(_bComplex);
-        }
+        return this;
     }
+
+    typedef Polynom* (Polynom::*setcplx_t)(bool);
+    Polynom* pIT = checkRef(this, (setcplx_t)&Polynom::setComplex, _bComplex);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
+    for (int i = 0 ; i < getSize() ; i++)
+    {
+        get(i)->setComplex(_bComplex);
+    }
+
+    return this;
 }
 
 Polynom* Polynom::clone()
@@ -383,8 +415,15 @@ Double* Polynom::getCoef(void)
     return pCoef;
 }
 
-bool Polynom::setCoef(Double *_pCoef)
+Polynom* Polynom::setCoef(Double *_pCoef)
 {
+    typedef Polynom* (Polynom::*setCoef_t)(Double*);
+    Polynom* pIT = checkRef(this, (setCoef_t)&Polynom::setCoef, _pCoef);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     setComplex(_pCoef->isComplex());
     double *pR = _pCoef->getReal();
 
@@ -420,7 +459,7 @@ bool Polynom::setCoef(Double *_pCoef)
         }
     }
 
-    return true;
+    return this;
 }
 
 bool Polynom::subMatrixToString(std::wostringstream& ostr, int* _piDims, int _iDims)

--- a/scilab/modules/ast/src/cpp/types/sparse.cpp
+++ b/scilab/modules/ast/src/cpp/types/sparse.cpp
@@ -614,11 +614,18 @@ void Sparse::fill(Double& dest, int r, int c) SPARSE_CONST
     }
 }
 
-bool Sparse::set(int _iRows, int _iCols, std::complex<double> v, bool _bFinalize)
+Sparse* Sparse::set(int _iRows, int _iCols, std::complex<double> v, bool _bFinalize)
 {
     if (_iRows >= getRows() || _iCols >= getCols())
     {
-        return false;
+        return NULL;
+    }
+
+    typedef Sparse* (Sparse::*set_t)(int, int, std::complex<double>, bool);
+    Sparse* pIT = checkRef(this, (set_t)&Sparse::set, _iRows, _iCols, v, _bFinalize);
+    if (pIT != this)
+    {
+        return pIT;
     }
 
     if (matrixReal)
@@ -644,14 +651,21 @@ bool Sparse::set(int _iRows, int _iCols, std::complex<double> v, bool _bFinalize
     {
         finalize();
     }
-    return true;
+    return this;
 }
 
-bool Sparse::set(int _iRows, int _iCols, double _dblReal, bool _bFinalize)
+Sparse* Sparse::set(int _iRows, int _iCols, double _dblReal, bool _bFinalize)
 {
     if (_iRows >= getRows() || _iCols >= getCols())
     {
-        return false;
+        return NULL;
+    }
+
+    typedef Sparse* (Sparse::*set_t)(int, int, double, bool);
+    Sparse* pIT = checkRef(this, (set_t)&Sparse::set, _iRows, _iCols, _dblReal, _bFinalize);
+    if (pIT != this)
+    {
+        return pIT;
     }
 
     if (matrixReal)
@@ -679,7 +693,7 @@ bool Sparse::set(int _iRows, int _iCols, double _dblReal, bool _bFinalize)
         finalize();
     }
 
-    return true;
+    return this;
 }
 
 void Sparse::finalize()
@@ -809,12 +823,19 @@ bool Sparse::toString(std::wostringstream& ostr)
     return true;
 }
 
-bool Sparse::resize(int _iNewRows, int _iNewCols)
+Sparse* Sparse::resize(int _iNewRows, int _iNewCols)
 {
+    typedef Sparse* (Sparse::*resize_t)(int, int);
+    Sparse* pIT = checkRef(this, (resize_t)&Sparse::resize, _iNewRows, _iNewCols);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     if (_iNewRows <= getRows() && _iNewCols <= getCols())
     {
         //nothing to do: hence we do NOT fail
-        return true;
+        return this;
     }
 
     Sparse* res = NULL;
@@ -897,7 +918,7 @@ bool Sparse::resize(int _iNewRows, int _iNewCols)
     {
         res = NULL;
     }
-    return (bool)res;
+    return res;
 }
 // TODO decide if a complex matrix with 0 imag can be == to a real matrix
 // not true for dense (cf double.cpp)
@@ -1174,7 +1195,7 @@ Sparse* Sparse::insert(typed_list* _pArgs, InternalType* _pSource)
     //now you are sure to be able to insert values
     if (bNeedToResize)
     {
-        if (resize(iNewRows, iNewCols) == false)
+        if (resize(iNewRows, iNewCols) == NULL)
         {
             //free pArg content
             cleanIndexesArguments(_pArgs, &pArg);
@@ -1597,7 +1618,7 @@ Sparse* Sparse::insert(typed_list* _pArgs, Sparse* _pSource)
     //now you are sure to be able to insert values
     if (bNeedToResize)
     {
-        if (resize(iNewRows, iNewCols) == false)
+        if (resize(iNewRows, iNewCols) == NULL)
         {
             //free pArg content
             cleanIndexesArguments(_pArgs, &pArg);
@@ -1911,8 +1932,14 @@ GenericType* Sparse::remove(typed_list* _pArgs)
     return pOut;
 }
 
-bool Sparse::append(int r, int c, types::Sparse SPARSE_CONST* src)
+Sparse* Sparse::append(int r, int c, types::Sparse SPARSE_CONST* src)
 {
+    Sparse* pIT = checkRef(this, &Sparse::append, r, c, src);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     //        std::wcerr << L"to a sparse of size"<<getRows() << L","<<getCols() << L" should append @"<<r << L","<<c<< "a sparse:"<< src->toString(32,80)<<std::endl;
     if (src->isComplex())
     {
@@ -1936,7 +1963,7 @@ bool Sparse::append(int r, int c, types::Sparse SPARSE_CONST* src)
 
     finalize();
 
-    return true; // realloc is meaningless for sparse matrices
+    return this; // realloc is meaningless for sparse matrices
 }
 
 /*
@@ -2958,8 +2985,9 @@ SparseBool* Sparse::newEqualTo(Sparse &o)
     return ret;
 }
 
-bool Sparse::reshape(int* _piDims, int _iDims)
+Sparse* Sparse::reshape(int* _piDims, int _iDims)
 {
+    Sparse* pSp = NULL;
     int iCols = 1;
 
     if (_iDims == 2)
@@ -2969,17 +2997,24 @@ bool Sparse::reshape(int* _piDims, int _iDims)
 
     if (_iDims <= 2)
     {
-        return reshape(_piDims[0], iCols);
+        pSp = reshape(_piDims[0], iCols);
     }
 
-    return false;
+    return pSp;
 }
 
-bool Sparse::reshape(int _iNewRows, int _iNewCols)
+Sparse* Sparse::reshape(int _iNewRows, int _iNewCols)
 {
+    typedef Sparse* (Sparse::*reshape_t)(int, int);
+    Sparse* pIT = checkRef(this, (reshape_t)&Sparse::reshape, _iNewRows, _iNewCols);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     if (_iNewRows * _iNewCols != getRows() * getCols())
     {
-        return false;
+        return NULL;
     }
 
     Sparse* res = NULL;
@@ -3067,7 +3102,7 @@ bool Sparse::reshape(int _iNewRows, int _iNewCols)
     {
         res = NULL;
     }
-    return (bool)res;
+    return res;
 }
 
 //    SparseBool* SparseBool::new
@@ -3237,12 +3272,19 @@ SparseBool* SparseBool::clone(void)
     return new SparseBool(*this);
 }
 
-bool SparseBool::resize(int _iNewRows, int _iNewCols)
+SparseBool* SparseBool::resize(int _iNewRows, int _iNewCols)
 {
+    typedef SparseBool* (SparseBool::*resize_t)(int, int);
+    SparseBool* pIT = checkRef(this, (resize_t)&SparseBool::resize, _iNewRows, _iNewCols);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     if (_iNewRows <= getRows() && _iNewCols <= getCols())
     {
         //nothing to do: hence we do NOT fail
-        return true;
+        return this;
     }
 
     SparseBool* res = NULL;
@@ -3284,7 +3326,7 @@ bool SparseBool::resize(int _iNewRows, int _iNewCols)
     {
         res = NULL;
     }
-    return (bool)res;
+    return res;
 }
 
 SparseBool* SparseBool::insert(typed_list* _pArgs, SparseBool* _pSource)
@@ -3369,7 +3411,7 @@ SparseBool* SparseBool::insert(typed_list* _pArgs, SparseBool* _pSource)
     //now you are sure to be able to insert values
     if (bNeedToResize)
     {
-        if (resize(iNewRows, iNewCols) == false)
+        if (resize(iNewRows, iNewCols) == NULL)
         {
             //free pArg content
             cleanIndexesArguments(_pArgs, &pArg);
@@ -3520,7 +3562,7 @@ SparseBool* SparseBool::insert(typed_list* _pArgs, InternalType* _pSource)
     //now you are sure to be able to insert values
     if (bNeedToResize)
     {
-        if (resize(iNewRows, iNewCols) == false)
+        if (resize(iNewRows, iNewCols) == NULL)
         {
             //free pArg content
             cleanIndexesArguments(_pArgs, &pArg);
@@ -3798,11 +3840,17 @@ GenericType* SparseBool::remove(typed_list* _pArgs)
     return pOut;
 }
 
-bool SparseBool::append(int r, int c, SparseBool SPARSE_CONST* src)
+SparseBool* SparseBool::append(int r, int c, SparseBool SPARSE_CONST* src)
 {
+    SparseBool* pIT = checkRef(this, &SparseBool::append, r, c, src);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     doAppend(*src, r, c, *matrixBool);
     finalize();
-    return true;
+    return this;
 }
 
 GenericType* SparseBool::insertNew(typed_list* _pArgs)
@@ -4254,8 +4302,15 @@ bool SparseBool::get(int r, int c) SPARSE_CONST
     return matrixBool->coeff(r, c);
 }
 
-bool SparseBool::set(int _iRows, int _iCols, bool _bVal, bool _bFinalize) SPARSE_CONST
+SparseBool* SparseBool::set(int _iRows, int _iCols, bool _bVal, bool _bFinalize) SPARSE_CONST
 {
+    typedef SparseBool* (SparseBool::*set_t)(int, int, bool, bool);
+    SparseBool* pIT = checkRef(this, (set_t)&SparseBool::set, _iRows, _iCols, _bVal, _bFinalize);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     if (matrixBool->isCompressed() && matrixBool->coeff(_iRows, _iCols) == false)
     {
         matrixBool->reserve(1);
@@ -4268,7 +4323,7 @@ bool SparseBool::set(int _iRows, int _iCols, bool _bVal, bool _bFinalize) SPARSE
         finalize();
     }
 
-    return true;
+    return this;
 }
 
 void SparseBool::fill(Bool& dest, int r, int c) SPARSE_CONST
@@ -4375,8 +4430,9 @@ SparseBool* SparseBool::newLogicalAnd(SparseBool const&o) const
     return cwiseOp<std::logical_and>(*this, o);
 }
 
-bool SparseBool::reshape(int* _piDims, int _iDims)
+SparseBool* SparseBool::reshape(int* _piDims, int _iDims)
 {
+    SparseBool* pSpBool = NULL;
     int iCols = 1;
 
     if (_iDims == 2)
@@ -4386,17 +4442,24 @@ bool SparseBool::reshape(int* _piDims, int _iDims)
 
     if (_iDims <= 2)
     {
-        return reshape(_piDims[0], iCols);
+        pSpBool = reshape(_piDims[0], iCols);
     }
 
-    return false;
+    return pSpBool;
 }
 
-bool SparseBool::reshape(int _iNewRows, int _iNewCols)
+SparseBool* SparseBool::reshape(int _iNewRows, int _iNewCols)
 {
+    typedef SparseBool* (SparseBool::*reshape_t)(int, int);
+    SparseBool* pIT = checkRef(this, (reshape_t)&SparseBool::reshape, _iNewRows, _iNewCols);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     if (_iNewRows * _iNewCols != getRows() * getCols())
     {
-        return false;
+        return NULL;
     }
 
     SparseBool* res = NULL;
@@ -4442,7 +4505,7 @@ bool SparseBool::reshape(int _iNewRows, int _iNewCols)
     {
         res = NULL;
     }
-    return (bool)res;
+    return res;
 }
 
 bool SparseBool::transpose(InternalType *& out)

--- a/scilab/modules/ast/src/cpp/types/string.cpp
+++ b/scilab/modules/ast/src/cpp/types/string.cpp
@@ -602,39 +602,51 @@ void String::deleteData(wchar_t* data)
     }
 }
 
-void String::set_(int _iPos, const wchar_t* _pwstData)
+String* String::set_(int _iPos, const wchar_t* _pwstData)
 {
     deleteString(_iPos);
     m_pRealData[_iPos] = copyValue(_pwstData);
+    return this;
 }
 
-bool String::set(int _iPos, const wchar_t* _pwstData)
+String* String::set(int _iPos, const wchar_t* _pwstData)
 {
     if (m_pRealData == NULL || _iPos >= m_iSize)
     {
-        return false;
+        return NULL;
     }
 
-    deleteString(_iPos);
-    m_pRealData[_iPos] = copyValue(_pwstData);
-    return true;
+    typedef String* (String::*set_t)(int, const wchar_t*);
+    String* pIT = checkRef(this, (set_t)&String::set_, _iPos, _pwstData);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
+    return set_(_iPos, _pwstData);
 }
 
-void String::set_(int _iRows, int _iCols, const wchar_t* _pwstData)
+String* String::set_(int _iRows, int _iCols, const wchar_t* _pwstData)
 {
-    set_(_iCols * getRows() + _iRows, _pwstData);
+    return set_(_iCols * getRows() + _iRows, _pwstData);
 }
 
-bool String::set(int _iRows, int _iCols, const wchar_t* _pwstData)
+String* String::set(int _iRows, int _iCols, const wchar_t* _pwstData)
 {
     return set(_iCols * getRows() + _iRows, _pwstData);
 }
 
-bool String::set(const wchar_t* const* _pwstData)
+String* String::set(const wchar_t* const* _pwstData)
 {
+    typedef String* (String::*set_t)(const wchar_t * const*);
+    String* pIT = checkRef(this, (set_t)&String::set, _pwstData);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     int i = m_iSize;
 
-    // FIXME: check m_pRealData more effeciently?
     while (i && m_pRealData)
     {
         --i;
@@ -644,40 +656,47 @@ bool String::set(const wchar_t* const* _pwstData)
 
     if (i)
     {
-        return false;
+        return NULL;
     }
     else
     {
-        return true;
+        return this;
     }
 }
 
-bool String::set(int _iPos, const char* _pcData)
+String* String::set(int _iPos, const char* _pcData)
 {
     wchar_t* w = to_wide_string(_pcData);
-    bool ret = set(_iPos, w);
+    String* ret = set(_iPos, w);
     FREE(w);
     return ret;
 }
 
-bool String::set(int _iRows, int _iCols, const char* _pcData)
+String* String::set(int _iRows, int _iCols, const char* _pcData)
 {
     return set(_iCols * getRows() + _iRows, _pcData);
 }
 
-bool String::set(const char* const* _pstrData)
+String* String::set(const char* const* _pstrData)
 {
+    typedef String* (String::*set_t)(const char * const*);
+    String* pIT = checkRef(this, (set_t)&String::set, _pstrData);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     int i = m_iSize;
 
     while (i-- && set(i, _pstrData[i]));
 
     if (++i) // revert decrement
     {
-        return false;
+        return NULL;
     }
     else
     {
-        return true;
+        return this;
     }
 }
 

--- a/scilab/modules/ast/src/cpp/types/struct.cpp
+++ b/scilab/modules/ast/src/cpp/types/struct.cpp
@@ -203,31 +203,38 @@ bool Struct::invoke(typed_list & in, optional_list & opt, int _iRetCount, typed_
     return ArrayOf<SingleStruct*>::invoke(in, opt, _iRetCount, out, e);
 }
 
-bool Struct::set(int _iRows, int _iCols, SingleStruct* _pIT)
+Struct* Struct::set(int _iRows, int _iCols, SingleStruct* _pIT)
 {
     if (_iRows < getRows() && _iCols < getCols())
     {
         return set(_iCols * getRows() + _iRows, _pIT);
     }
-    return false;
+    return NULL;
 }
 
-bool Struct::set(int _iRows, int _iCols, const SingleStruct* _pIT)
+Struct* Struct::set(int _iRows, int _iCols, const SingleStruct* _pIT)
 {
     if (_iRows < getRows() && _iCols < getCols())
     {
         return set(_iCols * getRows() + _iRows, _pIT);
     }
-    return false;
+    return NULL;
 }
 
-bool Struct::set(int _iIndex, SingleStruct* _pIT)
+Struct* Struct::set(int _iIndex, SingleStruct* _pIT)
 {
+    typedef Struct* (Struct::*set_t)(int, SingleStruct*);
+    Struct* pIT = checkRef(this, (set_t)&Struct::set, _iIndex, _pIT);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     if (_iIndex < getSize())
     {
         if (m_bDisableCloneInCopyValue && m_pRealData[_iIndex] == _pIT)
         {
-            return true;
+            return this;
         }
 
         InternalType* pOld = m_pRealData[_iIndex];
@@ -245,13 +252,20 @@ bool Struct::set(int _iIndex, SingleStruct* _pIT)
             pOld->killMe();
         }
 
-        return true;
+        return this;
     }
-    return false;
+    return NULL;
 }
 
-bool Struct::set(int _iIndex, const SingleStruct* _pIT)
+Struct* Struct::set(int _iIndex, const SingleStruct* _pIT)
 {
+    typedef Struct* (Struct::*set_t)(int, const SingleStruct*);
+    Struct* pIT = checkRef(this, (set_t)&Struct::set, _iIndex, _pIT);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     if (_iIndex < getSize())
     {
         InternalType* pOld = m_pRealData[_iIndex];
@@ -264,21 +278,28 @@ bool Struct::set(int _iIndex, const SingleStruct* _pIT)
             pOld->killMe();
         }
 
-        return true;
+        return this;
     }
-    return false;
+    return NULL;
 }
 
-bool Struct::set(SingleStruct** _pIT)
+Struct* Struct::set(SingleStruct** _pIT)
 {
+    typedef Struct* (Struct::*set_t)(SingleStruct**);
+    Struct* pIT = checkRef(this, (set_t)&Struct::set, _pIT);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     for (int i = 0 ; i < getSize() ; i++)
     {
-        if (set(i, _pIT[i]) == false)
+        if (set(i, _pIT[i]) == NULL)
         {
-            return false;
+            return NULL;
         }
     }
-    return true;
+    return this;
 }
 
 String* Struct::getFieldNames()
@@ -406,8 +427,14 @@ bool Struct::subMatrixToString(std::wostringstream& /*ostr*/, int* /*_piDims*/, 
     return true;
 }
 
-void Struct::addField(const std::wstring& _sKey)
+Struct* Struct::addField(const std::wstring& _sKey)
 {
+    Struct* pIT = checkRef(this, &Struct::addField, _sKey);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     if (getSize() == 0)
     {
         //change dimension to 1x1 and add field
@@ -418,10 +445,18 @@ void Struct::addField(const std::wstring& _sKey)
     {
         get(i)->addField(_sKey);
     }
+
+    return this;
 }
 
-void Struct::addFieldFront(const std::wstring& _sKey)
+Struct* Struct::addFieldFront(const std::wstring& _sKey)
 {
+    Struct* pIT = checkRef(this, &Struct::addFieldFront, _sKey);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     if (getSize() == 0)
     {
         //change dimension to 1x1 and add field
@@ -432,14 +467,24 @@ void Struct::addFieldFront(const std::wstring& _sKey)
     {
         get(i)->addFieldFront(_sKey);
     }
+
+    return this;
 }
 
-void Struct::removeField(const std::wstring& _sKey)
+Struct* Struct::removeField(const std::wstring& _sKey)
 {
+    Struct* pIT = checkRef(this, &Struct::removeField, _sKey);
+    if (pIT != this)
+    {
+        return pIT;
+    }
+
     for (int j = 0; j < getSize(); j++)
     {
         get(j)->removeField(_sKey);
     }
+
+    return this;
 }
 
 bool Struct::toString(std::wostringstream& ostr)
@@ -649,31 +694,40 @@ std::vector<InternalType*> Struct::extractFields(typed_list* _pArgs)
     return ResultList;
 }
 
-bool Struct::resize(int _iNewRows, int _iNewCols)
+Struct* Struct::resize(int _iNewRows, int _iNewCols)
 {
     int piDims[2] = {_iNewRows, _iNewCols};
     return resize(piDims, 2);
 }
 
-bool Struct::resize(int* _piDims, int _iDims)
+Struct* Struct::resize(int* _piDims, int _iDims)
 {
-    m_bDisableCloneInCopyValue = true;
-    ArrayOf<SingleStruct*>::resize(_piDims, _iDims);
-    m_bDisableCloneInCopyValue = false;
-
-    // insert field(s) only in new element(s) of current struct
-    String* pFields = getFieldNames();
-    for (int iterField = 0; iterField < pFields->getSize(); iterField++)
+    typedef Struct* (Struct::*resize_t)(int*, int);
+    Struct* pIT = checkRef(this, (resize_t)&Struct::resize, _piDims, _iDims);
+    if (pIT != this)
     {
-        for (int iterStruct = 0; iterStruct < getSize(); iterStruct++)
-        {
-            get(iterStruct)->addField(pFields->get(iterField));
-        }
+        return pIT;
     }
 
-    pFields->killMe();
+    m_bDisableCloneInCopyValue = true;
+    Struct* pSRes = ArrayOf<SingleStruct*>::resize(_piDims, _iDims)->getAs<Struct>();
+    m_bDisableCloneInCopyValue = false;
+    if (pSRes)
+    {
+        // insert field(s) only in new element(s) of current struct
+        String* pFields = getFieldNames();
+        for (int iterField = 0; iterField < pFields->getSize(); iterField++)
+        {
+            for (int iterStruct = 0; iterStruct < getSize(); iterStruct++)
+            {
+                get(iterStruct)->addField(pFields->get(iterField));
+            }
+        }
 
-    return true;
+        pFields->killMe();
+    }
+
+    return pSRes;
 }
 
 InternalType* Struct::insertWithoutClone(typed_list* _pArgs, InternalType* _pSource)

--- a/scilab/modules/ast/src/cpp/types/tlist.cpp
+++ b/scilab/modules/ast/src/cpp/types/tlist.cpp
@@ -283,24 +283,14 @@ std::wstring TList::getShortTypeStr() const
     return getTypeStr();
 }
 
-bool TList::set(const std::wstring& _sKey, InternalType* _pIT)
+TList* TList::set(const std::wstring& _sKey, InternalType* _pIT)
 {
-    return List::set(getIndexFromString(_sKey), _pIT);
+    return List::set(getIndexFromString(_sKey), _pIT)->getAs<TList>();
 }
 
-bool TList::set(const int _iIndex, InternalType* _pIT)
+TList* TList::set(const int _iIndex, InternalType* _pIT)
 {
-    return List::set(_iIndex, _pIT);
-}
-
-TList* TList::setClone(const std::wstring& _sKey, InternalType* _pIT)
-{
-    return List::setClone(getIndexFromString(_sKey), _pIT)->getAs<types::TList>();
-}
-
-TList* TList::setClone(const int _iIndex, InternalType* _pIT)
-{
-    return List::setClone(_iIndex, _pIT)->getAs<types::TList>();
+    return List::set(_iIndex, _pIT)->getAs<TList>();
 }
 
 String* TList::getFieldNames() const

--- a/scilab/modules/ast/src/cpp/types/types.cpp
+++ b/scilab/modules/ast/src/cpp/types/types.cpp
@@ -66,23 +66,4 @@ int GenericType::getVarMaxDim(int _iCurrentDim, int _iMaxDim)
         return getSize();
     }
 }
-
-GenericType* GenericType::resizeClone(int* _piDims, int _iDims)
-{
-    if (getRef() > 1)
-    {
-        GenericType* pClone = clone();
-
-        if (pClone->resize(_piDims, _iDims) == false)
-        {
-            pClone->killMe();
-            return NULL;
-        }
-
-        return pClone;
-    }
-
-    return resize(_piDims, _iDims) ? this : NULL;
-}
-
 }

--- a/scilab/modules/data_structures/sci_gateway/cpp/sci_setfield.cpp
+++ b/scilab/modules/data_structures/sci_gateway/cpp/sci_setfield.cpp
@@ -1,8 +1,8 @@
 /*
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2013 - Scilab Enterprises - Antoine Elias
+ *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -70,8 +70,9 @@ types::Function::ReturnValue sci_setfield(types::typed_list &in, int _iRetCount,
         }
 
         types::TList* pT = pL->getAs<types::TList>();
+
         std::wstring stField = pS->get(0);
-        types::TList* pRet = pT->setClone(stField, pData);
+        types::TList* pRet = pT->set(stField, pData);
         if (pRet == nullptr)
         {
             Scierror(999, _("%s: Invalid index.\n"), "setfield");

--- a/scilab/modules/mexlib/src/cpp/mexlib.cpp
+++ b/scilab/modules/mexlib/src/cpp/mexlib.cpp
@@ -1,11 +1,11 @@
 /*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2011-2011 - Gsoc 2011 - Iuri SILVIO
- * Copyright (C) 2011-2011 - DIGITEO - Bruno JOFRET
- * Copyright (C) 2011 - DIGITEO - Antoine ELIAS
+ *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ *  Copyright (C) 2011-2011 - Gsoc 2011 - Iuri SILVIO
+ *  Copyright (C) 2011-2011 - DIGITEO - Bruno JOFRET
+ *  Copyright (C) 2011 - DIGITEO - Antoine ELIAS
+ *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Gsoc 2017 - Siddhartha Gairola
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ *  Copyright (C) 2017 - Gsoc 2017 - Siddhartha Gairola
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -63,7 +63,6 @@
 #include "printvisitor.hxx"
 
 #include "types.hxx"
-#include "internal.hxx"
 #include "int.hxx"
 #include "double.hxx"
 #include "bool.hxx"
@@ -1006,9 +1005,9 @@ void mxSetM(mxArray *ptr, int M)
         return;
     }
 
-    types::GenericType* pGT = pIT->getAs<types::GenericType>();
-    types::InternalType* res = pGT->resizeClone(M, pGT->getCols());
+    types::GenericType *pGT = pIT->getAs<types::GenericType>();
 
+    types::InternalType* res = pGT->resize(M, pGT->getCols());
     ptr->ptr = (int*)res;
 }
 
@@ -1032,9 +1031,9 @@ void mxSetN(mxArray *ptr, int N)
         return;
     }
 
-    types::GenericType* pGT = pIT->getAs<types::GenericType>();
-    types::InternalType* res = pGT->resizeClone(pGT->getRows(), N);
+    types::GenericType * pGT = pIT->getAs<types::GenericType>();
 
+    types::InternalType* res = pGT->resize(pGT->getRows(), N);
     ptr->ptr = (int*)res;
 }
 
@@ -1567,9 +1566,7 @@ int mxAddField(mxArray *ptr, const char *fieldname)
 
     types::Struct *pa = (types::Struct*)ptr->ptr;
     wchar_t *wfieldname = to_wide_string(fieldname);
-    pa = pa->copyAs<types::Struct>();
-    pa->addField(wfieldname);
-    ptr->ptr = (int*)pa;
+    ptr->ptr = (int*)pa->addField(wfieldname);
     FREE(wfieldname);
     return mxGetFieldNumber(ptr, fieldname);
 }


### PR DESCRIPTION
This PR was too ambitious :-( Almost everything worked, but the given design and implementation of reference counting, cloning ... is a little mess ... tangled, intransparent and inefficient.

So we prefer to go back one step, rather than spending too much time on something that should be completely redesigned from scratch.

Nonetheless, this attempt showed, that an overall performance gain of 3-5% or even more is feasible, just by getting rid of some of the prevailing redundancy in the `checkRef` stuff.
