### PR TITLE
Fix #112: Replaced {Min,Max} by std::{min,max} in C++ code

### DIFF
--- a/scilab/modules/ast/includes/system_env/configvariable.hxx
+++ b/scilab/modules/ast/includes/system_env/configvariable.hxx
@@ -35,7 +35,6 @@ extern "C"
 {
 #include "dynamiclibrary.h"
 #include "dynlib_ast.h"
-#include "core_math.h"
 }
 
 // Minimal values for iConsoleLines & iConsoleWidth
@@ -178,7 +177,7 @@ private :
 public :
     static void setConsoleWidth(int _iConsoleWidth)
     {
-        m_iConsoleWidth = Max(ICONSOLEWIDTH_MIN, _iConsoleWidth);
+        m_iConsoleWidth = std::max(ICONSOLEWIDTH_MIN, _iConsoleWidth);
     }
     
     static int getConsoleWidth(void)
@@ -193,7 +192,7 @@ private :
 public :
     static void setConsoleLines(int _iConsoleLines)
     {
-        m_iConsoleLines = Max(ICONSOLELINES_MIN, _iConsoleLines);
+        m_iConsoleLines = std::max(ICONSOLELINES_MIN, _iConsoleLines);
     }
 
     static int getConsoleLines(void)

--- a/scilab/modules/elementary_functions/src/cpp/clean.cpp
+++ b/scilab/modules/elementary_functions/src/cpp/clean.cpp
@@ -15,6 +15,7 @@
 /*--------------------------------------------------------------------------*/
 
 #include <cmath>
+#include <algorithm>
 #include "clean.hxx"
 
 extern "C"
@@ -28,7 +29,7 @@ void clean(double* pdblReal, double* pdblImg, int iSize, double dEpsA, double dE
     if (pdblImg)
     {
         double dNorm = wasums(iSize, pdblReal, pdblImg);
-        double dEps = Max(dEpsA, dEpsR * dNorm);
+        double dEps = std::max(dEpsA, dEpsR * dNorm);
         for (int i = 0 ; i < iSize ; i++)
         {
             if (std::abs(pdblImg[i]) <= dEps)
@@ -46,7 +47,7 @@ void clean(double* pdblReal, double* pdblImg, int iSize, double dEpsA, double dE
     {
         int iOne = 1;
         double dNorm = C2F(dasum)(&iSize, pdblReal, &iOne);
-        double dEps = Max(dEpsA, dEpsR * dNorm);
+        double dEps = std::max(dEpsA, dEpsR * dNorm);
         for (int i = 0 ; i < iSize ; i++)
         {
             if (std::abs(pdblReal[i]) <= dEps)

--- a/scilab/modules/elementary_functions/src/cpp/diag.hxx
+++ b/scilab/modules/elementary_functions/src/cpp/diag.hxx
@@ -1,8 +1,8 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2012-2014 - DIGITEO - cedric delamarre
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2012-2014 - DIGITEO - cedric delamarre
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 #ifndef __DIAG_H__
 #define __DIAG_H__
@@ -45,12 +45,12 @@ types::InternalType* diag(bigT* pIn,  int iStartPos)
     {
         if (iStartPos < 0)
         {
-            iSize = Max(0, Min(iRows + iStartPos, iCols));
+            iSize = std::max(0, std::min(iRows + iStartPos, iCols));
             iStartRow = -iStartPos;
         }
         else
         {
-            iSize = Max(0, Min(iRows, iCols - iStartPos));
+            iSize = std::max(0, std::min(iRows, iCols - iStartPos));
             iStartCol = iStartPos;
         }
 
@@ -89,7 +89,7 @@ types::InternalType* diag(bigT* pIn,  int iStartPos)
     }
     else // pIn is a vector
     {
-        int iSizeOfVector = Max(iRows, iCols);
+        int iSizeOfVector = std::max(iRows, iCols);
         if (iStartPos < 0)
         {
             iSize = iSizeOfVector - iStartPos;

--- a/scilab/modules/gui/sci_gateway/cpp/sci_ClipBoard.cpp
+++ b/scilab/modules/gui/sci_gateway/cpp/sci_ClipBoard.cpp
@@ -15,6 +15,8 @@
  *
  */
 
+#include <algorithm>
+
 extern "C"
 {
 #include <string.h>
@@ -49,7 +51,7 @@ int sci_ClipBoard(char *fname, void* pvApiCtx)
     char* param1 = NULL;
     char* param2 = NULL;
 
-    nbInputArgument(pvApiCtx) = Max(0, nbInputArgument(pvApiCtx));
+    nbInputArgument(pvApiCtx) = std::max(0, nbInputArgument(pvApiCtx));
     CheckInputArgument(pvApiCtx, 0, 2);
     CheckOutputArgument(pvApiCtx, 0, 1);
 

--- a/scilab/modules/hdf5/src/cpp/handle_properties.cpp
+++ b/scilab/modules/hdf5/src/cpp/handle_properties.cpp
@@ -1,8 +1,8 @@
 /*
-* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-* Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 #include <vector>
 #include <string>
@@ -1256,10 +1256,10 @@ static void updateXYDataBounds(double rect[6], int axes = -1)
         double * dataBounds = NULL;
         getGraphicObjectProperty(axes, __GO_DATA_BOUNDS__, jni_double_vector, (void **)&dataBounds);
 
-        rect[0] = Min(rect[0], dataBounds[0]);
-        rect[1] = Max(rect[1], dataBounds[1]);
-        rect[2] = Min(rect[2], dataBounds[2]);
-        rect[3] = Max(rect[3], dataBounds[3]);
+        rect[0] = std::min(rect[0], dataBounds[0]);
+        rect[1] = std::max(rect[1], dataBounds[1]);
+        rect[2] = std::min(rect[2], dataBounds[2]);
+        rect[3] = std::max(rect[3], dataBounds[3]);
         rect[4] = dataBounds[4];
         rect[5] = dataBounds[5];
     }


### PR DESCRIPTION
fixes #112 