### PR TITLE
Removed checkRef from setComplex

### DIFF
--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -217,13 +217,6 @@ public :
 
     virtual ArrayOf<T>* setComplex(bool _bComplex)
     {
-        typedef ArrayOf<T>* (ArrayOf<T>::*setcplx_t)(bool);
-        ArrayOf<T>* pIT = checkRef(this, (setcplx_t)&ArrayOf<T>::setComplex, _bComplex);
-        if (pIT != this)
-        {
-            return pIT;
-        }
-
         if (_bComplex == false)
         {
             if (m_pImgData != NULL)

--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -215,7 +215,7 @@ public :
         deleteData(tNullVal);
     }
 
-    virtual ArrayOf<T>* setComplex(bool _bComplex)
+    virtual void setComplex(bool _bComplex)
     {
         if (_bComplex == false)
         {
@@ -232,8 +232,6 @@ public :
                 memset(m_pImgData, 0x00, sizeof(T) * m_iSize);
             }
         }
-
-        return this;
     }
 
     virtual ArrayOf<T>* set(int _iPos, const T _data)

--- a/scilab/modules/ast/includes/types/polynom.hxx
+++ b/scilab/modules/ast/includes/types/polynom.hxx
@@ -1,8 +1,8 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 // This code is separated in matrixpoly.hxx
 // but will be inlined in arrayof.hxx
@@ -53,7 +53,7 @@ public :
     Polynom*                setCoef(int _iRows, int _iCols, Double *_pdblCoef);
     Polynom*                setCoef(int _iIdx, Double *_pdblCoef);
 
-    virtual Polynom*        setComplex(bool _bComplex);
+    virtual void setComplex(bool _bComplex);
 
     inline ScilabType       getType(void)
     {

--- a/scilab/modules/ast/src/cpp/types/polynom.cpp
+++ b/scilab/modules/ast/src/cpp/types/polynom.cpp
@@ -229,19 +229,15 @@ bool Polynom::isComplex()
     return false;
 }
 
-Polynom* Polynom::setComplex(bool _bComplex)
+void Polynom::setComplex(bool _bComplex)
 {
-    if (_bComplex == isComplex())
+    if (_bComplex != isComplex())
     {
-        return this;
+        for (int i = 0 ; i < getSize() ; i++)
+        {
+            get(i)->setComplex(_bComplex);
+        }
     }
-
-    for (int i = 0 ; i < getSize() ; i++)
-    {
-        get(i)->setComplex(_bComplex);
-    }
-
-    return this;
 }
 
 Polynom* Polynom::clone()

--- a/scilab/modules/ast/src/cpp/types/polynom.cpp
+++ b/scilab/modules/ast/src/cpp/types/polynom.cpp
@@ -236,13 +236,6 @@ Polynom* Polynom::setComplex(bool _bComplex)
         return this;
     }
 
-    typedef Polynom* (Polynom::*setcplx_t)(bool);
-    Polynom* pIT = checkRef(this, (setcplx_t)&Polynom::setComplex, _bComplex);
-    if (pIT != this)
-    {
-        return pIT;
-    }
-
     for (int i = 0 ; i < getSize() ; i++)
     {
         get(i)->setComplex(_bComplex);


### PR DESCRIPTION
- it was superfluous and only introduced overhead
- return type of `setComplex` is now `void` to avoid future misuse
- cf. #137 