### PR TITLE
Enforce Usage of empty() and clear() with C++ strings

### DIFF
--- a/scilab/modules/ast/includes/system_env/configvariable.hxx
+++ b/scilab/modules/ast/includes/system_env/configvariable.hxx
@@ -292,10 +292,10 @@ public :
     {
         //if (m_bLastErrorCall == false)
         {
-            m_wstError          = L"";
+            m_wstError.clear();
             m_iError            = 0;
             m_iErrorLine        = 0;
-            m_wstErrorFunction  = L"";
+            m_wstErrorFunction.clear();
         }
         m_bLastErrorCall = false;
     }

--- a/scilab/modules/ast/src/cpp/ast/debuggervisitor.cpp
+++ b/scilab/modules/ast/src/cpp/ast/debuggervisitor.cpp
@@ -1,8 +1,8 @@
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -224,7 +224,7 @@ void DebuggerVisitor::visit(const SeqExp  &e)
                     }
                     catch (const InternalError& ie)
                     {
-                        if (ConfigVariable::getLastErrorFunction() == L"")
+                        if (ConfigVariable::getLastErrorFunction().empty())
                         {
                             ConfigVariable::setLastErrorFunction(pCall->getName());
                             ConfigVariable::setLastErrorLine(e.getLocation().first_line);

--- a/scilab/modules/ast/src/cpp/ast/macrovarvisitor.cpp
+++ b/scilab/modules/ast/src/cpp/ast/macrovarvisitor.cpp
@@ -1,8 +1,8 @@
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2013 - Scilab Enterprises - Antoine ELIAS
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2013 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -154,7 +154,7 @@ std::list<std::wstring>& MacrovarVisitor::getLocal()
 
 void MacrovarVisitor::add(std::list<std::wstring>& lst)
 {
-    if (m_current == L"")
+    if (m_current.empty())
     {
         return;
     }

--- a/scilab/modules/ast/src/cpp/ast/run_SeqExp.hpp
+++ b/scilab/modules/ast/src/cpp/ast/run_SeqExp.hpp
@@ -159,7 +159,7 @@ void RunVisitorT<T>::visitprivate(const SeqExp  &e)
                     }
                     catch (const InternalError& ie)
                     {
-                        if (ConfigVariable::getLastErrorFunction() == L"")
+                        if (ConfigVariable::getLastErrorFunction().empty())
                         {
                             ConfigVariable::setLastErrorFunction(pCall->getName());
                             ConfigVariable::setLastErrorLine(e.getLocation().first_line);

--- a/scilab/modules/ast/src/cpp/symbol/variables.cpp
+++ b/scilab/modules/ast/src/cpp/symbol/variables.cpp
@@ -1,8 +1,8 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 #include <algorithm>
 #include "variables.hxx"
@@ -391,7 +391,7 @@ int Variables::getFunctionList(std::list<Symbol>& lst, std::wstring _stModuleNam
         if ((var.second->top()->m_iLevel == _iLevel || _iLevel == 1) && var.second->top()->m_pIT->isCallable())
         {
             types::Callable* pCall = var.second->top()->m_pIT->getAs<types::Callable>();
-            if (_stModuleName == L"" || _stModuleName == pCall->getModule())
+            if (_stModuleName.empty() || _stModuleName == pCall->getModule())
             {
                 lst.push_back(var.first);
             }
@@ -413,7 +413,7 @@ int Variables::getFunctionList(std::list<types::Callable *>& lst, std::wstring _
         if ((var.second->top()->m_iLevel == _iLevel || _iLevel == 1) && var.second->top()->m_pIT->isCallable())
         {
             types::Callable * pCall = var.second->top()->m_pIT->getAs<types::Callable>();
-            if (_stModuleName == L"" || _stModuleName == pCall->getModule())
+            if (_stModuleName.empty() || _stModuleName == pCall->getModule())
             {
                 lst.push_back(pCall);
             }

--- a/scilab/modules/ast/src/cpp/system_env/configvariable.cpp
+++ b/scilab/modules/ast/src/cpp/system_env/configvariable.cpp
@@ -826,7 +826,7 @@ void ConfigVariable::whereErrorToString(std::wostringstream &ostr)
             where.m_file_name.replace(pos, pos + 4, L".sci");
             if (FileExistW(const_cast<wchar_t*>(where.m_file_name.c_str())) == false)
             {
-                where.m_file_name = L"";
+                where.m_file_name.clear();
             }
         }
     }

--- a/scilab/modules/ast/src/cpp/system_env/configvariable.cpp
+++ b/scilab/modules/ast/src/cpp/system_env/configvariable.cpp
@@ -820,7 +820,7 @@ void ConfigVariable::whereErrorToString(std::wostringstream &ostr)
         iLenName = std::max((int)where.m_name.length(), iLenName);
 
         // in case of bin file, the file path and line is displayed only if the associated .sci file exists
-        if (where.m_file_name != L"" && where.m_file_name.find(L".bin") != std::wstring::npos)
+        if (!where.m_file_name.empty() && where.m_file_name.find(L".bin") != std::wstring::npos)
         {
             std::size_t pos = where.m_file_name.find_last_of(L".");
             where.m_file_name.replace(pos, pos + 4, L".sci");
@@ -891,7 +891,7 @@ void ConfigVariable::whereErrorToString(std::wostringstream &ostr)
         ostr.width(iLenName);
         ostr << where.m_name;
 
-        if (where.m_file_name != L"")
+        if (!where.m_file_name.empty())
         {
             // -1 because the first line of a function dec is : "function myfunc()"
             ostr << L"( " << where.m_file_name << L" " << _W("line") << L" " << where.m_macro_first_line + where.m_line - 1 << L" )";

--- a/scilab/modules/ast/src/cpp/system_env/sci_home.cpp
+++ b/scilab/modules/ast/src/cpp/system_env/sci_home.cpp
@@ -60,7 +60,7 @@ wchar_t* getSCIHOMEW(void)
 char* getSCIHOME(void)
 {
     std::wstring tmpSCIHOME = ConfigVariable::getSCIHOME();
-    if (tmpSCIHOME == L"")
+    if (tmpSCIHOME.empty())
     {
         tmpSCIHOME = L"empty_SCIHOME";
     }

--- a/scilab/modules/ast/src/cpp/types/file.cpp
+++ b/scilab/modules/ast/src/cpp/types/file.cpp
@@ -29,10 +29,10 @@ File::File()
     m_fileDesc = NULL;
     m_iSwap = 0;
     m_pstMode.reserve(3);
-    m_pstMode = L"";
+    m_pstMode.clear();
     m_iFortranMode = -1; // see clunit.f
     m_iType = 0; // 1 : fortran open   2 : c open   3 : std::err std::out std::in
-    m_stFilename = L"";
+    m_stFilename.clear();
 }
 
 File::~File()
@@ -101,7 +101,7 @@ void File::setFileModeAsInt(int _iMode)
     int iPlus  = (int)((_iMode - iMode * 100) / 10);
     int iBin   = _iMode - iMode * 100 - iPlus * 10;
 
-    m_pstMode = L"";
+    m_pstMode.clear();
 
     switch (iMode)
     {

--- a/scilab/modules/ast/src/cpp/types/function.cpp
+++ b/scilab/modules/ast/src/cpp/types/function.cpp
@@ -656,7 +656,7 @@ DynamicFunction::DynamicFunction(const std::wstring& _wstName, const std::wstrin
     m_wstModule             = _wstModule;
     m_wstEntryPoint         = _wstEntryPointName;
     m_pLoadDeps             = _pLoadDeps;
-    m_wstLoadDepsName       = L"";
+    m_wstLoadDepsName.clear();
     m_bCloseLibAfterCall    = _bCloseLibAfterCall;
     m_iType                 = _iType;
     m_pFunc                 = NULL;

--- a/scilab/modules/ast/src/cpp/types/function.cpp
+++ b/scilab/modules/ast/src/cpp/types/function.cpp
@@ -778,7 +778,7 @@ Callable::ReturnValue DynamicFunction::Init()
     }
 
     /*Load gateway*/
-    if (m_wstName != L"")
+    if (!m_wstName.empty())
     {
         char* pstEntryPoint = wide_string_to_UTF8(m_wstEntryPoint.c_str());
         switch (m_iType)

--- a/scilab/modules/ast/src/cpp/types/macro.cpp
+++ b/scilab/modules/ast/src/cpp/types/macro.cpp
@@ -55,7 +55,7 @@ Macro::Macro(const std::wstring& _stName, std::list<symbol::Variable*>& _inputAr
     m_pDblArgOut->IncreaseRef(); //never delete
 
     m_body->setReturnable();
-    m_stPath = L"";
+    m_stPath.clear();
 }
 
 Macro::~Macro()

--- a/scilab/modules/ast/src/cpp/types/overload.cpp
+++ b/scilab/modules/ast/src/cpp/types/overload.cpp
@@ -160,7 +160,7 @@ types::Function::ReturnValue Overload::call(const std::wstring& _stOverloadingFu
         ConfigVariable::fillWhereError(ie.GetErrorLocation().first_line);
         if (pCall)
         {
-            if (ConfigVariable::getLastErrorFunction() == L"")
+            if (ConfigVariable::getLastErrorFunction().empty())
             {
                 ConfigVariable::setLastErrorFunction(pCall->getName());
                 ConfigVariable::setLastErrorLine(ie.GetErrorLocation().first_line);

--- a/scilab/modules/core/sci_gateway/cpp/sci_lasterror.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_lasterror.cpp
@@ -71,7 +71,7 @@ types::Function::ReturnValue sci_lasterror(types::typed_list &in, int _iRetCount
         if (!vectLines.empty())
         {
             // do not create an empty line if the end of the error message is '\n'
-            if (vectLines.back() == L"")
+            if (vectLines.back().empty())
             {
                 vectLines.pop_back();
             }

--- a/scilab/modules/coverage/src/cpp/CoverModule.cpp
+++ b/scilab/modules/coverage/src/cpp/CoverModule.cpp
@@ -1,8 +1,8 @@
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2015 - Scilab Enterprises - Calixte DENIZET
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2015 - Scilab Enterprises - Calixte DENIZET
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -389,7 +389,7 @@ void CoverModule::toHTML(const std::wstring & outputDir)
     wchar_t * _outputDir = expandPathVariableW((wchar_t *)outputDir.c_str());
     createdirectoryW(_outputDir);
 
-    if (results.size() == 1 && results.begin()->first == L"" && results.begin()->second.size() == 1 && results.begin()->second.begin()->first == L"")
+    if (results.size() == 1 && results.begin()->first.empty() && results.begin()->second.size() == 1 && results.begin()->second.begin()->first.empty())
     {
         for (const auto & p : macros)
         {

--- a/scilab/modules/functions/sci_gateway/cpp/sci_exec.cpp
+++ b/scilab/modules/functions/sci_gateway/cpp/sci_exec.cpp
@@ -1,8 +1,8 @@
 /*
-* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-* Copyright (C) 2006 - INRIA - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2006 - INRIA - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 #include "functions_gw.hxx"
 
@@ -332,7 +332,7 @@ types::Function::ReturnValue sci_exec(types::typed_list &in, int _iRetCount, typ
     }
     catch (const ast::InternalError& ie)
     {
-        if (pMacro && ConfigVariable::getLastErrorFunction() == L"")
+        if (pMacro && ConfigVariable::getLastErrorFunction().empty())
         {
             ConfigVariable::setLastErrorFunction(pMacro->getName());
         }

--- a/scilab/modules/functions/sci_gateway/cpp/sci_functionlist.cpp
+++ b/scilab/modules/functions/sci_gateway/cpp/sci_functionlist.cpp
@@ -1,8 +1,8 @@
 /*
-* Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-* Copyright (C) 2006 - INRIA - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2006 - INRIA - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 #include <string.h>
 #include "funcmanager.hxx"
@@ -50,7 +50,7 @@ types::Function::ReturnValue sci_funclist(types::typed_list &in, int _iRetCount,
     }
     else
     {
-        pstLibName = L"";
+        pstLibName.clear();
     }
 
     std::list<symbol::Symbol> funcList;

--- a/scilab/modules/functions_manager/includes/dynamic_modules.hxx
+++ b/scilab/modules/functions_manager/includes/dynamic_modules.hxx
@@ -1,8 +1,8 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2011 - DIGITEO - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2011 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 #ifndef __DYNAMIC_MODULES_HXX_
 #define __DYNAMIC_MODULES_HXX_
@@ -23,8 +23,8 @@ struct GatewayStr
 {
     GatewayStr()
     {
-        wstName = L"";
-        wstFunction = L"";
+        wstName.clear();
+        wstFunction.clear();
         iType = types::Function::EntryPointOldC;
     }
 

--- a/scilab/modules/functions_manager/src/cpp/funcmanager.cpp
+++ b/scilab/modules/functions_manager/src/cpp/funcmanager.cpp
@@ -102,7 +102,7 @@ bool FuncManager::GetModules()
     std::wstring szModulesFilename;
 
     std::wstring szPath = ConfigVariable::getSCIPath();
-    if (szPath == L"")
+    if (szPath.empty())
     {
         std::wcout << L"The SCI environment variable is not set." << std::endl;
         return false;
@@ -236,7 +236,7 @@ bool FuncManager::AppendModules()
 bool FuncManager::VerifyModule(wchar_t* _pszModuleName)
 {
     std::wstring SciPath = ConfigVariable::getSCIPath();
-    if (SciPath == L"")
+    if (SciPath.empty())
     {
         std::wcout << L"The SCI environment variable is not set." << std::endl;
         return false;

--- a/scilab/modules/output_stream/src/cpp/Diary.cpp
+++ b/scilab/modules/output_stream/src/cpp/Diary.cpp
@@ -1,9 +1,8 @@
-/*--------------------------------------------------------------------------*/
 /*
-* ( http://www.scilab.org/ ) - This file is part of Scilab
-* Copyright (C) DIGITEO - 2009 - Allan CORNET
-*
+ * ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) DIGITEO - 2009 - Allan CORNET
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -11,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 /*--------------------------------------------------------------------------*/
 #include <fstream>
 #include <iostream>
@@ -95,7 +94,7 @@ Diary::Diary(const std::wstring& _wfilename, int _mode, int ID, bool autorename)
 /*--------------------------------------------------------------------------*/
 Diary::~Diary()
 {
-    wfilename = L"";
+    wfilename.clear();
     fileAttribMode = -1;
     setID(-1);
 }

--- a/scilab/modules/polynomials/sci_gateway/cpp/sci_bezout.cpp
+++ b/scilab/modules/polynomials/sci_gateway/cpp/sci_bezout.cpp
@@ -78,7 +78,7 @@ types::Function::ReturnValue sci_bezout(types::typed_list &in, int _iRetCount, t
         else // polynom
         {
             types::Polynom* pPolyIn = in[i]->getAs<types::Polynom>();
-            if (wstrName != L"" && wstrName != pPolyIn->getVariableName())
+            if (!wstrName.empty() && wstrName != pPolyIn->getVariableName())
             {
                 Scierror(999, _("%s: Wrong value for input argument #%d: A polynomial '%ls' expected.\n"), "bezout", i + 1, wstrName.c_str());
                 return types::Function::Error;

--- a/scilab/modules/polynomials/sci_gateway/cpp/sci_bezout.cpp
+++ b/scilab/modules/polynomials/sci_gateway/cpp/sci_bezout.cpp
@@ -1,8 +1,8 @@
 /*
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2012 - Scilab Enterprises - Cedric DELAMARRE
- *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -106,7 +106,7 @@ types::Function::ReturnValue sci_bezout(types::typed_list &in, int _iRetCount, t
     types::SinglePoly* pSP = new types::SinglePoly(&pdblSP, np - 1);
     memcpy(pdblSP, pdblOut + ipb[0] - 1, np * sizeof(double));
 
-    if (wstrName == L"")
+    if (wstrName.empty())
     {
         wstrName = L"s";
     }

--- a/scilab/modules/polynomials/sci_gateway/cpp/sci_pppdiv.cpp
+++ b/scilab/modules/polynomials/sci_gateway/cpp/sci_pppdiv.cpp
@@ -1,8 +1,8 @@
 /*
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2012 - Scilab Enterprises - Cedric DELAMARRE
- *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -85,7 +85,7 @@ types::Function::ReturnValue sci_pppdiv(types::typed_list &in, int _iRetCount, t
                 return types::Function::Error;
             }
 
-            if (wstrName != L"" && wstrName != pPolyIn->getVariableName())
+            if (!wstrName.empty() && wstrName != pPolyIn->getVariableName())
             {
                 Scierror(999, _("%s: Wrong value for input argument #%d: A polynomial '%ls' expected.\n"), "pppdiv", i + 1, wstrName.c_str());
                 return types::Function::Error;


### PR DESCRIPTION
- `s.empty()` instead of `s == L""`
- `!s.empty()` instead of `s != L""`
- `s.clear()` instead of `s = L""`