### PR TITLE
Fixed Inconsistencies of ImplicitList::compute(), (Re-)Fixes #87

### DIFF
--- a/scilab/modules/ast/src/cpp/types/implicitlist.cpp
+++ b/scilab/modules/ast/src/cpp/types/implicitlist.cpp
@@ -264,7 +264,7 @@ bool ImplicitList::compute()
                 m_bComputed = true;
                 return true;
             }
-            else if (std::fabs(m_iSize * dblStep) <= fabs(dblRange))
+            else if (std::fabs(m_iSize * dblStep) <= std::nextafter(std::fabs(dblRange), HUGE_VAL))
             {
                 ++m_iSize;
             }

--- a/scilab/modules/core/tests/nonreg_tests/issue_87.dia.ref
+++ b/scilab/modules/core/tests/nonreg_tests/issue_87.dia.ref
@@ -20,3 +20,10 @@ assert_checkequal(1:c, [1,2,3,4,5]);
 assert_checkequal(a:-1:1, a-[0,1,2,3]);
 assert_checkequal(b:-1:1, b-[0,1,2,3,4]);
 assert_checkequal(c:-1:1, c-[0,1,2,3,4]);
+// step and end values _not_ exactly representable by double floats
+assert_checkalmostequal(0:0.1:0.1, [0.0,0.1]);
+assert_checkalmostequal(0:0.1:0.2, [0.0,0.1,0.2]);
+assert_checkalmostequal(0:0.1:0.3, [0.0,0.1,0.2,0.3]);
+assert_checkalmostequal(0:0.1:0.4, [0.0,0.1,0.2,0.3,0.4]);
+assert_checkalmostequal(0:0.1:0.5, [0.0,0.1,0.2,0.3,0.4,0.5]);
+assert_checkalmostequal(0:0.1:0.6, [0.0,0.1,0.2,0.3,0.4,0.5,0.6]);

--- a/scilab/modules/core/tests/nonreg_tests/issue_87.tst
+++ b/scilab/modules/core/tests/nonreg_tests/issue_87.tst
@@ -22,3 +22,11 @@ assert_checkequal(1:c, [1,2,3,4,5]);
 assert_checkequal(a:-1:1, a-[0,1,2,3]);
 assert_checkequal(b:-1:1, b-[0,1,2,3,4]);
 assert_checkequal(c:-1:1, c-[0,1,2,3,4]);
+
+// step and end values _not_ exactly representable by double floats
+assert_checkalmostequal(0:0.1:0.1, [0.0,0.1]);
+assert_checkalmostequal(0:0.1:0.2, [0.0,0.1,0.2]);
+assert_checkalmostequal(0:0.1:0.3, [0.0,0.1,0.2,0.3]);
+assert_checkalmostequal(0:0.1:0.4, [0.0,0.1,0.2,0.3,0.4]);
+assert_checkalmostequal(0:0.1:0.5, [0.0,0.1,0.2,0.3,0.4,0.5]);
+assert_checkalmostequal(0:0.1:0.6, [0.0,0.1,0.2,0.3,0.4,0.5,0.6]);


### PR DESCRIPTION
- fixes #87 
- furthermore, `test_run("scicos")` yields now about the same results as in Scilab 6.x.
