### PR TITLE
Decrease overhead of get functions

### DIFF
--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -314,6 +314,17 @@ public :
         return get(_iCols * getRows() + _iRows);
     }
 
+    // unsafe "get" functions
+    inline T get_(int _iPos)
+    {
+        return m_pRealData[_iPos];
+    }
+
+    inline T get_(int _iRows, int _iCols)
+    {
+        return get_(_iCols * getRows() + _iRows);
+    }
+
     // specialized "get" for scalars (first element)
     // wo/ any safety checks!!!
     inline T getScalar_()
@@ -416,6 +427,17 @@ public :
     inline T getImg(int _iRows, int _iCols)
     {
         return getImg(_iCols * getRows() + _iRows);
+    }
+
+    // unsafe "getImg" functions
+    inline T getImg_(int _iPos)
+    {
+        return m_pImgData[_iPos];
+    }
+
+    inline T getImg_(int _iRows, int _iCols)
+    {
+        return getImg_(_iCols * getRows() + _iRows);
     }
 
     virtual ArrayOf<T>* insert(typed_list* _pArgs, InternalType* _pSource);

--- a/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
+++ b/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
@@ -330,7 +330,7 @@ types::InternalType* AddElementToVariable(types::InternalType* _poDest, types::I
                     {
                         for (int j = 0; j < cols; j++)
                         {
-                            pPResult->set_(iCurRow + i, iCurCol + j, pPSource->get(i, j));
+                            pPResult->set_(iCurRow + i, iCurCol + j, pPSource->get_(i, j));
                         }
                     }
 
@@ -354,11 +354,11 @@ types::InternalType* AddElementToVariable(types::InternalType* _poDest, types::I
                         {
                             for (int j = 0 ; j < cols; j++)
                             {
-                                types::SinglePoly* pSPOut = pPolyOut->get(iCurRow + i, iCurCol + j);
+                                types::SinglePoly* pSPOut = pPolyOut->get_(iCurRow + i, iCurCol + j);
 
                                 pSPOut->setRank(0);
-                                double pDblR = pD->get(i, j);
-                                double pDblI = pD->getImg(i, j);
+                                double pDblR = pD->get_(i, j);
+                                double pDblI = pD->getImg_(i, j);
                                 pSPOut->setCoef(&pDblR, &pDblI);
                             }
                         }
@@ -372,10 +372,10 @@ types::InternalType* AddElementToVariable(types::InternalType* _poDest, types::I
                         {
                             for (int j = 0 ; j < cols; j++)
                             {
-                                types::SinglePoly* pSPOut = pPolyOut->get(iCurRow + i, iCurCol + j);
+                                types::SinglePoly* pSPOut = pPolyOut->get_(iCurRow + i, iCurCol + j);
 
                                 pSPOut->setRank(0);
-                                double pDbl = pD->get(i, j);
+                                double pDbl = pD->get_(i, j);
                                 pSPOut->setCoef(&pDbl, NULL);
                             }
                         }
@@ -411,8 +411,8 @@ types::InternalType* AddElementToVariable(types::InternalType* _poDest, types::I
                             {
                                 for (int j = 0; j < cols; j++)
                                 {
-                                    double dbl = poSource->get(i, j);
-                                    double dblImg = poSource->getImg(i, j);
+                                    double dbl = poSource->get_(i, j);
+                                    double dblImg = poSource->getImg_(i, j);
                                     if (dbl != 0 || dblImg != 0)
                                     {
                                         spResult->set(i + iCurRow, j + iCurCol, std::complex<double>(dbl, dblImg));
@@ -429,7 +429,7 @@ types::InternalType* AddElementToVariable(types::InternalType* _poDest, types::I
                             {
                                 for (int j = 0; j < cols; j++)
                                 {
-                                    double dbl = poSource->get(i, j);
+                                    double dbl = poSource->get_(i, j);
                                     if (dbl != 0)
                                     {
                                         spResult->set(i + iCurRow, j + iCurCol, std::complex<double>(dbl, 0));
@@ -447,7 +447,7 @@ types::InternalType* AddElementToVariable(types::InternalType* _poDest, types::I
                         {
                             for (int j = 0; j < cols; j++)
                             {
-                                double dbl = poSource->get(i, j);
+                                double dbl = poSource->get_(i, j);
                                 if (dbl != 0)
                                 {
                                     spResult->set(i + iCurRow, j + iCurCol, dbl);
@@ -473,7 +473,7 @@ types::InternalType* AddElementToVariable(types::InternalType* _poDest, types::I
                     {
                         for (int j = 0; j < cols; j++)
                         {
-                            bool bValue = poSource->get(i, j) != 0;
+                            bool bValue = poSource->get_(i, j) != 0;
                             if (bValue)
                             {
                                 spResult->set(i + iCurRow, j + iCurCol, true);
@@ -1982,8 +1982,8 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
                 int size = pP->getSize();
                 for (int idx = 0; idx < size; idx++)
                 {
-                    double dblR = pDest->get(idx);
-                    double dblI = pDest->getImg(idx);
+                    double dblR = pDest->get_(idx);
+                    double dblI = pDest->getImg_(idx);
                     pP->get(idx)->setCoef(&dblR, &dblI);
                 }
             }
@@ -1992,8 +1992,8 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
                 int size = pP->getSize();
                 for (int idx = 0; idx < size; idx++)
                 {
-                    double dblR = pDest->get(idx);
-                    pP->get(idx)->setCoef(&dblR, NULL);
+                    double dblR = pDest->get_(idx);
+                    pP->get_(idx)->setCoef(&dblR, NULL);
                 }
             }
 
@@ -2074,7 +2074,7 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
                     pStruct->addField(pS->getScalar_());
                     for (int i = 0; i < size; i++)
                     {
-                        pStruct->get(i)->set(pS->getScalar_(), _pInsert);
+                        pStruct->get_(i)->set(pS->getScalar_(), _pInsert);
                     }
                 }
                 pRet = pStruct;
@@ -2094,13 +2094,13 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
                         // insert fields of pStruct in pStructInsert
                         for (int i = pStrFieldsName->getSize(); i > 0; i--)
                         {
-                            if (pStructInsert->exists(pStrFieldsName->get(i - 1)) == false)
+                            if (pStructInsert->exists(pStrFieldsName->get_(i - 1)) == false)
                             {
-                                pStructInsert->addFieldFront(pStrFieldsName->get(i - 1));
+                                pStructInsert->addFieldFront(pStrFieldsName->get_(i - 1));
                             }
                             else
                             {
-                                std::wstring pwcsField = pStrFieldsName->get(i - 1);
+                                std::wstring pwcsField = pStrFieldsName->get_(i - 1);
                                 types::List* pLExtract = pStructInsert->extractFieldWithoutClone(pwcsField);
                                 
                                 int size = pLExtract->getSize();
@@ -2137,9 +2137,9 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
                     int size = pStrInsertFieldsName->getSize();
                     for (int i = 0; i < size; i++)
                     {
-                        if (pStructRet->exists(pStrInsertFieldsName->get(i)) == false)
+                        if (pStructRet->exists(pStrInsertFieldsName->get_(i)) == false)
                         {
-                            pStructRet->addField(pStrInsertFieldsName->get(i));
+                            pStructRet->addField(pStrInsertFieldsName->get_(i));
                         }
                     }
 

--- a/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
+++ b/scilab/modules/ast/src/cpp/ast/visitor_common.cpp
@@ -1413,7 +1413,7 @@ types::InternalType* evaluateFields(const ast::Exp* _pExp, std::list<ExpHistory*
                             // extract each elements of a(x)
                             for (int iCell = 0; iCell < pCell->getSize(); iCell++)
                             {
-                                types::InternalType* pIT = pCell->get(iCell);
+                                types::InternalType* pIT = pCell->get_(iCell);
                                 if ((*iterFields)->getExp() == NULL)
                                 {
                                     // a{x}(y)
@@ -1984,7 +1984,7 @@ types::InternalType* insertionCall(const ast::Exp& e, types::typed_list* _pArgs,
                 {
                     double dblR = pDest->get_(idx);
                     double dblI = pDest->getImg_(idx);
-                    pP->get(idx)->setCoef(&dblR, &dblI);
+                    pP->get_(idx)->setCoef(&dblR, &dblI);
                 }
             }
             else

--- a/scilab/modules/ast/src/cpp/operations/types_addition.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_addition.cpp
@@ -964,8 +964,8 @@ int AddSparseToDouble(Sparse* sp, Double* d, GenericType** pDRes)
                 int iRow = static_cast<int>(pRows[i]) - 1;
                 int iCol = static_cast<int>(pCols[i]) - 1;
                 std::complex<double> dbl = sp->getImg(iRow, iCol);
-                pRes->set(iRow, iCol, pRes->get(iRow, iCol) + dbl.real());
-                pRes->setImg(iRow, iCol, pRes->getImg(iRow, iCol) + dbl.imag());
+                pRes->set(iRow, iCol, pRes->get_(iRow, iCol) + dbl.real());
+                pRes->setImg(iRow, iCol, pRes->getImg_(iRow, iCol) + dbl.imag());
             }
         }
         else
@@ -974,7 +974,7 @@ int AddSparseToDouble(Sparse* sp, Double* d, GenericType** pDRes)
             {
                 int iRow = static_cast<int>(pRows[i]) - 1;
                 int iCol = static_cast<int>(pCols[i]) - 1;
-                pRes->set(iRow, iCol, pRes->get(iRow, iCol) + sp->get(iRow, iCol));
+                pRes->set(iRow, iCol, pRes->get_(iRow, iCol) + sp->get(iRow, iCol));
             }
         }
         *pDRes = pRes;
@@ -1034,8 +1034,8 @@ int AddSparseToDouble(Sparse* sp, Double* d, GenericType** pDRes)
                 int iRow = static_cast<int>(pRows[i]) - 1;
                 int iCol = static_cast<int>(pCols[i]) - 1;
                 std::complex<double> dbl = sp->getImg(iRow, iCol);
-                pRes->set(iRow, iCol, pRes->get(iRow, iCol) + dbl.real());
-                pRes->setImg(iRow, iCol, pRes->getImg(iRow, iCol) + dbl.imag());
+                pRes->set(iRow, iCol, pRes->get_(iRow, iCol) + dbl.real());
+                pRes->setImg(iRow, iCol, pRes->getImg_(iRow, iCol) + dbl.imag());
             }
         }
         else
@@ -1044,7 +1044,7 @@ int AddSparseToDouble(Sparse* sp, Double* d, GenericType** pDRes)
             {
                 int iRow = static_cast<int>(pRows[i]) - 1;
                 int iCol = static_cast<int>(pCols[i]) - 1;
-                pRes->set(iRow, iCol, pRes->get(iRow, iCol) + sp->get(iRow, iCol));
+                pRes->set(iRow, iCol, pRes->get_(iRow, iCol) + sp->get(iRow, iCol));
             }
         }
 
@@ -1429,7 +1429,7 @@ InternalType* add_IC_MC(T *_pL, U *_pR)
 
         int index = _pR->getIndex(piIndex);
 
-        add(_pL->getScalar_(), _pL->getImgScalar_(), _pR->get(index), _pR->getImg(index), pOut->get() + index, pOut->getImg() + index);
+        add(_pL->getScalar_(), _pL->getImgScalar_(), _pR->get_(index), _pR->getImg_(index), pOut->get() + index, pOut->getImg() + index);
     }
 
     delete[] piIndex;
@@ -1614,8 +1614,8 @@ InternalType* add_M_M<String, String, String>(String* _pL, String* _pR)
     int* sizeOut = new int[size];
     for (int i = 0 ; i < size ; ++i)
     {
-        wchar_t* pwstL = _pL->get(i);
-        wchar_t* pwstR = _pR->get(i);
+        wchar_t* pwstL = _pL->get_(i);
+        wchar_t* pwstR = _pR->get_(i);
         int sizeL = (int)wcslen(pwstL);
         int sizeR = (int)wcslen(pwstR);
 
@@ -1642,7 +1642,7 @@ InternalType* add_S_M<String, String, String>(String* _pL, String* _pR)
 
     for (int i = 0 ; i < size ; ++i)
     {
-        wchar_t* pwstR = _pR->get(i);
+        wchar_t* pwstR = _pR->get_(i);
         int sizeR = (int)wcslen(pwstR);
 
         sizeOut[i] = sizeL + sizeR + 1;
@@ -1668,7 +1668,7 @@ InternalType* add_M_S<String, String, String>(String* _pL, String* _pR)
 
     for (int i = 0 ; i < size ; ++i)
     {
-        wchar_t* pwstL = _pL->get(i);
+        wchar_t* pwstL = _pL->get_(i);
         int sizeL = (int)wcslen(pwstL);
 
         sizeOut[i] = sizeL + sizeR + 1;
@@ -1834,11 +1834,11 @@ template<> InternalType* add_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
         double *p1I = pCoef1->getImg();
         for (int i = 0 ; i < _pR->getSize() ; i++)
         {
-            SinglePoly *pCoef2 = _pR->get(i);
+            SinglePoly *pCoef2 = _pR->get_(i);
             double *p2R = pCoef2->get();
             double *p2I = pCoef2->getImg();
 
-            SinglePoly *pCoefR = pOut->get(i);
+            SinglePoly *pCoefR = pOut->get_(i);
             double *pRR = pCoefR->get();
             double *pRI = pCoefR->getImg();
 
@@ -1912,11 +1912,11 @@ template<> InternalType* add_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
 
         for (int i = 0 ; i < _pL->getSize() ; i++)
         {
-            SinglePoly *pCoef1 = _pL->get(i);
+            SinglePoly *pCoef1 = _pL->get_(i);
             double *p1R = pCoef1->get();
             double *p1I = pCoef1->getImg();
 
-            SinglePoly *pCoefR = pOut->get(i);
+            SinglePoly *pCoefR = pOut->get_(i);
             double *pRR = pCoefR->get();
             double *pRI = pCoefR->getImg();
 
@@ -2028,9 +2028,9 @@ template<> InternalType* add_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
         for (int i = 0 ; i < _pL->getSize() ; i++)
         {
             iAddScilabPolynomToScilabPolynom(
-                _pL->get(i)->get(), pRank1[i] + 1,
-                _pR->get(i)->get(), pRank2[i] + 1,
-                pOut->get(i)->get(), pRank[i] + 1);
+                _pL->get_(i)->get(), pRank1[i] + 1,
+                _pR->get_(i)->get(), pRank2[i] + 1,
+                pOut->get_(i)->get(), pRank[i] + 1);
         }
     }
     else if (bComplex1 == false && bComplex2 == true)
@@ -2038,9 +2038,9 @@ template<> InternalType* add_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
         for (int i = 0 ; i < _pL->getSize() ; i++)
         {
             iAddScilabPolynomToComplexPoly(
-                _pL->get(i)->get(), pRank1[i] + 1,
-                _pR->get(i)->get(), _pR->get(i)->getImg(), pRank2[i] + 1,
-                pOut->get(i)->get(), pOut->get(i)->getImg(), pRank[i] + 1);
+                _pL->get_(i)->get(), pRank1[i] + 1,
+                _pR->get_(i)->get(), _pR->get_(i)->getImg(), pRank2[i] + 1,
+                pOut->get_(i)->get(), pOut->get_(i)->getImg(), pRank[i] + 1);
         }
     }
     else if (bComplex1 == true && bComplex2 == false)
@@ -2048,9 +2048,9 @@ template<> InternalType* add_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
         for (int i = 0 ; i < _pL->getSize() ; i++)
         {
             iAddScilabPolynomToComplexPoly(
-                _pR->get(i)->get(), pRank2[i] + 1,
-                _pL->get(i)->get(), _pL->get(i)->getImg(), pRank1[i] + 1,
-                pOut->get(i)->get(), pOut->get(i)->getImg(), pRank[i] + 1);
+                _pR->get_(i)->get(), pRank2[i] + 1,
+                _pL->get_(i)->get(), _pL->get_(i)->getImg(), pRank1[i] + 1,
+                pOut->get_(i)->get(), pOut->get_(i)->getImg(), pRank[i] + 1);
         }
     }
     else if (bComplex1 == true && bComplex2 == true)
@@ -2058,9 +2058,9 @@ template<> InternalType* add_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
         for (int i = 0 ; i < _pL->getSize() ; i++)
         {
             iAddComplexPolyToComplexPoly(
-                _pL->get(i)->get(), _pL->get(i)->getImg(), pRank1[i] + 1,
-                _pR->get(i)->get(), _pR->get(i)->getImg(), pRank2[i] + 1,
-                pOut->get(i)->get(), pOut->get(i)->getImg(), pRank[i] + 1);
+                _pL->get_(i)->get(), _pL->get_(i)->getImg(), pRank1[i] + 1,
+                _pR->get_(i)->get(), _pR->get_(i)->getImg(), pRank2[i] + 1,
+                pOut->get_(i)->get(), pOut->get_(i)->getImg(), pRank[i] + 1);
         }
     }
 
@@ -2123,7 +2123,7 @@ template<> InternalType* add_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
             SinglePoly *pInPoly  = _pR->getScalar_();
-            SinglePoly *pOutPoly = pOut->get(i);
+            SinglePoly *pOutPoly = pOut->get_(i);
             double *pInPolyR     = pInPoly->get();
             double *pOutPolyR    = pOutPoly->get();
 
@@ -2140,7 +2140,7 @@ template<> InternalType* add_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
             for (int i = 0 ; i < pOut->getSize() ; i++)
             {
                 SinglePoly *pInPoly  = _pR->getScalar_();
-                SinglePoly *pOutPoly = pOut->get(i);
+                SinglePoly *pOutPoly = pOut->get_(i);
                 double *pInPolyI     = pInPoly->getImg();
                 double *pOutPolyI    = pOutPoly->getImg();
 
@@ -2164,7 +2164,7 @@ template<> InternalType* add_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
         {
             for (int i = 0 ; i < pOut->getSize() ; i++)
             {
-                SinglePoly *pSPOut   = pOut->get(i);
+                SinglePoly *pSPOut   = pOut->get_(i);
                 double *pOutPolyR    = pSPOut->get();
                 double *pOutPolyI    = pSPOut->getImg();
 
@@ -2177,7 +2177,7 @@ template<> InternalType* add_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
             pOut->setComplex(true);
             for (int i = 0 ; i < pOut->getSize() ; i++)
             {
-                SinglePoly *pSPOut   = pOut->get(i);
+                SinglePoly *pSPOut   = pOut->get_(i);
                 double *pOutPolyR    = pSPOut->get();
                 double *pOutPolyI    = pSPOut->getImg();
 
@@ -2189,7 +2189,7 @@ template<> InternalType* add_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
         {
             for (int i = 0 ; i < pOut->getSize() ; i++)
             {
-                SinglePoly *pSPOut = pOut->get(i);
+                SinglePoly *pSPOut = pOut->get_(i);
                 double *pOutPolyR  = pSPOut->get();
 
                 pOutPolyR[0] += pInDblR[0];
@@ -2225,7 +2225,7 @@ template<> InternalType* add_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
     {
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
-            SinglePoly *pSPOut   = pOut->get(i);
+            SinglePoly *pSPOut   = pOut->get_(i);
             double *pOutPolyR    = pSPOut->get();
             double *pOutPolyI    = pSPOut->getImg();
 
@@ -2238,7 +2238,7 @@ template<> InternalType* add_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
         pOut->setComplex(true);
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
-            SinglePoly *pSPOut   = pOut->get(i);
+            SinglePoly *pSPOut   = pOut->get_(i);
             double *pOutPolyR    = pSPOut->get();
             double *pOutPolyI    = pSPOut->getImg();
 
@@ -2250,7 +2250,7 @@ template<> InternalType* add_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
     {
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
-            SinglePoly *pSPOut = pOut->get(i);
+            SinglePoly *pSPOut = pOut->get_(i);
             double *pOutPolyR  = pSPOut->get();
 
             pOutPolyR[0] += pInDblR[i];
@@ -2442,8 +2442,8 @@ template<> InternalType* add_M_M<Sparse, Double, Double>(Sparse* _pL, Double* _p
                 int iRow = static_cast<int>(pRows[i]) - 1;
                 int iCol = static_cast<int>(pCols[i]) - 1;
                 std::complex<double> dbl = _pL->getImg(iRow, iCol);
-                pOut->set(iRow, iCol, pOut->get(iRow, iCol) + dbl.real());
-                pOut->setImg(iRow, iCol, pOut->getImg(iRow, iCol) + dbl.imag());
+                pOut->set(iRow, iCol, pOut->get_(iRow, iCol) + dbl.real());
+                pOut->setImg(iRow, iCol, pOut->getImg_(iRow, iCol) + dbl.imag());
             }
         }
         else
@@ -2452,7 +2452,7 @@ template<> InternalType* add_M_M<Sparse, Double, Double>(Sparse* _pL, Double* _p
             {
                 int iRow = static_cast<int>(pRows[i]) - 1;
                 int iCol = static_cast<int>(pCols[i]) - 1;
-                pOut->set(iRow, iCol, pOut->get(iRow, iCol) + _pL->get(iRow, iCol));
+                pOut->set(iRow, iCol, pOut->get_(iRow, iCol) + _pL->get(iRow, iCol));
             }
         }
 
@@ -2512,8 +2512,8 @@ template<> InternalType* add_M_M<Sparse, Double, Double>(Sparse* _pL, Double* _p
                 int iRow = static_cast<int>(pRows[i]) - 1;
                 int iCol = static_cast<int>(pCols[i]) - 1;
                 std::complex<double> dbl = _pL->getImg(iRow, iCol);
-                pOut->set(iRow, iCol, pOut->get(iRow, iCol) + dbl.real());
-                pOut->setImg(iRow, iCol, pOut->getImg(iRow, iCol) + dbl.imag());
+                pOut->set(iRow, iCol, pOut->get_(iRow, iCol) + dbl.real());
+                pOut->setImg(iRow, iCol, pOut->getImg_(iRow, iCol) + dbl.imag());
             }
         }
         else
@@ -2522,7 +2522,7 @@ template<> InternalType* add_M_M<Sparse, Double, Double>(Sparse* _pL, Double* _p
             {
                 int iRow = static_cast<int>(pRows[i]) - 1;
                 int iCol = static_cast<int>(pCols[i]) - 1;
-                pOut->set(iRow, iCol, pOut->get(iRow, iCol) + _pL->get(iRow, iCol));
+                pOut->set(iRow, iCol, pOut->get_(iRow, iCol) + _pL->get(iRow, iCol));
             }
         }
 

--- a/scilab/modules/ast/src/cpp/operations/types_and.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_and.cpp
@@ -452,9 +452,9 @@ void isValueFalse(T* _pL, types::Bool** _pOut)
 {
     for (int i = 0 ; i < _pL->getSize() ; i++)
     {
-        if (_pL->get(i) == 0)
+        if (_pL->get_(i) == 0)
         {
-            if ( !_pL->isComplex() || (_pL->getImg(i) == 0) )
+            if ( !_pL->isComplex() || (_pL->getImg_(i) == 0) )
             {
                 *_pOut = new Bool(0); //false && something -> false
                 return;
@@ -479,9 +479,9 @@ void isValueFalse(Double* _pL, Bool** _pOut)
 
     for (int i = 0 ; i < _pL->getSize() ; i++)
     {
-        if (_pL->get(i) == 0)
+        if (_pL->get_(i) == 0)
         {
-            if ( !_pL->isComplex() || (_pL->getImg(i) == 0) )
+            if ( !_pL->isComplex() || (_pL->getImg_(i) == 0) )
             {
                 *_pOut = new Bool(0); //false && something -> false
                 return;

--- a/scilab/modules/ast/src/cpp/operations/types_comparison_eq.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_comparison_eq.cpp
@@ -2772,7 +2772,7 @@ InternalType* compequal_M_SP(T* _pL, U* _pR)
 
             for (int i = 0; i < iSizeOut; i++)
             {
-                std::complex<double> stComplex((double)_pL->get(i), (double)_pL->getImg(i));
+                std::complex<double> stComplex((double)_pL->get_(i), (double)_pL->getImg_(i));
                 pspConvert->set(i, stComplex, false);
             }
         }
@@ -2781,7 +2781,7 @@ InternalType* compequal_M_SP(T* _pL, U* _pR)
             pspConvert = new Sparse(_pR->getRows(), _pR->getCols(), _pR->isComplex());
             for (int i = 0; i < iSizeOut; i++)
             {
-                pspConvert->set(i, (double)_pL->get(i), false);
+                pspConvert->set(i, (double)_pL->get_(i), false);
             }
         }
     }
@@ -2836,7 +2836,7 @@ InternalType* compequal_SP_M(T* _pL, U* _pR)
 
             for (int i = 0; i < iSizeOut; i++)
             {
-                std::complex<double> stComplex((double)_pR->get(i), (double)_pR->getImg(i));
+                std::complex<double> stComplex((double)_pR->get_(i), (double)_pR->getImg_(i));
                 pspConvert->set(i, stComplex, false);
             }
         }
@@ -2845,7 +2845,7 @@ InternalType* compequal_SP_M(T* _pL, U* _pR)
             pspConvert = new Sparse(_pL->getRows(), _pL->getCols(), _pL->isComplex());
             for (int i = 0; i < iSizeOut; i++)
             {
-                pspConvert->set(i, (double)_pR->get(i), false);
+                pspConvert->set(i, (double)_pR->get_(i), false);
             }
         }
     }
@@ -2892,7 +2892,7 @@ InternalType* compequal_M_M<Bool, SparseBool, SparseBool>(Bool* _pL, SparseBool*
         pspConvert = new SparseBool(_pR->getRows(), _pR->getCols());
         for (int i = 0; i < iSizeOut; i++)
         {
-            pspConvert->set(i, _pL->get(i) == 1, false);
+            pspConvert->set(i, _pL->get_(i) == 1, false);
         }
     }
 
@@ -2934,7 +2934,7 @@ InternalType* compequal_M_M<SparseBool, Bool, SparseBool>(SparseBool* _pL, Bool*
         pspConvert = new SparseBool(_pL->getRows(), _pL->getCols());
         for (int i = 0; i < iSizeOut; i++)
         {
-            pspConvert->set(i, _pR->get(i) == 1, false);
+            pspConvert->set(i, _pR->get_(i) == 1, false);
         }
     }
 
@@ -3273,7 +3273,7 @@ InternalType* compequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)pdblEye->get(i), (double)pdblEye->getImg(i), &(pbOut->get()[i]));
+                        compequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)pdblEye->get_(i), (double)pdblEye->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3288,7 +3288,7 @@ InternalType* compequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)pdblEye->get(i), (double)0, &(pbOut->get()[i]));
+                        compequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)pdblEye->get_(i), (double)0, &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3306,7 +3306,7 @@ InternalType* compequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compequal((double)pSPR[i]->getScalar_(), (double)0, (double)pdblEye->get(i), (double)pdblEye->getImg(i), &(pbOut->get()[i]));
+                        compequal((double)pSPR[i]->getScalar_(), (double)0, (double)pdblEye->get_(i), (double)pdblEye->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3321,7 +3321,7 @@ InternalType* compequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compequal((double)pSPR[i]->getScalar_(), (double)pdblEye->get(i), &(pbOut->get()[i]));
+                        compequal((double)pSPR[i]->getScalar_(), (double)pdblEye->get_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3410,14 +3410,14 @@ InternalType* compequal_P_M(T *_pL, U *_pR)
                 {
                     for (int i = 0; i < iSize; i++)
                     {
-                        compequal((double)pSPR[0]->getScalar_(), (double)pSPR[0]->getImgScalar_(), (double)_pR->get(i), (double)_pR->getImg(i), &(pbOut->get()[i]));
+                        compequal((double)pSPR[0]->getScalar_(), (double)pSPR[0]->getImgScalar_(), (double)_pR->get_(i), (double)_pR->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
                 else
                 {
                     for (int i = 0; i < iSize; i++)
                     {
-                        compequal((double)pSPR[0]->getScalar_(), (double)pSPR[0]->getImgScalar_(), (double)_pR->get(i), (double)0, &(pbOut->get()[i]));
+                        compequal((double)pSPR[0]->getScalar_(), (double)pSPR[0]->getImgScalar_(), (double)_pR->get_(i), (double)0, &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3427,14 +3427,14 @@ InternalType* compequal_P_M(T *_pL, U *_pR)
                 {
                     for (int i = 0; i < iSize; i++)
                     {
-                        compequal((double)pSPR[0]->getScalar_(), (double)0, (double)_pR->get(i), (double)_pR->getImg(i), &(pbOut->get()[i]));
+                        compequal((double)pSPR[0]->getScalar_(), (double)0, (double)_pR->get_(i), (double)_pR->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
                 else
                 {
                     for (int i = 0; i < iSize; i++)
                     {
-                        compequal((double)pSPR[0]->getScalar_(), (double)_pR->get(i), &(pbOut->get()[i]));
+                        compequal((double)pSPR[0]->getScalar_(), (double)_pR->get_(i), &(pbOut->get()[i]));
                     }
                 }
 
@@ -3478,7 +3478,7 @@ InternalType* compequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)_pR->get(i), (double)_pR->getImg(i), &(pbOut->get()[i]));
+                        compequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)_pR->get_(i), (double)_pR->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3492,7 +3492,7 @@ InternalType* compequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)_pR->get(i), (double)0, &(pbOut->get()[i]));
+                        compequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)_pR->get_(i), (double)0, &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3509,7 +3509,7 @@ InternalType* compequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compequal((double)pSPR[i]->getScalar_(), (double)0, (double)_pR->get(i), (double)_pR->getImg(i), &(pbOut->get()[i]));
+                        compequal((double)pSPR[i]->getScalar_(), (double)0, (double)_pR->get_(i), (double)_pR->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3523,7 +3523,7 @@ InternalType* compequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compequal((double)pSPR[i]->getScalar_(), (double)_pR->get(i), &(pbOut->get()[i]));
+                        compequal((double)pSPR[i]->getScalar_(), (double)_pR->get_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3550,7 +3550,7 @@ InternalType* compequal_M_M<String, String, Bool>(String* _pL, String* _pR)
 
         for (int i = 0; i < _pR->getSize(); i++)
         {
-            pb[i] = wcscmp(_pL->getScalar_(), _pR->get(i)) == 0;
+            pb[i] = wcscmp(_pL->getScalar_(), _pR->get_(i)) == 0;
         }
 
         return pOut;
@@ -3563,7 +3563,7 @@ InternalType* compequal_M_M<String, String, Bool>(String* _pL, String* _pR)
 
         for (int i = 0; i < _pL->getSize(); i++)
         {
-            pb[i] = wcscmp(_pL->get(i), _pR->getScalar_()) == 0;
+            pb[i] = wcscmp(_pL->get_(i), _pR->getScalar_()) == 0;
         }
 
         return pOut;
@@ -3598,7 +3598,7 @@ InternalType* compequal_M_M<String, String, Bool>(String* _pL, String* _pR)
 
         for (int i = 0; i < _pL->getSize(); i++)
         {
-            pb[i] = wcscmp(_pL->get(i), _pR->get(i)) == 0;
+            pb[i] = wcscmp(_pL->get_(i), _pR->get_(i)) == 0;
         }
         return pOut;
     }
@@ -3635,7 +3635,7 @@ types::InternalType* compequal_M_M<Struct, Struct, Bool>(types::Struct* _pL, typ
 
     for (int i = 0; i < _pL->getSize(); i++)
     {
-        pb[i] = *_pL->get(i) == *_pR->get(i);
+        pb[i] = *_pL->get_(i) == *_pR->get_(i);
     }
     return pOut;
 }
@@ -3711,7 +3711,7 @@ types::InternalType* compequal_M_M<Cell, Cell, Bool>(types::Cell* _pL, types::Ce
 
     for (int i = 0; i < _pL->getSize(); i++)
     {
-        pb[i] = *_pL->get(i) == *_pR->get(i);
+        pb[i] = *_pL->get_(i) == *_pR->get_(i);
     }
 
     return pB;

--- a/scilab/modules/ast/src/cpp/operations/types_comparison_lt_le_gt_ge.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_comparison_lt_le_gt_ge.cpp
@@ -156,7 +156,7 @@ int DoubleLessDouble(Double* _pDouble1, Double* _pDouble2, Bool** _pOut)
 
         for (int i = 0 ; i < pB->getSize() ; i++)
         {
-            pb[i] = dblRef < _pDouble2->get(i);
+            pb[i] = dblRef < _pDouble2->get_(i);
         }
 
         *_pOut = pB;
@@ -171,7 +171,7 @@ int DoubleLessDouble(Double* _pDouble1, Double* _pDouble2, Bool** _pOut)
 
         for (int i = 0 ; i < pB->getSize() ; i++)
         {
-            pb[i] = _pDouble1->get(i) < dblRef;
+            pb[i] = _pDouble1->get_(i) < dblRef;
         }
 
         *_pOut = pB;
@@ -200,7 +200,7 @@ int DoubleLessDouble(Double* _pDouble1, Double* _pDouble2, Bool** _pOut)
 
     for (int i = 0 ; i < pB->getSize() ; i++)
     {
-        pb[i] = _pDouble1->get(i) < _pDouble2->get(i);
+        pb[i] = _pDouble1->get_(i) < _pDouble2->get_(i);
     }
 
     *_pOut = pB;
@@ -371,7 +371,7 @@ int DoubleLessEqualDouble(Double* _pDouble1, Double* _pDouble2, Bool** _pOut)
 
         for (int i = 0 ; i < pB->getSize() ; i++)
         {
-            pb[i] = dblRef <= _pDouble2->get(i);
+            pb[i] = dblRef <= _pDouble2->get_(i);
         }
 
         *_pOut = pB;
@@ -387,7 +387,7 @@ int DoubleLessEqualDouble(Double* _pDouble1, Double* _pDouble2, Bool** _pOut)
 
         for (int i = 0 ; i < pB->getSize() ; i++)
         {
-            pb[i] = _pDouble1->get(i) <= dblRef;
+            pb[i] = _pDouble1->get_(i) <= dblRef;
         }
 
         *_pOut = pB;
@@ -416,7 +416,7 @@ int DoubleLessEqualDouble(Double* _pDouble1, Double* _pDouble2, Bool** _pOut)
 
     for (int i = 0 ; i < pB->getSize() ; i++)
     {
-        pb[i] = _pDouble1->get(i) <= _pDouble2->get(i);
+        pb[i] = _pDouble1->get_(i) <= _pDouble2->get_(i);
     }
 
     *_pOut = pB;
@@ -480,7 +480,7 @@ static int IntLessInt(T* _pL, T* _pR, types::GenericType** _pOut)
 
         for (int i = 0 ; i < pB->getSize() ; i++)
         {
-            pb[i] = x < _pR->get(i);
+            pb[i] = x < _pR->get_(i);
         }
 
         *_pOut = pB;
@@ -496,7 +496,7 @@ static int IntLessInt(T* _pL, T* _pR, types::GenericType** _pOut)
 
         for (int i = 0 ; i < pB->getSize() ; i++)
         {
-            pb[i] = _pL->get(i) < x;
+            pb[i] = _pL->get_(i) < x;
         }
 
         *_pOut = pB;
@@ -524,7 +524,7 @@ static int IntLessInt(T* _pL, T* _pR, types::GenericType** _pOut)
 
     for (int i = 0 ; i < _pL->getSize() ; i++)
     {
-        pb[i] = _pL->get(i) < _pR->get(i);
+        pb[i] = _pL->get_(i) < _pR->get_(i);
     }
 
     *_pOut = pB;
@@ -586,7 +586,7 @@ static int IntLessEqualInt(T* _pL, T* _pR, types::GenericType** _pOut)
 
         for (int i = 0 ; i < pB->getSize() ; i++)
         {
-            pb[i] = x <= _pR->get(i);
+            pb[i] = x <= _pR->get_(i);
         }
 
         *_pOut = pB;
@@ -602,7 +602,7 @@ static int IntLessEqualInt(T* _pL, T* _pR, types::GenericType** _pOut)
 
         for (int i = 0 ; i < pB->getSize() ; i++)
         {
-            pb[i] = _pL->get(i) <= x;
+            pb[i] = _pL->get_(i) <= x;
         }
 
         *_pOut = pB;
@@ -630,7 +630,7 @@ static int IntLessEqualInt(T* _pL, T* _pR, types::GenericType** _pOut)
 
     for (int i = 0 ; i < _pL->getSize() ; i++)
     {
-        pb[i] = _pL->get(i) <= _pR->get(i);
+        pb[i] = _pL->get_(i) <= _pR->get_(i);
     }
 
     *_pOut = pB;

--- a/scilab/modules/ast/src/cpp/operations/types_comparison_ne.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_comparison_ne.cpp
@@ -2778,7 +2778,7 @@ InternalType* compnoequal_M_SP(T* _pL, U* _pR)
 
             for (int i = 0; i < iSizeOut; i++)
             {
-                std::complex<double> stComplex((double)_pL->get(i), (double)_pL->getImg(i));
+                std::complex<double> stComplex((double)_pL->get_(i), (double)_pL->getImg_(i));
                 pspConvert->set(i, stComplex, false);
             }
         }
@@ -2787,7 +2787,7 @@ InternalType* compnoequal_M_SP(T* _pL, U* _pR)
             pspConvert = new Sparse(_pR->getRows(), _pR->getCols(), _pR->isComplex());
             for (int i = 0; i < iSizeOut; i++)
             {
-                pspConvert->set(i, (double)_pL->get(i), false);
+                pspConvert->set(i, (double)_pL->get_(i), false);
             }
         }
     }
@@ -2843,7 +2843,7 @@ InternalType* compnoequal_SP_M(T* _pL, U* _pR)
 
             for (int i = 0; i < iSizeOut; i++)
             {
-                std::complex<double> stComplex((double)_pR->get(i), (double)_pR->getImg(i));
+                std::complex<double> stComplex((double)_pR->get_(i), (double)_pR->getImg_(i));
                 pspConvert->set(i, stComplex, false);
             }
         }
@@ -2852,7 +2852,7 @@ InternalType* compnoequal_SP_M(T* _pL, U* _pR)
             pspConvert = new Sparse(_pL->getRows(), _pL->getCols(), _pL->isComplex());
             for (int i = 0; i < iSizeOut; i++)
             {
-                pspConvert->set(i, (double)_pR->get(i), false);
+                pspConvert->set(i, (double)_pR->get_(i), false);
             }
         }
     }
@@ -2899,7 +2899,7 @@ InternalType* compnoequal_M_M<Bool, SparseBool, SparseBool>(Bool* _pL, SparseBoo
         pspConvert = new SparseBool(_pR->getRows(), _pR->getCols());
         for (int i = 0; i < iSizeOut; i++)
         {
-            pspConvert->set(i, _pL->get(i) == 1, false);
+            pspConvert->set(i, _pL->get_(i) == 1, false);
         }
     }
 
@@ -2940,7 +2940,7 @@ InternalType* compnoequal_M_M<SparseBool, Bool, SparseBool>(SparseBool* _pL, Boo
         pspConvert = new SparseBool(_pL->getRows(), _pL->getCols());
         for (int i = 0; i < iSizeOut; i++)
         {
-            pspConvert->set(i, _pR->get(i) == 1, false);
+            pspConvert->set(i, _pR->get_(i) == 1, false);
         }
     }
 
@@ -2982,7 +2982,7 @@ InternalType* compnoequal_M_M<Polynom, Polynom, Bool>(Polynom* _pL, Polynom* _pR
                         bPoise = true;
                         for (int j = 0; j < pSPL[0]->getSize() && (bPoise == true); j++)
                         {
-                            compnoequal(pSPR[0]->get(j), pSPR[0]->getImg(j), pSPL[i]->get(j), pSPL[i]->getImg(j), &bPoise);
+                            compnoequal(pSPR[0]->get_(j), pSPR[0]->getImg_(j), pSPL[i]->get_(j), pSPL[i]->getImg_(j), &bPoise);
                         }
                     }
                     pb[i] = bPoise;
@@ -3002,7 +3002,7 @@ InternalType* compnoequal_M_M<Polynom, Polynom, Bool>(Polynom* _pL, Polynom* _pR
                         bPoise = true;
                         for (int j = 0; j < pSPL[0]->getSize() && (bPoise == true); j++)
                         {
-                            compnoequal(pSPR[0]->get(j), (double)0, pSPL[i]->get(j), pSPL[i]->getImg(j), &bPoise);
+                            compnoequal(pSPR[0]->get_(j), (double)0, pSPL[i]->get_(j), pSPL[i]->getImg_(j), &bPoise);
                         }
                     }
                     pb[i] = bPoise;
@@ -3240,7 +3240,7 @@ InternalType* compnoequal_M_M<Polynom, Polynom, Bool>(Polynom* _pL, Polynom* _pR
                         bPoise = true;
                         for (int j = 0; j < pSPR[i]->getSize() && (bPoise == true); j++)
                         {
-                            compnoequal(pSPR[i]->get(j), pSPL[i]->get(j), &bPoise);
+                            compnoequal(pSPR[i]->get_(j), pSPL[i]->get(j), &bPoise);
                         }
                     }
                     pb[i] = bPoise;
@@ -3279,7 +3279,7 @@ InternalType* compnoequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compnoequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)pdblEye->get(i), (double)pdblEye->getImg(i), &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)pdblEye->get_(i), (double)pdblEye->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3294,7 +3294,7 @@ InternalType* compnoequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compnoequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)pdblEye->get(i), (double)0, &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)pdblEye->get_(i), (double)0, &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3312,7 +3312,7 @@ InternalType* compnoequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compnoequal((double)pSPR[i]->getScalar_(), (double)0, (double)pdblEye->get(i), (double)pdblEye->getImg(i), &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[i]->getScalar_(), (double)0, (double)pdblEye->get_(i), (double)pdblEye->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3327,7 +3327,7 @@ InternalType* compnoequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compnoequal((double)pSPR[i]->getScalar_(), (double)pdblEye->get(i), &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[i]->getScalar_(), (double)pdblEye->get_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3416,14 +3416,14 @@ InternalType* compnoequal_P_M(T *_pL, U *_pR)
                 {
                     for (int i = 0; i < iSize; i++)
                     {
-                        compnoequal((double)pSPR[0]->getScalar_(), (double)pSPR[0]->getImgScalar_(), (double)_pR->get(i), (double)_pR->getImg(i), &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[0]->getScalar_(), (double)pSPR[0]->getImgScalar_(), (double)_pR->get_(i), (double)_pR->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
                 else
                 {
                     for (int i = 0; i < iSize; i++)
                     {
-                        compnoequal((double)pSPR[0]->getScalar_(), (double)pSPR[0]->getImgScalar_(), (double)_pR->get(i), (double)0, &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[0]->getScalar_(), (double)pSPR[0]->getImgScalar_(), (double)_pR->get_(i), (double)0, &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3433,14 +3433,14 @@ InternalType* compnoequal_P_M(T *_pL, U *_pR)
                 {
                     for (int i = 0; i < iSize; i++)
                     {
-                        compnoequal((double)pSPR[0]->getScalar_(), (double)0, (double)_pR->get(i), (double)_pR->getImg(i), &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[0]->getScalar_(), (double)0, (double)_pR->get_(i), (double)_pR->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
                 else
                 {
                     for (int i = 0; i < iSize; i++)
                     {
-                        compnoequal((double)pSPR[0]->getScalar_(), (double)_pR->get(i), &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[0]->getScalar_(), (double)_pR->get_(i), &(pbOut->get()[i]));
                     }
                 }
 
@@ -3484,7 +3484,7 @@ InternalType* compnoequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compnoequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)_pR->get(i), (double)_pR->getImg(i), &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)_pR->get_(i), (double)_pR->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3498,7 +3498,7 @@ InternalType* compnoequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compnoequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)_pR->get(i), (double)0, &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[i]->getScalar_(), (double)pSPR[i]->getImgScalar_(), (double)_pR->get_(i), (double)0, &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3515,7 +3515,7 @@ InternalType* compnoequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compnoequal((double)pSPR[i]->getScalar_(), (double)0, (double)_pR->get(i), (double)_pR->getImg(i), &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[i]->getScalar_(), (double)0, (double)_pR->get_(i), (double)_pR->getImg_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3529,7 +3529,7 @@ InternalType* compnoequal_P_M(T *_pL, U *_pR)
                     }
                     else
                     {
-                        compnoequal((double)pSPR[i]->getScalar_(), (double)_pR->get(i), &(pbOut->get()[i]));
+                        compnoequal((double)pSPR[i]->getScalar_(), (double)_pR->get_(i), &(pbOut->get()[i]));
                     }
                 }
             }
@@ -3555,7 +3555,7 @@ InternalType* compnoequal_M_M<String, String, Bool>(String* _pL, String* _pR)
 
         for (int i = 0; i < _pR->getSize(); i++)
         {
-            pb[i] = wcscmp(_pL->getScalar_(), _pR->get(i)) != 0;
+            pb[i] = wcscmp(_pL->getScalar_(), _pR->get_(i)) != 0;
         }
         return pOut;
     }
@@ -3567,7 +3567,7 @@ InternalType* compnoequal_M_M<String, String, Bool>(String* _pL, String* _pR)
 
         for (int i = 0; i < _pL->getSize(); i++)
         {
-            pb[i] = wcscmp(_pL->get(i), _pR->getScalar_()) != 0;
+            pb[i] = wcscmp(_pL->get_(i), _pR->getScalar_()) != 0;
         }
         return pOut;
     }
@@ -3600,7 +3600,7 @@ InternalType* compnoequal_M_M<String, String, Bool>(String* _pL, String* _pR)
 
         for (int i = 0; i < _pL->getSize(); i++)
         {
-            pb[i] = wcscmp(_pL->get(i), _pR->get(i)) != 0;
+            pb[i] = wcscmp(_pL->get_(i), _pR->get_(i)) != 0;
         }
         return pOut;
     }
@@ -3639,7 +3639,7 @@ types::InternalType* compnoequal_M_M<Struct, Struct, Bool>(types::Struct* _pL, t
 
     for (int i = 0; i < _pL->getSize(); i++)
     {
-        pb[i] = *_pL->get(i) != *_pR->get(i);
+        pb[i] = *_pL->get_(i) != *_pR->get_(i);
     }
     return pOut;
 
@@ -3716,7 +3716,7 @@ types::InternalType* compnoequal_M_M<Cell, Cell, Bool>(types::Cell* _pL, types::
 
     for (int i = 0; i < _pL->getSize(); i++)
     {
-        pb[i] = !(*_pL->get(i) == *_pR->get(i));
+        pb[i] = !(*_pL->get_(i) == *_pR->get_(i));
     }
 
     return pB;
@@ -3803,7 +3803,7 @@ InternalType* compnoequal_UT_UT(T *_pL, U *_pR)
     {
         for (int i = 0; i < eq->getSize(); ++i)
         {
-            eq->set(i, !eq->get(i));
+            eq->set(i, !eq->get_(i));
         }
     }
 

--- a/scilab/modules/ast/src/cpp/operations/types_multiplication.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_multiplication.cpp
@@ -385,7 +385,7 @@ int MultiplyDoubleByPoly(Double* _pDouble, Polynom* _pPoly, Polynom** _pPolyOut)
         int* piRank = new int[_pPoly->getSize()];
         for (int i = 0 ; i < _pPoly->getSize() ; i++)
         {
-            piRank[i] = _pPoly->get(i)->getRank();
+            piRank[i] = _pPoly->get_(i)->getRank();
         }
 
         (*_pPolyOut) = new Polynom(_pPoly->getVariableName(), _pPoly->getDims(), _pPoly->getDimsArray(), piRank);
@@ -397,11 +397,11 @@ int MultiplyDoubleByPoly(Double* _pDouble, Polynom* _pPoly, Polynom** _pPolyOut)
 
         for (int i = 0 ; i < _pPoly->getSize() ; i++)
         {
-            SinglePoly *pPolyIn     = _pPoly->get(i);
+            SinglePoly *pPolyIn     = _pPoly->get_(i);
             double* pRealIn         = pPolyIn->get();
             double* pImgIn          = pPolyIn->getImg();
 
-            SinglePoly *pPolyOut    = (*_pPolyOut)->get(i);
+            SinglePoly *pPolyOut    = (*_pPolyOut)->get_(i);
             double* pRealOut        = pPolyOut->get();
             double* pImgOut         = pPolyOut->getImg();
 
@@ -450,7 +450,7 @@ int MultiplyDoubleByPoly(Double* _pDouble, Polynom* _pPoly, Polynom** _pPolyOut)
 
         for (int i = 0 ; i < _pDouble->getSize() ; i++)
         {
-            SinglePoly *pPolyOut    = (*_pPolyOut)->get(i);
+            SinglePoly *pPolyOut    = (*_pPolyOut)->get_(i);
             double* pRealOut        = pPolyOut->get();
             double* pImgOut         = pPolyOut->getImg();
 
@@ -563,7 +563,7 @@ int MultiplyPolyByDouble(Polynom* _pPoly, Double* _pDouble, Polynom **_pPolyOut)
 
         for (int i = 0 ; i < _pDouble->getSize() ; i++)
         {
-            SinglePoly *pPolyOut    = (*_pPolyOut)->get(i);
+            SinglePoly *pPolyOut    = (*_pPolyOut)->get_(i);
             double* pRealOut        = pPolyOut->get();
             double* pImgOut         = pPolyOut->getImg();
 
@@ -593,7 +593,7 @@ int MultiplyPolyByDouble(Polynom* _pPoly, Double* _pDouble, Polynom **_pPolyOut)
         int* piRank = new int[_pPoly->getSize()];
         for (int i = 0 ; i < _pPoly->getSize() ; i++)
         {
-            piRank[i] = _pPoly->get(i)->getRank();
+            piRank[i] = _pPoly->get_(i)->getRank();
         }
 
         (*_pPolyOut) = new Polynom(_pPoly->getVariableName(), _pPoly->getDims(), _pPoly->getDimsArray(), piRank);
@@ -605,11 +605,11 @@ int MultiplyPolyByDouble(Polynom* _pPoly, Double* _pDouble, Polynom **_pPolyOut)
 
         for (int i = 0 ; i < _pPoly->getSize() ; i++)
         {
-            SinglePoly *pPolyIn = _pPoly->get(i);
+            SinglePoly *pPolyIn = _pPoly->get_(i);
             double* pRealIn     = pPolyIn->get();
             double* pImgIn      = pPolyIn->getImg();
 
-            SinglePoly *pPolyOut    = (*_pPolyOut)->get(i);
+            SinglePoly *pPolyOut    = (*_pPolyOut)->get_(i);
             double* pRealOut        = pPolyOut->get();
             double* pImgOut         = pPolyOut->getImg();
 
@@ -663,42 +663,42 @@ int MultiplyPolyByDouble(Polynom* _pPoly, Double* _pDouble, Polynom **_pPolyOut)
         //for each col of _pDouble
         for (int iCol2 = 0 ; iCol2 < _pDouble->getCols() ; iCol2++)
         {
-            SinglePoly* pSPOut = (*_pPolyOut)->get(iRow1, iCol2);
+            SinglePoly* pSPOut = (*_pPolyOut)->get_(iRow1, iCol2);
             pSPOut->setZeros();
 
             //for each rows of _pDouble / cols of _pPoly
             for (int iRow2 = 0 ; iRow2 < _pDouble->getRows() ; iRow2++)
             {
                 // SinglePoly(iRow1, iRow2) * Double(iRow2, iCol2)
-                SinglePoly* pSPIn = _pPoly->get(iRow1, iRow2);
+                SinglePoly* pSPIn = _pPoly->get_(iRow1, iRow2);
                 int iSize = pSPIn->getSize();
                 double* pdblMult = new double[iSize];
 
                 if (bComplex1 == false && bComplex2 == false)
                 {
                     //Real Matrix by Real Scalar
-                    iMultiRealScalarByRealMatrix(_pDouble->get(iRow2, iCol2), pSPIn->get(), iSize, 1, pdblMult);
+                    iMultiRealScalarByRealMatrix(_pDouble->get_(iRow2, iCol2), pSPIn->get(), iSize, 1, pdblMult);
                     add(pSPOut->get(), (long long)iSize, pdblMult, pSPOut->get());
                 }
                 else if (bComplex1 == false && bComplex2 == true)
                 {
                     //Real Matrix by Scalar Complex
                     double* pdblMultImg = new double[iSize];
-                    iMultiComplexScalarByRealMatrix(_pDouble->get(iRow2, iCol2), _pDouble->getImg(iRow2, iCol2), pSPIn->get(), pSPIn->getSize(), 1, pdblMult, pdblMultImg);
+                    iMultiComplexScalarByRealMatrix(_pDouble->get_(iRow2, iCol2), _pDouble->getImg_(iRow2, iCol2), pSPIn->get(), pSPIn->getSize(), 1, pdblMult, pdblMultImg);
                     add(pSPOut->get(), pSPOut->getImg(), (long long)iSize, pdblMult, pdblMultImg, pSPOut->get(), pSPOut->getImg());
                     delete[] pdblMultImg;
                 }
                 else if (bComplex1 == true && bComplex2 == false)
                 {
                     double* pdblMultImg = new double[iSize];
-                    iMultiRealScalarByComplexMatrix(_pDouble->get(iRow2, iCol2), pSPIn->get(), pSPIn->getImg(), pSPIn->getSize(), 1, pdblMult, pdblMultImg);
+                    iMultiRealScalarByComplexMatrix(_pDouble->get_(iRow2, iCol2), pSPIn->get(), pSPIn->getImg(), pSPIn->getSize(), 1, pdblMult, pdblMultImg);
                     add(pSPOut->get(), pSPOut->getImg(), (long long)iSize, pdblMult, pdblMultImg, pSPOut->get(), pSPOut->getImg());
                     delete[] pdblMultImg;
                 }
                 else //if(bComplex1 == true && bComplex2 == true)
                 {
                     double* pdblMultImg = new double[iSize];
-                    iMultiComplexScalarByComplexMatrix(_pDouble->get(iRow2, iCol2), _pDouble->getImg(iRow2, iCol2), pSPIn->get(), pSPIn->getImg(), pSPIn->getSize(), 1, pdblMult, pdblMultImg);
+                    iMultiComplexScalarByComplexMatrix(_pDouble->get_(iRow2, iCol2), _pDouble->getImg_(iRow2, iCol2), pSPIn->get(), pSPIn->getImg(), pSPIn->getSize(), 1, pdblMult, pdblMultImg);
                     add(pSPOut->get(), pSPOut->getImg(), (long long)iSize, pdblMult, pdblMultImg, pSPOut->get(), pSPOut->getImg());
                     delete[] pdblMultImg;
                 }
@@ -790,7 +790,7 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         int* piRank = new int[_pPoly2->getSize()];
         for (int i = 0 ; i < _pPoly2->getSize() ; i++)
         {
-            piRank[i] = _pPoly1->getScalar_()->getRank() + _pPoly2->get(i)->getRank();
+            piRank[i] = _pPoly1->getScalar_()->getRank() + _pPoly2->get_(i)->getRank();
         }
 
         (*_pPolyOut) = new Polynom(_pPoly1->getVariableName(), _pPoly2->getDims(), _pPoly2->getDimsArray(), piRank);
@@ -806,8 +806,8 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iPoly = 0 ; iPoly < _pPoly2->getSize() ; iPoly++)
             {
-                SinglePoly *pPoly2  = _pPoly2->get(iPoly);
-                SinglePoly *pPolyOut = (*_pPolyOut)->get(iPoly);
+                SinglePoly *pPoly2  = _pPoly2->get_(iPoly);
+                SinglePoly *pPolyOut = (*_pPolyOut)->get_(iPoly);
 
                 pPolyOut->setZeros();
 
@@ -821,8 +821,8 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iPoly = 0 ; iPoly < _pPoly2->getSize() ; iPoly++)
             {
-                SinglePoly *pPoly2  = _pPoly2->get(iPoly);
-                SinglePoly *pPolyOut = (*_pPolyOut)->get(iPoly);
+                SinglePoly *pPoly2  = _pPoly2->get_(iPoly);
+                SinglePoly *pPolyOut = (*_pPolyOut)->get_(iPoly);
 
                 pPolyOut->setZeros();
 
@@ -836,8 +836,8 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iPoly = 0 ; iPoly < _pPoly2->getSize() ; iPoly++)
             {
-                SinglePoly *pPoly2  = _pPoly2->get(iPoly);
-                SinglePoly *pPolyOut = (*_pPolyOut)->get(iPoly);
+                SinglePoly *pPoly2  = _pPoly2->get_(iPoly);
+                SinglePoly *pPolyOut = (*_pPolyOut)->get_(iPoly);
 
                 pPolyOut->setZeros();
 
@@ -851,8 +851,8 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iPoly = 0 ; iPoly < _pPoly2->getSize() ; iPoly++)
             {
-                SinglePoly *pPoly2   = _pPoly2->get(iPoly);
-                SinglePoly *pPolyOut  = (*_pPolyOut)->get(iPoly);
+                SinglePoly *pPoly2   = _pPoly2->get_(iPoly);
+                SinglePoly *pPolyOut  = (*_pPolyOut)->get_(iPoly);
 
                 pPolyOut->setZeros();
 
@@ -873,7 +873,7 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         int* piRank = new int[_pPoly1->getSize()];
         for (int i = 0 ; i < _pPoly1->getSize() ; i++)
         {
-            piRank[i] = _pPoly2->getScalar_()->getRank() + _pPoly1->get(i)->getRank();
+            piRank[i] = _pPoly2->getScalar_()->getRank() + _pPoly1->get_(i)->getRank();
         }
 
         (*_pPolyOut) = new Polynom(_pPoly1->getVariableName(), _pPoly1->getDims(), _pPoly1->getDimsArray(), piRank);
@@ -888,8 +888,8 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iPoly = 0 ; iPoly < _pPoly1->getSize() ; iPoly++)
             {
-                SinglePoly *pPoly1  = _pPoly1->get(iPoly);
-                SinglePoly *pPolyOut = (*_pPolyOut)->get(iPoly);
+                SinglePoly *pPoly1  = _pPoly1->get_(iPoly);
+                SinglePoly *pPolyOut = (*_pPolyOut)->get_(iPoly);
 
                 pPolyOut->setZeros();
 
@@ -903,8 +903,8 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iPoly = 0 ; iPoly < _pPoly1->getSize() ; iPoly++)
             {
-                SinglePoly *pPoly1  = _pPoly1->get(iPoly);
-                SinglePoly *pPolyOut = (*_pPolyOut)->get(iPoly);
+                SinglePoly *pPoly1  = _pPoly1->get_(iPoly);
+                SinglePoly *pPolyOut = (*_pPolyOut)->get_(iPoly);
 
                 pPolyOut->setZeros();
 
@@ -918,8 +918,8 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iPoly = 0 ; iPoly < _pPoly1->getSize() ; iPoly++)
             {
-                SinglePoly *pPoly1  = _pPoly1->get(iPoly);
-                SinglePoly *pPolyOut = (*_pPolyOut)->get(iPoly);
+                SinglePoly *pPoly1  = _pPoly1->get_(iPoly);
+                SinglePoly *pPolyOut = (*_pPolyOut)->get_(iPoly);
 
                 pPolyOut->setZeros();
 
@@ -933,8 +933,8 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iPoly = 0 ; iPoly < _pPoly1->getSize() ; iPoly++)
             {
-                SinglePoly *pPoly1   = _pPoly1->get(iPoly);
-                SinglePoly *pPolyOut  = (*_pPolyOut)->get(iPoly);
+                SinglePoly *pPoly1   = _pPoly1->get_(iPoly);
+                SinglePoly *pPolyOut  = (*_pPolyOut)->get_(iPoly);
 
                 pPolyOut->setZeros();
 
@@ -981,13 +981,13 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iCol = 0 ; iCol < _pPoly2->getCols() ; iCol++)
             {
-                SinglePoly *pResult = (*_pPolyOut)->get(iRow, iCol);
+                SinglePoly *pResult = (*_pPolyOut)->get_(iRow, iCol);
                 pResult->setZeros();
 
                 for (int iCommon = 0 ; iCommon < _pPoly1->getCols() ; iCommon++)
                 {
-                    SinglePoly *pL   = _pPoly1->get(iRow, iCommon);
-                    SinglePoly *pR   = _pPoly2->get(iCommon, iCol);
+                    SinglePoly *pL   = _pPoly1->get_(iRow, iCommon);
+                    SinglePoly *pR   = _pPoly2->get_(iCommon, iCol);
 
                     pTemp->setZeros();
 
@@ -1016,13 +1016,13 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iCol = 0 ; iCol < _pPoly2->getCols() ; iCol++)
             {
-                SinglePoly *pResult = (*_pPolyOut)->get(iRow, iCol);
+                SinglePoly *pResult = (*_pPolyOut)->get_(iRow, iCol);
                 pResult->setZeros();
 
                 for (int iCommon = 0 ; iCommon < _pPoly1->getCols() ; iCommon++)
                 {
-                    SinglePoly *pL   = _pPoly1->get(iRow, iCommon);
-                    SinglePoly *pR   = _pPoly2->get(iCommon, iCol);
+                    SinglePoly *pL   = _pPoly1->get_(iRow, iCommon);
+                    SinglePoly *pR   = _pPoly2->get_(iCommon, iCol);
 
                     pTemp->setZeros();
 
@@ -1051,13 +1051,13 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iCol = 0 ; iCol < _pPoly2->getCols() ; iCol++)
             {
-                SinglePoly *pResult = (*_pPolyOut)->get(iRow, iCol);
+                SinglePoly *pResult = (*_pPolyOut)->get_(iRow, iCol);
                 pResult->setZeros();
 
                 for (int iCommon = 0 ; iCommon < _pPoly1->getCols() ; iCommon++)
                 {
-                    SinglePoly *pL   = _pPoly1->get(iRow, iCommon);
-                    SinglePoly *pR   = _pPoly2->get(iCommon, iCol);
+                    SinglePoly *pL   = _pPoly1->get_(iRow, iCommon);
+                    SinglePoly *pR   = _pPoly2->get_(iCommon, iCol);
 
                     pTemp->setZeros();
 
@@ -1086,13 +1086,13 @@ int MultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOut)
         {
             for (int iCol = 0 ; iCol < _pPoly2->getCols() ; iCol++)
             {
-                SinglePoly *pResult = (*_pPolyOut)->get(iRow, iCol);
+                SinglePoly *pResult = (*_pPolyOut)->get_(iRow, iCol);
                 pResult->setZeros();
 
                 for (int iCommon = 0 ; iCommon < _pPoly1->getCols() ; iCommon++)
                 {
-                    SinglePoly *pL   = _pPoly1->get(iRow, iCommon);
-                    SinglePoly *pR   = _pPoly2->get(iCommon, iCol);
+                    SinglePoly *pL   = _pPoly1->get_(iRow, iCommon);
+                    SinglePoly *pR   = _pPoly2->get_(iCommon, iCol);
 
                     pTemp->setZeros();
 
@@ -1385,8 +1385,8 @@ int MultiplySparseByDouble(Sparse *_pSparse, Double*_pDouble, GenericType** _pOu
 
             for (int j = 0 ; j < _pDouble->getCols() ; j++)
             {
-                double dblVal = _pDouble->get(iCol, j) * dbl;
-                pOut->set(iRow, j, pOut->get(iRow, j) + dblVal);
+                double dblVal = _pDouble->get_(iCol, j) * dbl;
+                pOut->set(iRow, j, pOut->get_(iRow, j) + dblVal);
             }
         }
     }
@@ -1402,10 +1402,10 @@ int MultiplySparseByDouble(Sparse *_pSparse, Double*_pDouble, GenericType** _pOu
 
             for (int j = 0 ; j < _pDouble->getCols() ; j++)
             {
-                double dblValR = _pDouble->get(iCol, j) * dblR;
-                double dblValI = _pDouble->get(iCol, j) * dblI;
-                pOut->set(iRow, j, pOut->get(iRow, j) + dblValR);
-                pOut->setImg(iRow, j, pOut->getImg(iRow, j) + dblValI);
+                double dblValR = _pDouble->get_(iCol, j) * dblR;
+                double dblValI = _pDouble->get_(iCol, j) * dblI;
+                pOut->set(iRow, j, pOut->get_(iRow, j) + dblValR);
+                pOut->setImg(iRow, j, pOut->getImg_(iRow, j) + dblValI);
             }
         }
     }
@@ -1420,10 +1420,10 @@ int MultiplySparseByDouble(Sparse *_pSparse, Double*_pDouble, GenericType** _pOu
 
             for (int j = 0 ; j < _pDouble->getCols() ; j++)
             {
-                double dblValR = _pDouble->get(iCol, j) * dblR;
-                double dblValI = _pDouble->getImg(iCol, j) * dblR;
-                pOut->set(iRow, j, pOut->get(iRow, j) + dblValR);
-                pOut->setImg(iRow, j, pOut->getImg(iRow, j) + dblValI);
+                double dblValR = _pDouble->get_(iCol, j) * dblR;
+                double dblValI = _pDouble->getImg_(iCol, j) * dblR;
+                pOut->set(iRow, j, pOut->get_(iRow, j) + dblValR);
+                pOut->setImg(iRow, j, pOut->getImg_(iRow, j) + dblValI);
             }
         }
     }
@@ -1438,10 +1438,10 @@ int MultiplySparseByDouble(Sparse *_pSparse, Double*_pDouble, GenericType** _pOu
 
             for (int j = 0 ; j < _pDouble->getCols() ; j++)
             {
-                double dblValR = _pDouble->get(iCol, j) * dblR - _pDouble->getImg(iCol, j) * dblI;
-                double dblValI = _pDouble->get(iCol, j) * dblI + _pDouble->getImg(iCol, j) * dblR;
-                pOut->set(iRow, j, pOut->get(iRow, j) + dblValR);
-                pOut->setImg(iRow, j, pOut->getImg(iRow, j) + dblValI);
+                double dblValR = _pDouble->get_(iCol, j) * dblR - _pDouble->getImg_(iCol, j) * dblI;
+                double dblValI = _pDouble->get_(iCol, j) * dblI + _pDouble->getImg_(iCol, j) * dblR;
+                pOut->set(iRow, j, pOut->get_(iRow, j) + dblValR);
+                pOut->setImg(iRow, j, pOut->getImg_(iRow, j) + dblValI);
             }
         }
     }
@@ -1508,7 +1508,7 @@ int DotMultiplyDoubleBySparse(Double* _pDouble, Sparse* _pSparse, GenericType** 
         {
             int iRow = static_cast<int>(pRows[i]) - 1;
             int iCol = static_cast<int>(pCols[i]) - 1;
-            pOut->set(iRow, iCol, _pSparse->get(iRow, iCol) * _pDouble->get(iRow, iCol));
+            pOut->set(iRow, iCol, _pSparse->get(iRow, iCol) * _pDouble->get_(iRow, iCol));
         }
     }
     else if (_pDouble->isComplex() == false && _pSparse->isComplex() == true)
@@ -1518,7 +1518,7 @@ int DotMultiplyDoubleBySparse(Double* _pDouble, Sparse* _pSparse, GenericType** 
             int iRow = static_cast<int>(pRows[i]) - 1;
             int iCol = static_cast<int>(pCols[i]) - 1;
             std::complex<double> dbl = _pSparse->getImg(iRow, iCol);
-            std::complex<double> newVal(dbl.real() * _pDouble->get(iRow, iCol), dbl.imag() * _pDouble->get(iRow, iCol));
+            std::complex<double> newVal(dbl.real() * _pDouble->get_(iRow, iCol), dbl.imag() * _pDouble->get_(iRow, iCol));
             pOut->set(iRow, iCol, newVal);
         }
     }
@@ -1529,7 +1529,7 @@ int DotMultiplyDoubleBySparse(Double* _pDouble, Sparse* _pSparse, GenericType** 
             int iRow = static_cast<int>(pRows[i]) - 1;
             int iCol = static_cast<int>(pCols[i]) - 1;
             std::complex<double> dbl = _pSparse->getImg(iRow, iCol);
-            std::complex<double> newVal(dbl.real() * _pDouble->get(iRow, iCol), dbl.real() * _pDouble->getImg(iRow, iCol));
+            std::complex<double> newVal(dbl.real() * _pDouble->get_(iRow, iCol), dbl.real() * _pDouble->getImg_(iRow, iCol));
             pOut->set(iRow, iCol, newVal);
         }
     }
@@ -1540,8 +1540,8 @@ int DotMultiplyDoubleBySparse(Double* _pDouble, Sparse* _pSparse, GenericType** 
             int iRow = static_cast<int>(pRows[i]) - 1;
             int iCol = static_cast<int>(pCols[i]) - 1;
             std::complex<double> dbl = _pSparse->getImg(iRow, iCol);
-            double dblR = _pDouble->get(iRow, iCol) * dbl.real() - _pDouble->getImg(iRow, iCol) * dbl.imag();
-            double dblI = _pDouble->getImg(iRow, iCol) * dbl.real() + _pDouble->get(iRow, iCol) * dbl.imag();
+            double dblR = _pDouble->get_(iRow, iCol) * dbl.real() - _pDouble->getImg_(iRow, iCol) * dbl.imag();
+            double dblI = _pDouble->getImg_(iRow, iCol) * dbl.real() + _pDouble->get_(iRow, iCol) * dbl.imag();
 
             std::complex<double> newVal(dblR, dblI);
             pOut->set(iRow, iCol, newVal);
@@ -1599,7 +1599,7 @@ int DotMultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOu
         int* piRank = new int[_pPoly1->getSize()];
         for (int i = 0 ; i < _pPoly1->getSize() ; i++)
         {
-            piRank[i] = _pPoly1->get(i)->getRank() + _pPoly2->get(i)->getRank();
+            piRank[i] = _pPoly1->get_(i)->getRank() + _pPoly2->get_(i)->getRank();
         }
 
         (*_pPolyOut) = new Polynom(_pPoly1->getVariableName(), _pPoly1->getDims(), _pPoly1->getDimsArray(), piRank);
@@ -1610,9 +1610,9 @@ int DotMultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOu
             (*_pPolyOut)->setComplex(true);
             for (int i = 0; i < _pPoly1->getSize(); i++)
             {
-                SinglePoly *pSP1    = _pPoly1->get(i);
-                SinglePoly *pSP2    = _pPoly2->get(i);
-                SinglePoly *pSPOut  = (*_pPolyOut)->get(i);
+                SinglePoly *pSP1    = _pPoly1->get_(i);
+                SinglePoly *pSP2    = _pPoly2->get_(i);
+                SinglePoly *pSPOut  = (*_pPolyOut)->get_(i);
 
                 pSPOut->setZeros();
 
@@ -1628,9 +1628,9 @@ int DotMultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOu
             (*_pPolyOut)->setComplex(true);
             for (int i = 0; i < _pPoly1->getSize(); i++)
             {
-                SinglePoly *pSP1   = _pPoly1->get(i);
-                SinglePoly *pSP2   = _pPoly2->get(i);
-                SinglePoly *pSPOut = (*_pPolyOut)->get(i);
+                SinglePoly *pSP1   = _pPoly1->get_(i);
+                SinglePoly *pSP2   = _pPoly2->get_(i);
+                SinglePoly *pSPOut = (*_pPolyOut)->get_(i);
 
                 pSPOut->setZeros();
 
@@ -1645,9 +1645,9 @@ int DotMultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOu
             (*_pPolyOut)->setComplex(true);
             for (int i = 0; i < _pPoly1->getSize(); i++)
             {
-                SinglePoly *pSP1   = _pPoly1->get(i);
-                SinglePoly *pSP2   = _pPoly2->get(i);
-                SinglePoly *pSPOut = (*_pPolyOut)->get(i);
+                SinglePoly *pSP1   = _pPoly1->get_(i);
+                SinglePoly *pSP2   = _pPoly2->get_(i);
+                SinglePoly *pSPOut = (*_pPolyOut)->get_(i);
 
                 pSPOut->setZeros();
 
@@ -1661,9 +1661,9 @@ int DotMultiplyPolyByPoly(Polynom* _pPoly1, Polynom* _pPoly2, Polynom** _pPolyOu
         {
             for (int i = 0; i < _pPoly1->getSize(); i++)
             {
-                SinglePoly *pSP1   = _pPoly1->get(i);
-                SinglePoly *pSP2   = _pPoly2->get(i);
-                SinglePoly *pSPOut = (*_pPolyOut)->get(i);
+                SinglePoly *pSP1   = _pPoly1->get_(i);
+                SinglePoly *pSP2   = _pPoly2->get_(i);
+                SinglePoly *pSPOut = (*_pPolyOut)->get_(i);
 
                 pSPOut->setZeros();
 

--- a/scilab/modules/ast/src/cpp/operations/types_opposite.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_opposite.cpp
@@ -228,8 +228,8 @@ types::InternalType* opposite_M<types::Polynom, types::Polynom>(types::Polynom *
 
     for (int i = 0 ; i < iSize ; ++i)
     {
-        types::SinglePoly* pSPL = _pL->get(i);
-        types::SinglePoly* pSPO = pOut->get(i);
+        types::SinglePoly* pSPL = _pL->get_(i);
+        types::SinglePoly* pSPO = pOut->get_(i);
         opposite(pSPL->get(), pSPL->getSize(), pSPO->get());
     }
     return pOut;
@@ -244,8 +244,8 @@ types::InternalType* opposite_MC<types::Polynom, types::Polynom>(types::Polynom 
 
     for (int i = 0 ; i < iSize ; ++i)
     {
-        types::SinglePoly* pSPL = _pL->get(i);
-        types::SinglePoly* pSPO = pOut->get(i);
+        types::SinglePoly* pSPL = _pL->get_(i);
+        types::SinglePoly* pSPO = pOut->get_(i);
         opposite(pSPL->get(), pSPL->getImg(), pSPL->getSize(), pSPO->get(), pSPO->getImg());
     }
     return pOut;

--- a/scilab/modules/ast/src/cpp/operations/types_or.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_or.cpp
@@ -453,7 +453,7 @@ void isValueTrue(T* _pL, types::Bool** _pOut)
 {
     for (int i = 0 ; i < _pL->getSize() ; i++)
     {
-        if (_pL->get(i) == 0)
+        if (_pL->get_(i) == 0)
         {
             //call non shortcut opearion
             *_pOut = NULL;
@@ -478,9 +478,9 @@ void isValueTrue(Double* _pL, Bool** _pOut)
 
     for (int i = 0 ; i < _pL->getSize() ; i++)
     {
-        if (_pL->get(i) == 0)
+        if (_pL->get_(i) == 0)
         {
-            if ( !_pL->isComplex() || (_pL->getImg(i) == 0) )
+            if ( !_pL->isComplex() || (_pL->getImg_(i) == 0) )
             {
                 // Any value is false, call non shortcut operation
                 *_pOut = NULL;

--- a/scilab/modules/ast/src/cpp/operations/types_power.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_power.cpp
@@ -250,7 +250,7 @@ int PowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoubleO
                 for (int i = 0 ; i < (*_pDoubleOut)->getSize() ; i++)
                 {
                     iPowerRealScalarByRealScalar(
-                        _pDouble1->get(i),
+                        _pDouble1->get_(i),
                         _pDouble2->getScalar_(),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i], &iComplex);
                 }
@@ -260,7 +260,7 @@ int PowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoubleO
                 for (int i = 0 ; i < (*_pDoubleOut)->getSize() ; i++)
                 {
                     iPowerRealScalarByComplexScalar(
-                        _pDouble1->get(i),
+                        _pDouble1->get_(i),
                         _pDouble2->getScalar_(), _pDouble2->getImgScalar_(),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
@@ -270,7 +270,7 @@ int PowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoubleO
                 for (int i = 0 ; i < (*_pDoubleOut)->getSize() ; i++)
                 {
                     iPowerComplexScalarByRealScalar(
-                        _pDouble1->get(i), _pDouble1->getImg(i),
+                        _pDouble1->get_(i), _pDouble1->getImg_(i),
                         _pDouble2->getScalar_(),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
@@ -280,7 +280,7 @@ int PowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoubleO
                 for (int i = 0 ; i < (*_pDoubleOut)->getSize() ; i++)
                 {
                     iPowerComplexScalarByComplexScalar(
-                        _pDouble1->get(i), _pDouble1->getImg(i),
+                        _pDouble1->get_(i), _pDouble1->getImg_(i),
                         _pDouble2->getScalar_(), _pDouble2->getImgScalar_(),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
@@ -365,7 +365,7 @@ int PowerPolyByDouble(Polynom* _pPoly, Double* _pDouble, InternalType** _pOut)
         _pPoly->getRank(&iRank);
         for (int i = 0 ; i < _pDouble->getSize() ; i++)
         {
-            int iInputRank = (int)_pDouble->get(i);
+            int iInputRank = (int)_pDouble->get_(i);
             if (iInputRank < 0)
             {
                 //call overload
@@ -383,10 +383,10 @@ int PowerPolyByDouble(Polynom* _pPoly, Double* _pDouble, InternalType** _pOut)
 
         for (int i = 0 ; i < _pDouble->getSize() ; i++)
         {
-            SinglePoly* pCoeffOut = pOut->get(i);
+            SinglePoly* pCoeffOut = pOut->get_(i);
 
             int iCurrentRank    = 0;
-            int iLoop           = (int)_pDouble->get(i);
+            int iLoop           = (int)_pDouble->get_(i);
 
             //initialize Out to 1
             pCoeffOut->set(0, 1);
@@ -475,7 +475,7 @@ int DotPowerSpaseByDouble(Sparse* _pSp, Double* _pDouble, InternalType** _pOut)
             for (int i = 0; i < iSize; i++)
             {
                 pDbl[i] = new Double(pdbl[0]);
-                pDblSp[i] = new Double(_pSp->getReal(iPositVal[i]), _pSp->getImg(iPositVal[i]).imag());
+                pDblSp[i] = new Double(_pSp->get(iPositVal[i]), _pSp->getImg(iPositVal[i]).imag());
             }
         }
     }
@@ -487,7 +487,7 @@ int DotPowerSpaseByDouble(Sparse* _pSp, Double* _pDouble, InternalType** _pOut)
             for (int i = 0; i < iSize; i++)
             {
                 pDbl[i] = new Double(pdbl[i], pdblImg[i]);
-                pDblSp[i] = new Double(_pSp->getReal(iPositVal[i]), _pSp->getImg(iPositVal[i]).imag());
+                pDblSp[i] = new Double(_pSp->get(iPositVal[i]), _pSp->getImg(iPositVal[i]).imag());
             }
         }
         else
@@ -495,7 +495,7 @@ int DotPowerSpaseByDouble(Sparse* _pSp, Double* _pDouble, InternalType** _pOut)
             for (int i = 0; i < iSize; i++)
             {
                 pDbl[i] = new Double(pdbl[i]);
-                pDblSp[i] = new Double(_pSp->getReal(iPositVal[i]), _pSp->getImg(iPositVal[i]).imag());
+                pDblSp[i] = new Double(_pSp->get(iPositVal[i]), _pSp->getImg(iPositVal[i]).imag());
             }
         }
     }
@@ -688,7 +688,7 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 {
                     iPowerComplexScalarByComplexScalar(
                         dblR1, dblI1,
-                        _pDouble2->get(i), _pDouble2->getImg(i),
+                        _pDouble2->get_(i), _pDouble2->getImg_(i),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
             }
@@ -699,7 +699,7 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 {
                     iPowerComplexScalarByRealScalar(
                         dblR1, dblI1,
-                        _pDouble2->get(i),
+                        _pDouble2->get_(i),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
             }
@@ -714,7 +714,7 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 {
                     iPowerRealScalarByComplexScalar(
                         dblR1,
-                        _pDouble2->get(i), _pDouble2->getImg(i),
+                        _pDouble2->get_(i), _pDouble2->getImg_(i),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
             }
@@ -725,7 +725,7 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                     int iComplex = 1;
                     iPowerRealScalarByRealScalar(
                         dblR1,
-                        _pDouble2->get(i),
+                        _pDouble2->get_(i),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i], &iComplex);
                     iResultComplex |= iComplex;
                 }
@@ -746,7 +746,7 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 for (int i = 0 ; i < _pDouble1->getSize() ; i++)
                 {
                     iPowerComplexScalarByComplexScalar(
-                        _pDouble1->get(i), _pDouble1->getImg(i),
+                        _pDouble1->get_(i), _pDouble1->getImg_(i),
                         dblR2, dblI2,
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
@@ -758,7 +758,7 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 for (int i = 0 ; i < _pDouble1->getSize() ; i++)
                 {
                     iPowerComplexScalarByRealScalar(
-                        _pDouble1->get(i), _pDouble1->getImg(i),
+                        _pDouble1->get_(i), _pDouble1->getImg_(i),
                         dblR2,
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
@@ -774,7 +774,7 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 for (int i = 0 ; i < _pDouble1->getSize() ; i++)
                 {
                     iPowerRealScalarByComplexScalar(
-                        _pDouble1->get(i),
+                        _pDouble1->get_(i),
                         dblR2, dblI2,
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
@@ -785,7 +785,7 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 {
                     int iComplex = 1;
                     iPowerRealScalarByRealScalar(
-                        _pDouble1->get(i),
+                        _pDouble1->get_(i),
                         dblR2,
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i], &iComplex);
                     iResultComplex |= iComplex;
@@ -825,8 +825,8 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 for (int i = 0 ; i < _pDouble1->getSize() ; i++)
                 {
                     iPowerComplexScalarByComplexScalar(
-                        _pDouble1->get(i), _pDouble1->getImg(i),
-                        _pDouble2->get(i), _pDouble2->getImg(i),
+                        _pDouble1->get_(i), _pDouble1->getImg_(i),
+                        _pDouble2->get_(i), _pDouble2->getImg_(i),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
             }
@@ -836,8 +836,8 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 for (int i = 0 ; i < _pDouble1->getSize() ; i++)
                 {
                     iPowerComplexScalarByRealScalar(
-                        _pDouble1->get(i), _pDouble1->getImg(i),
-                        _pDouble2->get(i),
+                        _pDouble1->get_(i), _pDouble1->getImg_(i),
+                        _pDouble2->get_(i),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
             }
@@ -850,8 +850,8 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 for (int i = 0 ; i < _pDouble1->getSize() ; i++)
                 {
                     iPowerRealScalarByComplexScalar(
-                        _pDouble1->get(i),
-                        _pDouble2->get(i), _pDouble2->getImg(i),
+                        _pDouble1->get_(i),
+                        _pDouble2->get_(i), _pDouble2->getImg_(i),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i]);
                 }
             }
@@ -861,8 +861,8 @@ int DotPowerDoubleByDouble(Double* _pDouble1, Double* _pDouble2, Double** _pDoub
                 {
                     int iComplex = 1;
                     iPowerRealScalarByRealScalar(
-                        _pDouble1->get(i),
-                        _pDouble2->get(i),
+                        _pDouble1->get_(i),
+                        _pDouble2->get_(i),
                         &(*_pDoubleOut)->get()[i], &(*_pDoubleOut)->getImg()[i], &iComplex);
                     iResultComplex |= iComplex;
                 }

--- a/scilab/modules/ast/src/cpp/operations/types_subtraction.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_subtraction.cpp
@@ -1149,7 +1149,7 @@ InternalType* sub_I_M(T *_pL, U *_pR)
         std::fill(piIndex, piIndex + iDims, i);
 
         int index = _pR->getIndex(piIndex);
-        sub(dblLeft, _pR->get(index), pOut->get() + index);
+        sub(dblLeft, _pR->get_(index), pOut->get() + index);
     }
 
     delete[] piIndex;
@@ -1472,11 +1472,11 @@ template<> InternalType* sub_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
             double* p1I = p1Coef->getImg();
             for (int i = 0 ; i < _pR->getSize() ; i++)
             {
-                SinglePoly* p2Coef   = _pR->get(i);
+                SinglePoly* p2Coef   = _pR->get_(i);
                 double* p2R          = p2Coef->get();
                 double* p2I          = p2Coef->getImg();
 
-                SinglePoly* pOutCoef = pOut->get(i);
+                SinglePoly* pOutCoef = pOut->get_(i);
                 pOutCoef->setComplex(isOutComplex);
                 double* pOutR        = pOutCoef->get();
                 double* pOutI        = pOutCoef->getImg();
@@ -1505,10 +1505,10 @@ template<> InternalType* sub_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
         {
             for (int i = 0 ; i < _pR->getSize() ; i++)
             {
-                SinglePoly* p2Coef   = _pR->get(i);
+                SinglePoly* p2Coef   = _pR->get_(i);
                 double* p2R          = p2Coef->get();
 
-                SinglePoly* pOutCoef = pOut->get(i);
+                SinglePoly* pOutCoef = pOut->get_(i);
                 double* pOutR        = pOutCoef->get();
 
                 for (int j = 0 ; j < pRankOut[i] + 1 ; j++)
@@ -1560,11 +1560,11 @@ template<> InternalType* sub_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
             double *p2I             = p2Coef->getImg();
             for (int i = 0 ; i < _pL->getSize() ; i++)
             {
-                SinglePoly *p1Coef      = _pL->get(i);
+                SinglePoly *p1Coef      = _pL->get_(i);
                 double *p1R             = p1Coef->get();
                 double *p1I             = p1Coef->getImg();
 
-                SinglePoly *pOutCoef    = pOut->get(i);
+                SinglePoly *pOutCoef    = pOut->get_(i);
                 pOutCoef->setComplex(isOutComplex);
                 double *pOutR           = pOutCoef->get();
                 double *pOutI           = pOutCoef->getImg();
@@ -1593,10 +1593,10 @@ template<> InternalType* sub_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
         {
             for (int i = 0 ; i < _pL->getSize() ; i++)
             {
-                SinglePoly *p1Coef      = _pL->get(i);
+                SinglePoly *p1Coef      = _pL->get_(i);
                 double *p1R             = p1Coef->get();
 
-                SinglePoly *pOutCoef    = pOut->get(i);
+                SinglePoly *pOutCoef    = pOut->get_(i);
                 double *pOutR           = pOutCoef->get();
 
                 for (int j = 0 ; j < pRankOut[i] + 1 ; j++)
@@ -1660,11 +1660,11 @@ template<> InternalType* sub_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
     //Result P1(i) - P2(i)
     for (int i = 0 ; i < _pL->getSize() ; i++)
     {
-        SinglePoly* pOutCoef = pOut->get(i);
+        SinglePoly* pOutCoef = pOut->get_(i);
         pOutCoef->setComplex(isOutComplex);
 
-        double *p1R     = _pL->get(i)->get();
-        double *p2R     = _pR->get(i)->get();
+        double *p1R     = _pL->get_(i)->get();
+        double *p2R     = _pR->get_(i)->get();
         double *pOutR   = pOutCoef->get();
         int iMin        = std::min(pRank1[i], pRank2[i]);
         int iMax        = std::max(pRank1[i], pRank2[i]);
@@ -1694,8 +1694,8 @@ template<> InternalType* sub_M_M<Polynom, Polynom, Polynom>(Polynom* _pL, Polyno
 
         if (isOutComplex)
         {
-            double *p1I     = _pL->get(i)->getImg();
-            double *p2I     = _pR->get(i)->getImg();
+            double *p1I     = _pL->get_(i)->getImg();
+            double *p2I     = _pR->get_(i)->getImg();
             double *pOutI   = pOutCoef->getImg();
 
             for (int j = 0 ; j < iMin + 1 ; j++)
@@ -1881,7 +1881,7 @@ template<> InternalType* sub_M_M<Polynom, Double, Polynom>(Polynom* _pL, Double*
         double* pInDblI = _pR->getImg();
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
-            SinglePoly *pSPOut   = pOut->get(i);
+            SinglePoly *pSPOut   = pOut->get_(i);
             double *pOutPolyR    = pSPOut->get();
             double *pOutPolyI    = pSPOut->getImg();
 
@@ -1895,7 +1895,7 @@ template<> InternalType* sub_M_M<Polynom, Double, Polynom>(Polynom* _pL, Double*
         pOut->setComplex(true);
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
-            SinglePoly *pSPOut   = pOut->get(i);
+            SinglePoly *pSPOut   = pOut->get_(i);
             double *pOutPolyR    = pSPOut->get();
             double *pOutPolyI    = pSPOut->getImg();
 
@@ -1907,7 +1907,7 @@ template<> InternalType* sub_M_M<Polynom, Double, Polynom>(Polynom* _pL, Double*
     {
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
-            SinglePoly *pSPOut = pOut->get(i);
+            SinglePoly *pSPOut = pOut->get_(i);
             double *pOutPolyR  = pSPOut->get();
 
             pOutPolyR[0] -= pInDblR[i];
@@ -2048,7 +2048,7 @@ template<> InternalType* sub_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
             SinglePoly *pInPoly  = _pR->getScalar_();
-            SinglePoly *pOutPoly = pOut->get(i);
+            SinglePoly *pOutPoly = pOut->get_(i);
             double *pInPolyR     = pInPoly->get();
             double *pOutPolyR    = pOutPoly->get();
 
@@ -2065,7 +2065,7 @@ template<> InternalType* sub_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
             for (int i = 0 ; i < pOut->getSize() ; i++)
             {
                 SinglePoly *pInPoly  = _pR->getScalar_();
-                SinglePoly *pOutPoly = pOut->get(i);
+                SinglePoly *pOutPoly = pOut->get_(i);
                 double *pInPolyI     = pInPoly->getImg();
                 double *pOutPolyI    = pOutPoly->getImg();
 
@@ -2098,7 +2098,7 @@ template<> InternalType* sub_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
         {
             for (int i = 0 ; i < iSize ; i++)
             {
-                SinglePoly *pSPOut   = pOut->get(i);
+                SinglePoly *pSPOut   = pOut->get_(i);
                 double *pOutPolyR    = pSPOut->get();
                 double *pOutPolyI    = pSPOut->getImg();
 
@@ -2111,7 +2111,7 @@ template<> InternalType* sub_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
             pOut->setComplex(true);
             for (int i = 0 ; i < iSize ; i++)
             {
-                SinglePoly *pSPOut   = pOut->get(i);
+                SinglePoly *pSPOut   = pOut->get_(i);
                 double *pOutPolyR    = pSPOut->get();
                 double *pOutPolyI    = pSPOut->getImg();
 
@@ -2123,7 +2123,7 @@ template<> InternalType* sub_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
         {
             for (int i = 0 ; i < iSize ; i++)
             {
-                SinglePoly *pSPOut = pOut->get(i);
+                SinglePoly *pSPOut = pOut->get_(i);
                 double *pOutPolyR  = pSPOut->get();
 
                 pOutPolyR[0] += pInDblR[0];
@@ -2167,7 +2167,7 @@ template<> InternalType* sub_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
     {
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
-            SinglePoly *pSPOut   = pOut->get(i);
+            SinglePoly *pSPOut   = pOut->get_(i);
             double *pOutPolyR    = pSPOut->get();
             double *pOutPolyI    = pSPOut->getImg();
 
@@ -2180,7 +2180,7 @@ template<> InternalType* sub_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
         pOut->setComplex(true);
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
-            SinglePoly *pSPOut   = pOut->get(i);
+            SinglePoly *pSPOut   = pOut->get_(i);
             double *pOutPolyR    = pSPOut->get();
             double *pOutPolyI    = pSPOut->getImg();
 
@@ -2192,7 +2192,7 @@ template<> InternalType* sub_M_M<Double, Polynom, Polynom>(Double* _pL, Polynom*
     {
         for (int i = 0 ; i < pOut->getSize() ; i++)
         {
-            SinglePoly *pSPOut = pOut->get(i);
+            SinglePoly *pSPOut = pOut->get_(i);
             double *pOutPolyR  = pSPOut->get();
 
             pOutPolyR[0] += pInDblR[i];
@@ -2359,8 +2359,8 @@ template<> InternalType* sub_M_M<Double, Sparse, Double>(Double* _pL, Sparse* _p
                 int iRow = static_cast<int>(pRows[i]) - 1;
                 int iCol = static_cast<int>(pCols[i]) - 1;
                 std::complex<double> dbl = _pR->getImg(iRow, iCol);
-                pOut->set(iRow, iCol, pOut->get(iRow, iCol) - dbl.real());
-                pOut->setImg(iRow, iCol, pOut->getImg(iRow, iCol) - dbl.imag());
+                pOut->set(iRow, iCol, pOut->get_(iRow, iCol) - dbl.real());
+                pOut->setImg(iRow, iCol, pOut->getImg_(iRow, iCol) - dbl.imag());
             }
         }
         else
@@ -2369,7 +2369,7 @@ template<> InternalType* sub_M_M<Double, Sparse, Double>(Double* _pL, Sparse* _p
             {
                 int iRow = static_cast<int>(pRows[i]) - 1;
                 int iCol = static_cast<int>(pCols[i]) - 1;
-                pOut->set(iRow, iCol, pOut->get(iRow, iCol) - _pR->get(iRow, iCol));
+                pOut->set(iRow, iCol, pOut->get_(iRow, iCol) - _pR->get(iRow, iCol));
             }
         }
 

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -759,8 +759,8 @@ void ArrayOf<T>::append(int _iRows, int _iCols, InternalType* _poSource)
             for (int j = 0; j < iCols; j++)
             {
                 int c = _iCols + j;
-                set_(r, c, pGT->get(i, j));
-                setImg_(r, c, pGT->getImg(i, j));
+                set_(r, c, pGT->get_(i, j));
+                setImg_(r, c, pGT->getImg_(i, j));
             }
         }
     }
@@ -771,7 +771,7 @@ void ArrayOf<T>::append(int _iRows, int _iCols, InternalType* _poSource)
             int r = _iRows + i;
             for (int j = 0; j < iCols; j++)
             {
-                set_(r, _iCols + j, pGT->get(i, j));
+                set_(r, _iCols + j, pGT->get_(i, j));
             }
         }
     }
@@ -934,10 +934,10 @@ GenericType* ArrayOf<T>::remove(typed_list* _pArgs)
                 int ii = piNotEntireIndex[i] - 1;
                 for (int j = last; j < ii; ++j)
                 {
-                    pOut->set_(iNewPos, get(j));
+                    pOut->set_(iNewPos, get_(j));
                     if (m_pImgData != NULL)
                     {
-                        pOut->setImg_(iNewPos, getImg(j));
+                        pOut->setImg_(iNewPos, getImg_(j));
                     }
                     iNewPos++;
                 }
@@ -947,10 +947,10 @@ GenericType* ArrayOf<T>::remove(typed_list* _pArgs)
 
             for (int i = last; i < size; ++i)
             {
-                pOut->set_(iNewPos, get(i));
+                pOut->set_(iNewPos, get_(i));
                 if (m_pImgData != NULL)
                 {
-                    pOut->setImg_(iNewPos, getImg(i));
+                    pOut->setImg_(iNewPos, getImg_(i));
                 }
                 iNewPos++;
             }
@@ -988,10 +988,10 @@ GenericType* ArrayOf<T>::remove(typed_list* _pArgs)
             if (bByPass == false)
             {
                 //compute new index
-                pOut->set_(iNewPos, get(i));
+                pOut->set_(iNewPos, get_(i));
                 if (m_pImgData != NULL)
                 {
-                    pOut->setImg_(iNewPos, getImg(i));
+                    pOut->setImg_(iNewPos, getImg_(i));
                 }
                 iNewPos++;
             }
@@ -1036,10 +1036,10 @@ GenericType* ArrayOf<T>::extract(typed_list* _pArgs)
 
         static int dims[2] = {1, 1};
         pOut = createEmpty(2, dims, isComplex());;
-        pOut->set_(0, get(index));
+        pOut->set_(0, get_(index));
         if (m_pImgData)
         {
-            pOut->setImg_(0, getImg(index));
+            pOut->setImg_(0, getImg_(index));
         }
 
         return pOut;
@@ -1088,8 +1088,8 @@ GenericType* ArrayOf<T>::extract(typed_list* _pArgs)
             for (int i = 0; i < size; ++i)
             {
                 int index = static_cast<int>(idx) - 1;
-                pOut->set_(i, get(index));
-                pOut->setImg_(i, getImg(index));
+                pOut->set_(i, get_(index));
+                pOut->setImg_(i, getImg_(index));
                 idx += step;
             }
         }
@@ -1097,7 +1097,7 @@ GenericType* ArrayOf<T>::extract(typed_list* _pArgs)
         {
             for (int i = 0; i < size; ++i)
             {
-                pOut->set_(i, get(static_cast<int>(idx) - 1));
+                pOut->set_(i, get_(static_cast<int>(idx) - 1));
                 idx += step;
             }
         }
@@ -1135,8 +1135,8 @@ GenericType* ArrayOf<T>::extract(typed_list* _pArgs)
                     return NULL;
                 }
 
-                pOut->set_(idx, get(i));
-                pOut->setImg_(idx, getImg(i));
+                pOut->set_(idx, get_(i));
+                pOut->setImg_(idx, getImg_(i));
                 ++idx;
             }
         }
@@ -1145,7 +1145,7 @@ GenericType* ArrayOf<T>::extract(typed_list* _pArgs)
             int idx = 0;
             for (int & i : indexes)
             {
-                pOut->set_(idx, get(i));
+                pOut->set_(idx, get_(i));
                 ++idx;
             }
         }
@@ -1351,10 +1351,10 @@ GenericType* ArrayOf<T>::extract(typed_list* _pArgs)
             }
         }
 
-        pOut->set_(i, get(iPos));
+        pOut->set_(i, get_(iPos));
         if (m_pImgData != NULL)
         {
-            pOut->setImg_(i, getImg(iPos));
+            pOut->setImg_(i, getImg_(iPos));
         }
 
 

--- a/scilab/modules/ast/src/cpp/types/cell.cpp
+++ b/scilab/modules/ast/src/cpp/types/cell.cpp
@@ -108,7 +108,7 @@ Cell::Cell(Cell *_oCellCopyMe)
 
     for (int i = 0 ; i < getSize() ; i++)
     {
-        set_(i, _oCellCopyMe->get(i)->clone());
+        set_(i, _oCellCopyMe->get_(i)->clone());
     }
 #ifndef NDEBUG
     Inspector::addItem(this);
@@ -303,7 +303,7 @@ bool Cell::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_iDi
                 _piDims[1] = j;
 
                 int iPos = getIndex(_piDims);
-                InternalType* pIT = get(iPos);
+                InternalType* pIT = get_(iPos);
 
                 if (pIT->isAssignable())
                 {
@@ -342,7 +342,7 @@ bool Cell::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_iDi
                 _piDims[0] = i;
                 _piDims[1] = j;
                 int iPos = getIndex(_piDims);
-                InternalType* pIT = get(iPos);
+                InternalType* pIT = get_(iPos);
 
                 ostr << L"  [";
                 if (pIT->isAssignable())
@@ -416,7 +416,7 @@ bool Cell::operator==(const InternalType& it)
 
     for (int i = 0 ; i < getSize() ; i++)
     {
-        if (get(i) != pC->get(i))
+        if (get_(i) != pC->get_(i))
         {
             return false;
         }
@@ -442,7 +442,7 @@ List* Cell::extractCell(typed_list* _pArgs)
     Cell* pCell = pIT->getAs<Cell>();
     for (int i = 0 ; i < pCell->getSize() ; i++)
     {
-        pList->append(pCell->get(i));
+        pList->append(pCell->get_(i));
     }
     pCell->killMe();
     return pList;

--- a/scilab/modules/ast/src/cpp/types/graphichandle.cpp
+++ b/scilab/modules/ast/src/cpp/types/graphichandle.cpp
@@ -83,7 +83,7 @@ GraphicHandle* GraphicHandle::clone()
     GraphicHandle* pGH = new GraphicHandle(getDims(), getDimsArray());
     for (int i = 0 ; i < getSize() ; i++)
     {
-        pGH->set_(i, get(i));
+        pGH->set_(i, get_(i));
     }
     return pGH;
 }
@@ -112,7 +112,7 @@ bool GraphicHandle::operator==(const InternalType& it)
 
     for (int i = 0 ; i < getSize() ; i++)
     {
-        if (get(i) == pGH->get(i))
+        if (get_(i) == pGH->get_(i))
         {
             return false;
         }

--- a/scilab/modules/ast/src/cpp/types/list.cpp
+++ b/scilab/modules/ast/src/cpp/types/list.cpp
@@ -175,7 +175,7 @@ InternalType* List::extract(typed_list* _pArgs)
 
     for (int i = 0 ; i < iSeqCount ; i++)
     {
-        int idx = (int)pArg[0]->getAs<Double>()->get(i);
+        int idx = (int)pArg[0]->getAs<Double>()->get_(i);
         if (idx > getSize() || idx < 1)
         {
             delete outList;

--- a/scilab/modules/ast/src/cpp/types/mlist.cpp
+++ b/scilab/modules/ast/src/cpp/types/mlist.cpp
@@ -1,8 +1,8 @@
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2010-2010 - DIGITEO - Antoine ELIAS
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2010-2010 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -43,7 +43,7 @@ bool MList::invoke(typed_list & in, optional_list & /*opt*/, int /*_iRetCount*/,
             String * pString = arg->getAs<types::String>();
             for (int i = 0; i < pString->getSize(); ++i)
             {
-                stFields.push_back(pString->get(i));
+                stFields.push_back(pString->get_(i));
             }
 
             _out = extractStrings(stFields);

--- a/scilab/modules/ast/src/cpp/types/polynom.cpp
+++ b/scilab/modules/ast/src/cpp/types/polynom.cpp
@@ -222,7 +222,7 @@ void Polynom::setComplex(bool _bComplex)
     {
         for (int i = 0 ; i < getSize() ; i++)
         {
-            get(i)->setComplex(_bComplex);
+            get_(i)->setComplex(_bComplex);
         }
     }
 }
@@ -307,7 +307,7 @@ Double* Polynom::evaluate(Double* _pdblValue)
                     double OutR = 0;
                     double OutI = 0;
 
-                    SinglePoly *pPoly = get(iPolyRow, iPolyCol);
+                    SinglePoly *pPoly = get_(iPolyRow, iPolyCol);
                     if (pReturn->isComplex())
                     {
                         pPoly->evaluate(pR[iCol * iRows + iRow], pI[iCol * iRows + iRow], &OutR, &OutI);
@@ -547,11 +547,11 @@ std::wstring Polynom::getMatrixString(int* _piDims, int /*_iDims*/, bool _bCompl
             int iPos = getIndex(_piDims);
             if (_bComplex)
             {
-                get(iPos)->toStringImg(getVariableName(), &listExpR, &listCoefR);
+                get_(iPos)->toStringImg(getVariableName(), &listExpR, &listCoefR);
             }
             else
             {
-                get(iPos)->toStringReal(getVariableName(), &listExpR, &listCoefR);
+                get_(iPos)->toStringReal(getVariableName(), &listExpR, &listCoefR);
             }
 
             if (listExpR.size() > 1)
@@ -594,11 +594,11 @@ std::wstring Polynom::getMatrixString(int* _piDims, int /*_iDims*/, bool _bCompl
                     int iPos = getIndex(_piDims);
                     if (_bComplex)
                     {
-                        get(iPos)->toStringImg(getVariableName(), &listExpR, &listCoefR);
+                        get_(iPos)->toStringImg(getVariableName(), &listExpR, &listCoefR);
                     }
                     else
                     {
-                        get(iPos)->toStringReal(getVariableName(), &listExpR, &listCoefR);
+                        get_(iPos)->toStringReal(getVariableName(), &listExpR, &listCoefR);
                     }
 
                     if (listCoefR.size() > 1)
@@ -668,11 +668,11 @@ std::wstring Polynom::getMatrixString(int* _piDims, int /*_iDims*/, bool _bCompl
             int iPos = getIndex(_piDims);
             if (_bComplex)
             {
-                get(iPos)->toStringImg( getVariableName(), &listExpR, &listCoefR);
+                get_(iPos)->toStringImg( getVariableName(), &listExpR, &listCoefR);
             }
             else
             {
-                get(iPos)->toStringReal(getVariableName(), &listExpR, &listCoefR);
+                get_(iPos)->toStringReal(getVariableName(), &listExpR, &listCoefR);
             }
 
             if (listCoefR.size() > 1)
@@ -747,11 +747,11 @@ std::wstring Polynom::getRowString(int* _piDims, int /*_iDims*/, bool _bComplex)
         int iPos = getIndex(_piDims);
         if (_bComplex)
         {
-            get(iPos)->toStringImg(getVariableName(), &listExpR, &listCoefR);
+            get_(iPos)->toStringImg(getVariableName(), &listExpR, &listCoefR);
         }
         else
         {
-            get(iPos)->toStringReal(getVariableName(), &listExpR, &listCoefR);
+            get_(iPos)->toStringReal(getVariableName(), &listExpR, &listCoefR);
         }
 
         if (iLen != 0 && static_cast<int>(listExpR.front().size()) + iLen >= iLineLen - 1)
@@ -821,11 +821,11 @@ std::wstring Polynom::getColString(int* _piDims, int /*_iDims*/, bool _bComplex)
         int iPos = getIndex(_piDims);
         if (_bComplex)
         {
-            get(iPos)->toStringImg(getVariableName(), &listExpR, &listCoefR);
+            get_(iPos)->toStringImg(getVariableName(), &listExpR, &listCoefR);
         }
         else
         {
-            get(iPos)->toStringReal(getVariableName(), &listExpR, &listCoefR);
+            get_(iPos)->toStringReal(getVariableName(), &listExpR, &listCoefR);
         }
 
         for (it_Coef = listCoefR.begin(), it_Exp = listExpR.begin() ; it_Coef != listCoefR.end() ; ++it_Coef, ++it_Exp)
@@ -924,8 +924,8 @@ bool Polynom::operator==(const InternalType& it)
 
     for (int i = 0 ; i < getSize() ; i++)
     {
-        SinglePoly* p1 = get(i);
-        SinglePoly* p2 = pM->get(i);
+        SinglePoly* p1 = get_(i);
+        SinglePoly* p2 = pM->get_(i);
 
         if (*p1 != *p2)
         {

--- a/scilab/modules/ast/src/cpp/types/singlestruct.cpp
+++ b/scilab/modules/ast/src/cpp/types/singlestruct.cpp
@@ -150,7 +150,7 @@ InternalType* SingleStruct::insert(typed_list* _pArgs, InternalType* _pSource)
     String* pstKey = (*_pArgs)[0]->getAs<String>();
     for (int i = 0 ; i < pstKey->getSize() ; ++i)
     {
-        set(pstKey->get(i), _pSource);
+        set(pstKey->get_(i), _pSource);
     }
 
     return this;

--- a/scilab/modules/ast/src/cpp/types/string.cpp
+++ b/scilab/modules/ast/src/cpp/types/string.cpp
@@ -162,7 +162,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
         _piDims[1]  = 0;
 
         int iPos = getIndex(_piDims);
-        wchar_t* wcsStr = get(iPos);
+        wchar_t* wcsStr = get_(iPos);
         int iCurLen = static_cast<int>(wcslen(wcsStr));
         iMaxLen = std::max(iMaxLen, iCurLen);
         iMaxLen = std::min(iMaxLen, iStrMaxSize);
@@ -199,7 +199,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
             _piDims[1] = 0;
             _piDims[0] = i;
             int iPos = getIndex(_piDims);
-            iMaxLen = std::max(iMaxLen, static_cast<int>(wcslen(get(iPos))));
+            iMaxLen = std::max(iMaxLen, static_cast<int>(wcslen(get_(iPos))));
             iMaxLen = std::min(iMaxLen, iStrMaxSize);
         }
 
@@ -224,7 +224,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
             _piDims[1] = 0;
             _piDims[0] = i;
             int iPos = getIndex(_piDims);
-            wchar_t* wcsStr = get(iPos);
+            wchar_t* wcsStr = get_(iPos);
             int iCurLen = static_cast<int>(wcslen(wcsStr));
 
             ostr << L"!";
@@ -273,7 +273,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
             int iPos = getIndex(_piDims);
 
             int iLen = 0;
-            int iCurLen = static_cast<int>(wcslen(get(iPos)));
+            int iCurLen = static_cast<int>(wcslen(get_(iPos)));
             iLen = iCurLen + SIZE_BETWEEN_TWO_STRING_VALUES + static_cast<int>(ostemp.str().size());
             if (iLen > iLineLen && iLastVal != i)
             {
@@ -294,7 +294,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
             // Manage case where string length is greater than max line size.
             if (iStrMaxSize < iCurLen)
             {
-                wchar_t* wcsStr = get(iPos);
+                wchar_t* wcsStr = get_(iPos);
                 int iStrPos = 0;
                 while (iCurLen > iStrMaxSize) // -2 because of two "!"
                 {
@@ -310,7 +310,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
             else
             {
                 configureStream(&ostemp, iCurLen + 2, iPrecision, ' ');
-                ostemp << std::left << get(iPos);
+                ostemp << std::left << get_(iPos);
             }
         }
 
@@ -338,7 +338,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
                 _piDims[1] = iCols1;
                 _piDims[0] = iRows1;
                 int iPos = getIndex(_piDims);
-                piSize[iCols1] = std::max(piSize[iCols1], static_cast<int>(wcslen(get(iPos))));
+                piSize[iCols1] = std::max(piSize[iCols1], static_cast<int>(wcslen(get_(iPos))));
                 piSize[iCols1] = std::min(piSize[iCols1], iStrMaxSize);
             }
 
@@ -379,7 +379,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
                         _piDims[0] = iRows2;
                         _piDims[1] = iCols2;
                         int iPos = getIndex(_piDims);
-                        wchar_t* wcsStr = get(iPos);
+                        wchar_t* wcsStr = get_(iPos);
                         int iLenStr = static_cast<int>(wcslen(wcsStr));
 
                         // Manage case where string length is greater than max line size.
@@ -400,7 +400,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
                         else
                         {
                             configureStream(&ostemp, piSize[iCols2], iPrecision, ' ');
-                            ostemp << std::left << get(iPos) << spaces;
+                            ostemp << std::left << get_(iPos) << spaces;
                         }
                     }
                     ostemp << L"!\n";
@@ -468,7 +468,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
                 _piDims[0] = iRows2;
                 _piDims[1] = iCols2;
                 int iPos = getIndex(_piDims);
-                wchar_t* wcsStr = get(iPos);
+                wchar_t* wcsStr = get_(iPos);
                 int iLenStr = static_cast<int>(wcslen(wcsStr));
 
                 // Manage case where string length is greater than max line size.
@@ -490,7 +490,7 @@ bool String::subMatrixToString(std::wostringstream& ostr, int* _piDims, int /*_i
                 else
                 {
                     configureStream(&ostemp, piSize[iCols2], iPrecision, ' ');
-                    ostemp << std::left << get(iPos) << spaces;
+                    ostemp << std::left << get_(iPos) << spaces;
                     iLen += piSize[iCols2] + static_cast<int>(spaces.size());
                 }
             }

--- a/scilab/modules/ast/src/cpp/types/struct.cpp
+++ b/scilab/modules/ast/src/cpp/types/struct.cpp
@@ -98,7 +98,7 @@ Struct::Struct(Struct *_oStructCopyMe)
     create(_oStructCopyMe->getDimsArray(), _oStructCopyMe->getDims(), &pIT, NULL);
     for (int i = 0 ; i < getSize() ; i++)
     {
-        pIT[i] = _oStructCopyMe->get(i)->clone();
+        pIT[i] = _oStructCopyMe->get_(i)->clone();
         pIT[i]->IncreaseRef();
     }
 #ifndef NDEBUG
@@ -171,7 +171,7 @@ bool Struct::invoke(typed_list & in, optional_list & opt, int _iRetCount, typed_
             String * pString = arg->getAs<types::String>();
             for (int i = 0; i < pString->getSize(); ++i)
             {
-                std::wstring wstField(pString->get(i));
+                std::wstring wstField(pString->get_(i));
                 if (this->exists(wstField))
                 {
                     wstFields.push_back(wstField);
@@ -345,7 +345,7 @@ bool Struct::operator==(const InternalType& it)
 
     for (int i = 0 ; i < getSize() ; i++)
     {
-        if (*get(i) != *pStr->get(i))
+        if (*get_(i) != *pStr->get_(i))
         {
             return false;
         }
@@ -437,7 +437,7 @@ Struct* Struct::addField(const std::wstring& _sKey)
 
     for (int i = 0 ; i < getSize() ; i++)
     {
-        get(i)->addField(_sKey);
+        get_(i)->addField(_sKey);
     }
 
     return this;
@@ -453,7 +453,7 @@ Struct* Struct::addFieldFront(const std::wstring& _sKey)
 
     for (int i = 0 ; i < getSize() ; i++)
     {
-        get(i)->addFieldFront(_sKey);
+        get_(i)->addFieldFront(_sKey);
     }
 
     return this;
@@ -486,7 +486,7 @@ bool Struct::toString(std::wostringstream& ostr)
 
         for (int i = 0 ; i < pwstFields->getSize() ; i++)
         {
-            std::wstring wstField(pwstFields->get(i));
+            std::wstring wstField(pwstFields->get_(i));
             InternalType* pIT = pSS->get(wstField);
 
             //                ostr << L"  " << wstField << ": ";
@@ -513,7 +513,7 @@ bool Struct::toString(std::wostringstream& ostr)
         ostr <<  L"fields:" << L"\n";
         for (int i = 0 ; i < pwstFields->getSize() ; i++)
         {
-            ostr << L"    " << pwstFields->get(i) << L"\n";
+            ostr << L"    " << pwstFields->get_(i) << L"\n";
         }
         pwstFields->killMe();
     }
@@ -603,7 +603,7 @@ std::vector<InternalType*> Struct::extractFields(typed_list* _pArgs)
 
     for (int i = 0 ; i < iSeqCount ; i++)
     {
-        int iIndex = (int)pIndex->get(i);
+        int iIndex = (int)pIndex->get_(i);
 
         if (iIndex == 1)
         {
@@ -702,7 +702,7 @@ Struct* Struct::resize(int* _piDims, int _iDims)
         {
             for (int iterStruct = 0; iterStruct < getSize(); iterStruct++)
             {
-                get(iterStruct)->addField(pFields->get(iterField));
+                get_(iterStruct)->addField(pFields->get_(iterField));
             }
         }
 

--- a/scilab/modules/ast/src/cpp/types/tlist.cpp
+++ b/scilab/modules/ast/src/cpp/types/tlist.cpp
@@ -76,7 +76,7 @@ bool TList::exists(const std::wstring& _sKey)
     //first field is the tlist type
     for (int i = 1 ; i < pS->getSize() ; i++)
     {
-        if (wcscmp(pS->get(i), _sKey.c_str()) == 0)
+        if (wcscmp(pS->get_(i), _sKey.c_str()) == 0)
         {
             return true;
         }
@@ -118,7 +118,7 @@ bool TList::invoke(typed_list & in, optional_list & /*opt*/, int _iRetCount, typ
             String * pString = arg->getAs<types::String>();
             for (int i = 0; i < pString->getSize(); ++i)
             {
-                stFields.push_back(pString->get(i));
+                stFields.push_back(pString->get_(i));
             }
 
             _out = extractStrings(stFields);
@@ -232,7 +232,7 @@ int TList::getIndexFromString(const std::wstring& _sKey)
     //first field is the tlist type
     for (int i = 1 ; i < pS->getSize() ; i++)
     {
-        if (wcscmp(pS->get(i), _sKey.c_str()) == 0)
+        if (wcscmp(pS->get_(i), _sKey.c_str()) == 0)
         {
             return i;
         }


### PR DESCRIPTION
- implemented `ArrayOf<T>::{get_,getImg_}`
- replaced `get, getImg` by `get_, getImg_` (wip)
