### PR TITLE
Complete Rewrite of "name2rgb" using a Perfect Hash Function

### DIFF
--- a/scilab/modules/graphics/src/c/name2rgb.c
+++ b/scilab/modules/graphics/src/c/name2rgb.c
@@ -1,1637 +1,2466 @@
-/*
- * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2014 - Scilab Enterprises - Antoine ELIAS
- *
- * Copyright (C) 2012 - 2016 - Scilab Enterprises
- *
- * This file is hereby licensed under the terms of the GNU GPL v2.0,
- * pursuant to article 5.3.4 of the CeCILL v.2.1.
- * This file was originally licensed under the terms of the CeCILL v2.1,
- * and continues to be available under such terms.
- * For more information, see the COPYING file which you should have received
- * along with this program.
- *
- */
-#include "name2rgb.h"
-#include "os_string.h"
+/* C code produced by gperf version 3.0.4 */
+/* Command-line: gperf -m 50 name2rgb.gperf  */
+/* Computed positions: -k'1,3,5-9,12-15,$' */
 
-static char* colorName[] =
-{
-    "scilab blue4",
-    "scilabblue4",
-    "scilab blue3",
-    "scilabblue3",
-    "scilab blue2",
-    "scilabblue2",
-    "scilab green4",
-    "scilabgreen4",
-    "scilab green3",
-    "scilabgreen3",
-    "scilab green2",
-    "scilabgreen2",
-    "scilab cyan4",
-    "scilabcyan4",
-    "scilab cyan3",
-    "scilabcyan3",
-    "scilab cyan2",
-    "scilabcyan2",
-    "scilab red4",
-    "scilabred4",
-    "scilab red3",
-    "scilabred3",
-    "scilab red2",
-    "scilabred2",
-    "scilab magenta4",
-    "scilabmagenta4",
-    "scilab magenta3",
-    "scilabmagenta3",
-    "scilab magenta2",
-    "scilabmagenta2",
-    "scilab brown4",
-    "scilabbrown4",
-    "scilab brown3",
-    "scilabbrown3",
-    "scilab brown2",
-    "scilabbrown2",
-    "scilab pink4",
-    "scilabpink4",
-    "scilab pink3",
-    "scilabpink3",
-    "scilab pink2",
-    "scilabpink2",
-    "scilab pink",
-    "scilabpink",
-    "snow",
-    "ghost white",
-    "ghostwhite",
-    "white smoke",
-    "whitesmoke",
-    "gainsboro",
-    "floral white",
-    "floralwhite",
-    "old lace",
-    "oldlace",
-    "linen",
-    "antique white",
-    "antiquewhite",
-    "papaya whip",
-    "papayawhip",
-    "blanched almond",
-    "blanchedalmond",
-    "bisque",
-    "peach puff",
-    "peachpuff",
-    "navajo white",
-    "navajowhite",
-    "moccasin",
-    "cornsilk",
-    "ivory",
-    "lemon chiffon",
-    "lemonchiffon",
-    "seashell",
-    "honeydew",
-    "mint cream",
-    "mintcream",
-    "azure",
-    "alice blue",
-    "aliceblue",
-    "lavender",
-    "lavender blush",
-    "lavenderblush",
-    "misty rose",
-    "mistyrose",
-    "white",
-    "black",
-    "dark slate gray",
-    "darkslategray",
-    "dark slate grey",
-    "darkslategrey",
-    "dim gray",
-    "dimgray",
-    "dim grey",
-    "dimgrey",
-    "slate gray",
-    "slategray",
-    "slate grey",
-    "slategrey",
-    "light slate gray",
-    "lightslategray",
-    "light slate grey",
-    "lightslategrey",
-    "gray",
-    "grey",
-    "light grey",
-    "lightgrey",
-    "light gray",
-    "lightgray",
-    "midnight blue",
-    "midnightblue",
-    "navy",
-    "navy blue",
-    "navyblue",
-    "cornflower blue",
-    "cornflowerblue",
-    "dark slate blue",
-    "darkslateblue",
-    "slate blue",
-    "slateblue",
-    "medium slate blue",
-    "mediumslateblue",
-    "light slate blue",
-    "lightslateblue",
-    "medium blue",
-    "mediumblue",
-    "royal blue",
-    "royalblue",
-    "blue",
-    "dodger blue",
-    "dodgerblue",
-    "deep sky blue",
-    "deepskyblue",
-    "sky blue",
-    "skyblue",
-    "light sky blue",
-    "lightskyblue",
-    "steel blue",
-    "steelblue",
-    "light steel blue",
-    "lightsteelblue",
-    "light blue",
-    "lightblue",
-    "powder blue",
-    "powderblue",
-    "pale turquoise",
-    "paleturquoise",
-    "dark turquoise",
-    "darkturquoise",
-    "medium turquoise",
-    "mediumturquoise",
-    "turquoise",
-    "cyan",
-    "light cyan",
-    "lightcyan",
-    "cadet blue",
-    "cadetblue",
-    "medium aquamarine",
-    "mediumaquamarine",
-    "aquamarine",
-    "dark green",
-    "darkgreen",
-    "dark olive green",
-    "darkolivegreen",
-    "dark sea green",
-    "darkseagreen",
-    "sea green",
-    "seagreen",
-    "medium sea green",
-    "mediumseagreen",
-    "light sea green",
-    "lightseagreen",
-    "pale green",
-    "palegreen",
-    "spring green",
-    "springgreen",
-    "lawn green",
-    "lawngreen",
-    "green",
-    "chartreuse",
-    "medium spring green",
-    "mediumspringgreen",
-    "green yellow",
-    "greenyellow",
-    "lime green",
-    "limegreen",
-    "yellow green",
-    "yellowgreen",
-    "forest green",
-    "forestgreen",
-    "olive drab",
-    "olivedrab",
-    "dark khaki",
-    "darkkhaki",
-    "khaki",
-    "pale goldenrod",
-    "palegoldenrod",
-    "light goldenrod yellow",
-    "lightgoldenrodyellow",
-    "light yellow",
-    "lightyellow",
-    "yellow",
-    "gold",
-    "light goldenrod",
-    "lightgoldenrod",
-    "goldenrod",
-    "dark goldenrod",
-    "darkgoldenrod",
-    "rosy brown",
-    "rosybrown",
-    "indian red",
-    "indianred",
-    "saddle brown",
-    "saddlebrown",
-    "sienna",
-    "peru",
-    "burlywood",
-    "beige",
-    "wheat",
-    "sandy brown",
-    "sandybrown",
-    "tan",
-    "chocolate",
-    "firebrick",
-    "brown",
-    "dark salmon",
-    "darksalmon",
-    "salmon",
-    "light salmon",
-    "lightsalmon",
-    "orange",
-    "dark orange",
-    "darkorange",
-    "coral",
-    "light coral",
-    "lightcoral",
-    "tomato",
-    "orange red",
-    "orangered",
-    "red",
-    "hot pink",
-    "hotpink",
-    "deep pink",
-    "deeppink",
-    "pink",
-    "light pink",
-    "lightpink",
-    "pale violet red",
-    "palevioletred",
-    "maroon",
-    "medium violet red",
-    "mediumvioletred",
-    "violet red",
-    "violetred",
-    "magenta",
-    "violet",
-    "plum",
-    "orchid",
-    "medium orchid",
-    "mediumorchid",
-    "dark orchid",
-    "darkorchid",
-    "dark violet",
-    "darkviolet",
-    "blue violet",
-    "blueviolet",
-    "purple",
-    "medium purple",
-    "mediumpurple",
-    "thistle",
-    "snow1",
-    "snow2",
-    "snow3",
-    "snow4",
-    "seashell1",
-    "seashell2",
-    "seashell3",
-    "seashell4",
-    "antiquewhite1",
-    "antiquewhite2",
-    "antiquewhite3",
-    "antiquewhite4",
-    "bisque1",
-    "bisque2",
-    "bisque3",
-    "bisque4",
-    "peachpuff1",
-    "peachpuff2",
-    "peachpuff3",
-    "peachpuff4",
-    "navajowhite1",
-    "navajowhite2",
-    "navajowhite3",
-    "navajowhite4",
-    "lemonchiffon1",
-    "lemonchiffon2",
-    "lemonchiffon3",
-    "lemonchiffon4",
-    "cornsilk1",
-    "cornsilk2",
-    "cornsilk3",
-    "cornsilk4",
-    "ivory1",
-    "ivory2",
-    "ivory3",
-    "ivory4",
-    "honeydew1",
-    "honeydew2",
-    "honeydew3",
-    "honeydew4",
-    "lavenderblush1",
-    "lavenderblush2",
-    "lavenderblush3",
-    "lavenderblush4",
-    "mistyrose1",
-    "mistyrose2",
-    "mistyrose3",
-    "mistyrose4",
-    "azure1",
-    "azure2",
-    "azure3",
-    "azure4",
-    "slateblue1",
-    "slateblue2",
-    "slateblue3",
-    "slateblue4",
-    "royalblue1",
-    "royalblue2",
-    "royalblue3",
-    "royalblue4",
-    "blue1",
-    "blue2",
-    "blue3",
-    "blue4",
-    "dodgerblue1",
-    "dodgerblue2",
-    "dodgerblue3",
-    "dodgerblue4",
-    "steelblue1",
-    "steelblue2",
-    "steelblue3",
-    "steelblue4",
-    "deepskyblue1",
-    "deepskyblue2",
-    "deepskyblue3",
-    "deepskyblue4",
-    "skyblue1",
-    "skyblue2",
-    "skyblue3",
-    "skyblue4",
-    "lightskyblue1",
-    "lightskyblue2",
-    "lightskyblue3",
-    "lightskyblue4",
-    "slategray1",
-    "slategray2",
-    "slategray3",
-    "slategray4",
-    "lightsteelblue1",
-    "lightsteelblue2",
-    "lightsteelblue3",
-    "lightsteelblue4",
-    "lightblue1",
-    "lightblue2",
-    "lightblue3",
-    "lightblue4",
-    "lightcyan1",
-    "lightcyan2",
-    "lightcyan3",
-    "lightcyan4",
-    "paleturquoise1",
-    "paleturquoise2",
-    "paleturquoise3",
-    "paleturquoise4",
-    "cadetblue1",
-    "cadetblue2",
-    "cadetblue3",
-    "cadetblue4",
-    "turquoise1",
-    "turquoise2",
-    "turquoise3",
-    "turquoise4",
-    "cyan1",
-    "cyan2",
-    "cyan3",
-    "cyan4",
-    "darkslategray1",
-    "darkslategray2",
-    "darkslategray3",
-    "darkslategray4",
-    "aquamarine1",
-    "aquamarine2",
-    "aquamarine3",
-    "aquamarine4",
-    "darkseagreen1",
-    "darkseagreen2",
-    "darkseagreen3",
-    "darkseagreen4",
-    "seagreen1",
-    "seagreen2",
-    "seagreen3",
-    "seagreen4",
-    "palegreen1",
-    "palegreen2",
-    "palegreen3",
-    "palegreen4",
-    "springgreen1",
-    "springgreen2",
-    "springgreen3",
-    "springgreen4",
-    "green1",
-    "green2",
-    "green3",
-    "green4",
-    "chartreuse1",
-    "chartreuse2",
-    "chartreuse3",
-    "chartreuse4",
-    "olivedrab1",
-    "olivedrab2",
-    "olivedrab3",
-    "olivedrab4",
-    "darkolivegreen1",
-    "darkolivegreen2",
-    "darkolivegreen3",
-    "darkolivegreen4",
-    "khaki1",
-    "khaki2",
-    "khaki3",
-    "khaki4",
-    "lightgoldenrod1",
-    "lightgoldenrod2",
-    "lightgoldenrod3",
-    "lightgoldenrod4",
-    "lightyellow1",
-    "lightyellow2",
-    "lightyellow3",
-    "lightyellow4",
-    "yellow1",
-    "yellow2",
-    "yellow3",
-    "yellow4",
-    "gold1",
-    "gold2",
-    "gold3",
-    "gold4",
-    "goldenrod1",
-    "goldenrod2",
-    "goldenrod3",
-    "goldenrod4",
-    "darkgoldenrod1",
-    "darkgoldenrod2",
-    "darkgoldenrod3",
-    "darkgoldenrod4",
-    "rosybrown1",
-    "rosybrown2",
-    "rosybrown3",
-    "rosybrown4",
-    "indianred1",
-    "indianred2",
-    "indianred3",
-    "indianred4",
-    "sienna1",
-    "sienna2",
-    "sienna3",
-    "sienna4",
-    "burlywood1",
-    "burlywood2",
-    "burlywood3",
-    "burlywood4",
-    "wheat1",
-    "wheat2",
-    "wheat3",
-    "wheat4",
-    "tan1",
-    "tan2",
-    "tan3",
-    "tan4",
-    "chocolate1",
-    "chocolate2",
-    "chocolate3",
-    "chocolate4",
-    "firebrick1",
-    "firebrick2",
-    "firebrick3",
-    "firebrick4",
-    "brown1",
-    "brown2",
-    "brown3",
-    "brown4",
-    "salmon1",
-    "salmon2",
-    "salmon3",
-    "salmon4",
-    "lightsalmon1",
-    "lightsalmon2",
-    "lightsalmon3",
-    "lightsalmon4",
-    "orange1",
-    "orange2",
-    "orange3",
-    "orange4",
-    "darkorange1",
-    "darkorange2",
-    "darkorange3",
-    "darkorange4",
-    "coral1",
-    "coral2",
-    "coral3",
-    "coral4",
-    "tomato1",
-    "tomato2",
-    "tomato3",
-    "tomato4",
-    "orangered1",
-    "orangered2",
-    "orangered3",
-    "orangered4",
-    "red1",
-    "red2",
-    "red3",
-    "red4",
-    "deeppink1",
-    "deeppink2",
-    "deeppink3",
-    "deeppink4",
-    "hotpink1",
-    "hotpink2",
-    "hotpink3",
-    "hotpink4",
-    "pink1",
-    "pink2",
-    "pink3",
-    "pink4",
-    "lightpink1",
-    "lightpink2",
-    "lightpink3",
-    "lightpink4",
-    "palevioletred1",
-    "palevioletred2",
-    "palevioletred3",
-    "palevioletred4",
-    "maroon1",
-    "maroon2",
-    "maroon3",
-    "maroon4",
-    "violetred1",
-    "violetred2",
-    "violetred3",
-    "violetred4",
-    "magenta1",
-    "magenta2",
-    "magenta3",
-    "magenta4",
-    "orchid1",
-    "orchid2",
-    "orchid3",
-    "orchid4",
-    "plum1",
-    "plum2",
-    "plum3",
-    "plum4",
-    "mediumorchid1",
-    "mediumorchid2",
-    "mediumorchid3",
-    "mediumorchid4",
-    "darkorchid1",
-    "darkorchid2",
-    "darkorchid3",
-    "darkorchid4",
-    "purple1",
-    "purple2",
-    "purple3",
-    "purple4",
-    "mediumpurple1",
-    "mediumpurple2",
-    "mediumpurple3",
-    "mediumpurple4",
-    "thistle1",
-    "thistle2",
-    "thistle3",
-    "thistle4",
-    "gray0",
-    "grey0",
-    "gray1",
-    "grey1",
-    "gray2",
-    "grey2",
-    "gray3",
-    "grey3",
-    "gray4",
-    "grey4",
-    "gray5",
-    "grey5",
-    "gray6",
-    "grey6",
-    "gray7",
-    "grey7",
-    "gray8",
-    "grey8",
-    "gray9",
-    "grey9",
-    "gray10",
-    "grey10",
-    "gray11",
-    "grey11",
-    "gray12",
-    "grey12",
-    "gray13",
-    "grey13",
-    "gray14",
-    "grey14",
-    "gray15",
-    "grey15",
-    "gray16",
-    "grey16",
-    "gray17",
-    "grey17",
-    "gray18",
-    "grey18",
-    "gray19",
-    "grey19",
-    "gray20",
-    "grey20",
-    "gray21",
-    "grey21",
-    "gray22",
-    "grey22",
-    "gray23",
-    "grey23",
-    "gray24",
-    "grey24",
-    "gray25",
-    "grey25",
-    "gray26",
-    "grey26",
-    "gray27",
-    "grey27",
-    "gray28",
-    "grey28",
-    "gray29",
-    "grey29",
-    "gray30",
-    "grey30",
-    "gray31",
-    "grey31",
-    "gray32",
-    "grey32",
-    "gray33",
-    "grey33",
-    "gray34",
-    "grey34",
-    "gray35",
-    "grey35",
-    "gray36",
-    "grey36",
-    "gray37",
-    "grey37",
-    "gray38",
-    "grey38",
-    "gray39",
-    "grey39",
-    "gray40",
-    "grey40",
-    "gray41",
-    "grey41",
-    "gray42",
-    "grey42",
-    "gray43",
-    "grey43",
-    "gray44",
-    "grey44",
-    "gray45",
-    "grey45",
-    "gray46",
-    "grey46",
-    "gray47",
-    "grey47",
-    "gray48",
-    "grey48",
-    "gray49",
-    "grey49",
-    "gray50",
-    "grey50",
-    "gray51",
-    "grey51",
-    "gray52",
-    "grey52",
-    "gray53",
-    "grey53",
-    "gray54",
-    "grey54",
-    "gray55",
-    "grey55",
-    "gray56",
-    "grey56",
-    "gray57",
-    "grey57",
-    "gray58",
-    "grey58",
-    "gray59",
-    "grey59",
-    "gray60",
-    "grey60",
-    "gray61",
-    "grey61",
-    "gray62",
-    "grey62",
-    "gray63",
-    "grey63",
-    "gray64",
-    "grey64",
-    "gray65",
-    "grey65",
-    "gray66",
-    "grey66",
-    "gray67",
-    "grey67",
-    "gray68",
-    "grey68",
-    "gray69",
-    "grey69",
-    "gray70",
-    "grey70",
-    "gray71",
-    "grey71",
-    "gray72",
-    "grey72",
-    "gray73",
-    "grey73",
-    "gray74",
-    "grey74",
-    "gray75",
-    "grey75",
-    "gray76",
-    "grey76",
-    "gray77",
-    "grey77",
-    "gray78",
-    "grey78",
-    "gray79",
-    "grey79",
-    "gray80",
-    "grey80",
-    "gray81",
-    "grey81",
-    "gray82",
-    "grey82",
-    "gray83",
-    "grey83",
-    "gray84",
-    "grey84",
-    "gray85",
-    "grey85",
-    "gray86",
-    "grey86",
-    "gray87",
-    "grey87",
-    "gray88",
-    "grey88",
-    "gray89",
-    "grey89",
-    "gray90",
-    "grey90",
-    "gray91",
-    "grey91",
-    "gray92",
-    "grey92",
-    "gray93",
-    "grey93",
-    "gray94",
-    "grey94",
-    "gray95",
-    "grey95",
-    "gray96",
-    "grey96",
-    "gray97",
-    "grey97",
-    "gray98",
-    "grey98",
-    "gray99",
-    "grey99",
-    "gray100",
-    "grey100",
-    "dark grey",
-    "darkgrey",
-    "dark gray",
-    "darkgray",
-    "dark blue",
-    "darkblue",
-    "dark cyan",
-    "darkcyan",
-    "dark magenta",
-    "darkmagenta",
-    "dark red",
-    "darkred",
-    "light green",
-    "lightgreen"
-};
+#if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
+      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
+      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
+      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
+      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
+      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
+      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
+      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
+      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
+      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
+      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
+      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
+      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
+      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
+      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
+      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
+      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
+      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
+      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
+      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
+      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
+      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
+      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
+/* The character set is not based on ISO-646.  */
+error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+#endif
 
-static int colorRGB[][3] =
-{
-    {0, 0, 144},
-    {0, 0, 144},
-    {0, 0, 176},
-    {0, 0, 176},
-    {0, 0, 208},
-    {0, 0, 208},
-    {0, 144, 0},
-    {0, 144, 0},
-    {0, 176, 0},
-    {0, 176, 0},
-    {0, 208, 0},
-    {0, 208, 0},
-    {0, 144, 144},
-    {0, 144, 144},
-    {0, 176, 176},
-    {0, 176, 176},
-    {0, 208, 208},
-    {0, 208, 208},
-    {144, 0, 0},
-    {144, 0, 0},
-    {176, 0, 0},
-    {176, 0, 0},
-    {208, 0, 0},
-    {208, 0, 0},
-    {144, 0, 144},
-    {144, 0, 144},
-    {176, 0, 176},
-    {176, 0, 176},
-    {208, 0, 208},
-    {208, 0, 208},
-    {128, 48, 0},
-    {128, 48, 0},
-    {160, 64, 0},
-    {160, 64, 0},
-    {192, 96, 0},
-    {192, 96, 0},
-    {255, 128, 128},
-    {255, 128, 128},
-    {255, 160, 160},
-    {255, 160, 160},
-    {255, 192, 192},
-    {255, 192, 192},
-    {255, 224, 224},
-    {255, 224, 224},
-    {255, 250, 250},
-    {248, 248, 255},
-    {248, 248, 255},
-    {245, 245, 245},
-    {245, 245, 245},
-    {220, 220, 220},
-    {255, 250, 240},
-    {255, 250, 240},
-    {253, 245, 230},
-    {253, 245, 230},
-    {250, 240, 230},
-    {250, 235, 215},
-    {250, 235, 215},
-    {255, 239, 213},
-    {255, 239, 213},
-    {255, 235, 205},
-    {255, 235, 205},
-    {255, 228, 196},
-    {255, 218, 185},
-    {255, 218, 185},
-    {255, 222, 173},
-    {255, 222, 173},
-    {255, 228, 181},
-    {255, 248, 220},
-    {255, 255, 240},
-    {255, 250, 205},
-    {255, 250, 205},
-    {255, 245, 238},
-    {240, 255, 240},
-    {245, 255, 250},
-    {245, 255, 250},
-    {240, 255, 255},
-    {240, 248, 255},
-    {240, 248, 255},
-    {230, 230, 250},
-    {255, 240, 245},
-    {255, 240, 245},
-    {255, 228, 225},
-    {255, 228, 225},
-    {255, 255, 255},
-    {0, 0, 0},
-    {47, 79, 79},
-    {47, 79, 79},
-    {47, 79, 79},
-    {47, 79, 79},
-    {105, 105, 105},
-    {105, 105, 105},
-    {105, 105, 105},
-    {105, 105, 105},
-    {112, 128, 144},
-    {112, 128, 144},
-    {112, 128, 144},
-    {112, 128, 144},
-    {119, 136, 153},
-    {119, 136, 153},
-    {119, 136, 153},
-    {119, 136, 153},
-    {190, 190, 190},
-    {190, 190, 190},
-    {211, 211, 211},
-    {211, 211, 211},
-    {211, 211, 211},
-    {211, 211, 211},
-    {25, 25, 112},
-    {25, 25, 112},
-    {0, 0, 128},
-    {0, 0, 128},
-    {0, 0, 128},
-    {100, 149, 237},
-    {100, 149, 237},
-    {72, 61, 139},
-    {72, 61, 139},
-    {106, 90, 205},
-    {106, 90, 205},
-    {123, 104, 238},
-    {123, 104, 238},
-    {132, 112, 255},
-    {132, 112, 255},
-    {0, 0, 205},
-    {0, 0, 205},
-    {65, 105, 225},
-    {65, 105, 225},
-    {0, 0, 255},
-    {30, 144, 255},
-    {30, 144, 255},
-    {0, 191, 255},
-    {0, 191, 255},
-    {135, 206, 235},
-    {135, 206, 235},
-    {135, 206, 250},
-    {135, 206, 250},
-    {70, 130, 180},
-    {70, 130, 180},
-    {176, 196, 222},
-    {176, 196, 222},
-    {173, 216, 230},
-    {173, 216, 230},
-    {176, 224, 230},
-    {176, 224, 230},
-    {175, 238, 238},
-    {175, 238, 238},
-    {0, 206, 209},
-    {0, 206, 209},
-    {72, 209, 204},
-    {72, 209, 204},
-    {64, 224, 208},
-    {0, 255, 255},
-    {224, 255, 255},
-    {224, 255, 255},
-    {95, 158, 160},
-    {95, 158, 160},
-    {102, 205, 170},
-    {102, 205, 170},
-    {127, 255, 212},
-    {0, 100, 0},
-    {0, 100, 0},
-    {85, 107, 47},
-    {85, 107, 47},
-    {143, 188, 143},
-    {143, 188, 143},
-    {46, 139, 87},
-    {46, 139, 87},
-    {60, 179, 113},
-    {60, 179, 113},
-    {32, 178, 170},
-    {32, 178, 170},
-    {152, 251, 152},
-    {152, 251, 152},
-    {0, 255, 127},
-    {0, 255, 127},
-    {124, 252, 0},
-    {124, 252, 0},
-    {0, 255, 0},
-    {127, 255, 0},
-    {0, 250, 154},
-    {0, 250, 154},
-    {173, 255, 47},
-    {173, 255, 47},
-    {50, 205, 50},
-    {50, 205, 50},
-    {154, 205, 50},
-    {154, 205, 50},
-    {34, 139, 34},
-    {34, 139, 34},
-    {107, 142, 35},
-    {107, 142, 35},
-    {189, 183, 107},
-    {189, 183, 107},
-    {240, 230, 140},
-    {238, 232, 170},
-    {238, 232, 170},
-    {250, 250, 210},
-    {250, 250, 210},
-    {255, 255, 224},
-    {255, 255, 224},
-    {255, 255, 0},
-    {255, 215, 0},
-    {238, 221, 130},
-    {238, 221, 130},
-    {218, 165, 32},
-    {184, 134, 11},
-    {184, 134, 11},
-    {188, 143, 143},
-    {188, 143, 143},
-    {205, 92, 92},
-    {205, 92, 92},
-    {139, 69, 19},
-    {139, 69, 19},
-    {160, 82, 45},
-    {205, 133, 63},
-    {222, 184, 135},
-    {245, 245, 220},
-    {245, 222, 179},
-    {244, 164, 96},
-    {244, 164, 96},
-    {210, 180, 140},
-    {210, 105, 30},
-    {178, 34, 34},
-    {165, 42, 42},
-    {233, 150, 122},
-    {233, 150, 122},
-    {250, 128, 114},
-    {255, 160, 122},
-    {255, 160, 122},
-    {255, 165, 0},
-    {255, 140, 0},
-    {255, 140, 0},
-    {255, 127, 80},
-    {240, 128, 128},
-    {240, 128, 128},
-    {255, 99, 71},
-    {255, 69, 0},
-    {255, 69, 0},
-    {255, 0, 0},
-    {255, 105, 180},
-    {255, 105, 180},
-    {255, 20, 147},
-    {255, 20, 147},
-    {255, 192, 203},
-    {255, 182, 193},
-    {255, 182, 193},
-    {219, 112, 147},
-    {219, 112, 147},
-    {176, 48, 96},
-    {199, 21, 133},
-    {199, 21, 133},
-    {208, 32, 144},
-    {208, 32, 144},
-    {255, 0, 255},
-    {238, 130, 238},
-    {221, 160, 221},
-    {218, 112, 214},
-    {186, 85, 211},
-    {186, 85, 211},
-    {153, 50, 204},
-    {153, 50, 204},
-    {148, 0, 211},
-    {148, 0, 211},
-    {138, 43, 226},
-    {138, 43, 226},
-    {160, 32, 240},
-    {147, 112, 219},
-    {147, 112, 219},
-    {216, 191, 216},
-    {255, 250, 250},
-    {238, 233, 233},
-    {205, 201, 201},
-    {139, 137, 137},
-    {255, 245, 238},
-    {238, 229, 222},
-    {205, 197, 191},
-    {139, 134, 130},
-    {255, 239, 219},
-    {238, 223, 204},
-    {205, 192, 176},
-    {139, 131, 120},
-    {255, 228, 196},
-    {238, 213, 183},
-    {205, 183, 158},
-    {139, 125, 107},
-    {255, 218, 185},
-    {238, 203, 173},
-    {205, 175, 149},
-    {139, 119, 101},
-    {255, 222, 173},
-    {238, 207, 161},
-    {205, 179, 139},
-    {139, 121, 94},
-    {255, 250, 205},
-    {238, 233, 191},
-    {205, 201, 165},
-    {139, 137, 112},
-    {255, 248, 220},
-    {238, 232, 205},
-    {205, 200, 177},
-    {139, 136, 120},
-    {255, 255, 240},
-    {238, 238, 224},
-    {205, 205, 193},
-    {139, 139, 131},
-    {240, 255, 240},
-    {224, 238, 224},
-    {193, 205, 193},
-    {131, 139, 131},
-    {255, 240, 245},
-    {238, 224, 229},
-    {205, 193, 197},
-    {139, 131, 134},
-    {255, 228, 225},
-    {238, 213, 210},
-    {205, 183, 181},
-    {139, 125, 123},
-    {240, 255, 255},
-    {224, 238, 238},
-    {193, 205, 205},
-    {131, 139, 139},
-    {131, 111, 255},
-    {122, 103, 238},
-    {105, 89, 205},
-    {71, 60, 139},
-    {72, 118, 255},
-    {67, 110, 238},
-    {58, 95, 205},
-    {39, 64, 139},
-    {0, 0, 255},
-    {0, 0, 238},
-    {0, 0, 205},
-    {0, 0, 139},
-    {30, 144, 255},
-    {28, 134, 238},
-    {24, 116, 205},
-    {16, 78, 139},
-    {99, 184, 255},
-    {92, 172, 238},
-    {79, 148, 205},
-    {54, 100, 139},
-    {0, 191, 255},
-    {0, 178, 238},
-    {0, 154, 205},
-    {0, 104, 139},
-    {135, 206, 255},
-    {126, 192, 238},
-    {108, 166, 205},
-    {74, 112, 139},
-    {176, 226, 255},
-    {164, 211, 238},
-    {141, 182, 205},
-    {96, 123, 139},
-    {198, 226, 255},
-    {185, 211, 238},
-    {159, 182, 205},
-    {108, 123, 139},
-    {202, 225, 255},
-    {188, 210, 238},
-    {162, 181, 205},
-    {110, 123, 139},
-    {191, 239, 255},
-    {178, 223, 238},
-    {154, 192, 205},
-    {104, 131, 139},
-    {224, 255, 255},
-    {209, 238, 238},
-    {180, 205, 205},
-    {122, 139, 139},
-    {187, 255, 255},
-    {174, 238, 238},
-    {150, 205, 205},
-    {102, 139, 139},
-    {152, 245, 255},
-    {142, 229, 238},
-    {122, 197, 205},
-    {83, 134, 139},
-    {0, 245, 255},
-    {0, 229, 238},
-    {0, 197, 205},
-    {0, 134, 139},
-    {0, 255, 255},
-    {0, 238, 238},
-    {0, 205, 205},
-    {0, 139, 139},
-    {151, 255, 255},
-    {141, 238, 238},
-    {121, 205, 205},
-    {82, 139, 139},
-    {127, 255, 212},
-    {118, 238, 198},
-    {102, 205, 170},
-    {69, 139, 116},
-    {193, 255, 193},
-    {180, 238, 180},
-    {155, 205, 155},
-    {105, 139, 105},
-    {84, 255, 159},
-    {78, 238, 148},
-    {67, 205, 128},
-    {46, 139, 87},
-    {154, 255, 154},
-    {144, 238, 144},
-    {124, 205, 124},
-    {84, 139, 84},
-    {0, 255, 127},
-    {0, 238, 118},
-    {0, 205, 102},
-    {0, 139, 69},
-    {0, 255, 0},
-    {0, 238, 0},
-    {0, 205, 0},
-    {0, 139, 0},
-    {127, 255, 0},
-    {118, 238, 0},
-    {102, 205, 0},
-    {69, 139, 0},
-    {192, 255, 62},
-    {179, 238, 58},
-    {154, 205, 50},
-    {105, 139, 34},
-    {202, 255, 112},
-    {188, 238, 104},
-    {162, 205, 90},
-    {110, 139, 61},
-    {255, 246, 143},
-    {238, 230, 133},
-    {205, 198, 115},
-    {139, 134, 78},
-    {255, 236, 139},
-    {238, 220, 130},
-    {205, 190, 112},
-    {139, 129, 76},
-    {255, 255, 224},
-    {238, 238, 209},
-    {205, 205, 180},
-    {139, 139, 122},
-    {255, 255, 0},
-    {238, 238, 0},
-    {205, 205, 0},
-    {139, 139, 0},
-    {255, 215, 0},
-    {238, 201, 0},
-    {205, 173, 0},
-    {139, 117, 0},
-    {255, 193, 37},
-    {238, 180, 34},
-    {205, 155, 29},
-    {139, 105, 20},
-    {255, 185, 15},
-    {238, 173, 14},
-    {205, 149, 12},
-    {139, 101, 8},
-    {255, 193, 193},
-    {238, 180, 180},
-    {205, 155, 155},
-    {139, 105, 105},
-    {255, 106, 106},
-    {238, 99, 99},
-    {205, 85, 85},
-    {139, 58, 58},
-    {255, 130, 71},
-    {238, 121, 66},
-    {205, 104, 57},
-    {139, 71, 38},
-    {255, 211, 155},
-    {238, 197, 145},
-    {205, 170, 125},
-    {139, 115, 85},
-    {255, 231, 186},
-    {238, 216, 174},
-    {205, 186, 150},
-    {139, 126, 102},
-    {255, 165, 79},
-    {238, 154, 73},
-    {205, 133, 63},
-    {139, 90, 43},
-    {255, 127, 36},
-    {238, 118, 33},
-    {205, 102, 29},
-    {139, 69, 19},
-    {255, 48, 48},
-    {238, 44, 44},
-    {205, 38, 38},
-    {139, 26, 26},
-    {255, 64, 64},
-    {238, 59, 59},
-    {205, 51, 51},
-    {139, 35, 35},
-    {255, 140, 105},
-    {238, 130, 98},
-    {205, 112, 84},
-    {139, 76, 57},
-    {255, 160, 122},
-    {238, 149, 114},
-    {205, 129, 98},
-    {139, 87, 66},
-    {255, 165, 0},
-    {238, 154, 0},
-    {205, 133, 0},
-    {139, 90, 0},
-    {255, 127, 0},
-    {238, 118, 0},
-    {205, 102, 0},
-    {139, 69, 0},
-    {255, 114, 86},
-    {238, 106, 80},
-    {205, 91, 69},
-    {139, 62, 47},
-    {255, 99, 71},
-    {238, 92, 66},
-    {205, 79, 57},
-    {139, 54, 38},
-    {255, 69, 0},
-    {238, 64, 0},
-    {205, 55, 0},
-    {139, 37, 0},
-    {255, 0, 0},
-    {238, 0, 0},
-    {205, 0, 0},
-    {139, 0, 0},
-    {255, 20, 147},
-    {238, 18, 137},
-    {205, 16, 118},
-    {139, 10, 80},
-    {255, 110, 180},
-    {238, 106, 167},
-    {205, 96, 144},
-    {139, 58, 98},
-    {255, 181, 197},
-    {238, 169, 184},
-    {205, 145, 158},
-    {139, 99, 108},
-    {255, 174, 185},
-    {238, 162, 173},
-    {205, 140, 149},
-    {139, 95, 101},
-    {255, 130, 171},
-    {238, 121, 159},
-    {205, 104, 137},
-    {139, 71, 93},
-    {255, 52, 179},
-    {238, 48, 167},
-    {205, 41, 144},
-    {139, 28, 98},
-    {255, 62, 150},
-    {238, 58, 140},
-    {205, 50, 120},
-    {139, 34, 82},
-    {255, 0, 255},
-    {238, 0, 238},
-    {205, 0, 205},
-    {139, 0, 139},
-    {255, 131, 250},
-    {238, 122, 233},
-    {205, 105, 201},
-    {139, 71, 137},
-    {255, 187, 255},
-    {238, 174, 238},
-    {205, 150, 205},
-    {139, 102, 139},
-    {224, 102, 255},
-    {209, 95, 238},
-    {180, 82, 205},
-    {122, 55, 139},
-    {191, 62, 255},
-    {178, 58, 238},
-    {154, 50, 205},
-    {104, 34, 139},
-    {155, 48, 255},
-    {145, 44, 238},
-    {125, 38, 205},
-    {85, 26, 139},
-    {171, 130, 255},
-    {159, 121, 238},
-    {137, 104, 205},
-    {93, 71, 139},
-    {255, 225, 255},
-    {238, 210, 238},
-    {205, 181, 205},
-    {139, 123, 139},
-    {0, 0, 0},
-    {0, 0, 0},
-    {3, 3, 3},
-    {3, 3, 3},
-    {5, 5, 5},
-    {5, 5, 5},
-    {8, 8, 8},
-    {8, 8, 8},
-    {10, 10, 10},
-    {10, 10, 10},
-    {13, 13, 13},
-    {13, 13, 13},
-    {15, 15, 15},
-    {15, 15, 15},
-    {18, 18, 18},
-    {18, 18, 18},
-    {20, 20, 20},
-    {20, 20, 20},
-    {23, 23, 23},
-    {23, 23, 23},
-    {26, 26, 26},
-    {26, 26, 26},
-    {28, 28, 28},
-    {28, 28, 28},
-    {31, 31, 31},
-    {31, 31, 31},
-    {33, 33, 33},
-    {33, 33, 33},
-    {36, 36, 36},
-    {36, 36, 36},
-    {38, 38, 38},
-    {38, 38, 38},
-    {41, 41, 41},
-    {41, 41, 41},
-    {43, 43, 43},
-    {43, 43, 43},
-    {46, 46, 46},
-    {46, 46, 46},
-    {48, 48, 48},
-    {48, 48, 48},
-    {51, 51, 51},
-    {51, 51, 51},
-    {54, 54, 54},
-    {54, 54, 54},
-    {56, 56, 56},
-    {56, 56, 56},
-    {59, 59, 59},
-    {59, 59, 59},
-    {61, 61, 61},
-    {61, 61, 61},
-    {64, 64, 64},
-    {64, 64, 64},
-    {66, 66, 66},
-    {66, 66, 66},
-    {69, 69, 69},
-    {69, 69, 69},
-    {71, 71, 71},
-    {71, 71, 71},
-    {74, 74, 74},
-    {74, 74, 74},
-    {77, 77, 77},
-    {77, 77, 77},
-    {79, 79, 79},
-    {79, 79, 79},
-    {82, 82, 82},
-    {82, 82, 82},
-    {84, 84, 84},
-    {84, 84, 84},
-    {87, 87, 87},
-    {87, 87, 87},
-    {89, 89, 89},
-    {89, 89, 89},
-    {92, 92, 92},
-    {92, 92, 92},
-    {94, 94, 94},
-    {94, 94, 94},
-    {97, 97, 97},
-    {97, 97, 97},
-    {99, 99, 99},
-    {99, 99, 99},
-    {102, 102, 102},
-    {102, 102, 102},
-    {105, 105, 105},
-    {105, 105, 105},
-    {107, 107, 107},
-    {107, 107, 107},
-    {110, 110, 110},
-    {110, 110, 110},
-    {112, 112, 112},
-    {112, 112, 112},
-    {115, 115, 115},
-    {115, 115, 115},
-    {117, 117, 117},
-    {117, 117, 117},
-    {120, 120, 120},
-    {120, 120, 120},
-    {122, 122, 122},
-    {122, 122, 122},
-    {125, 125, 125},
-    {125, 125, 125},
-    {127, 127, 127},
-    {127, 127, 127},
-    {130, 130, 130},
-    {130, 130, 130},
-    {133, 133, 133},
-    {133, 133, 133},
-    {135, 135, 135},
-    {135, 135, 135},
-    {138, 138, 138},
-    {138, 138, 138},
-    {140, 140, 140},
-    {140, 140, 140},
-    {143, 143, 143},
-    {143, 143, 143},
-    {145, 145, 145},
-    {145, 145, 145},
-    {148, 148, 148},
-    {148, 148, 148},
-    {150, 150, 150},
-    {150, 150, 150},
-    {153, 153, 153},
-    {153, 153, 153},
-    {156, 156, 156},
-    {156, 156, 156},
-    {158, 158, 158},
-    {158, 158, 158},
-    {161, 161, 161},
-    {161, 161, 161},
-    {163, 163, 163},
-    {163, 163, 163},
-    {166, 166, 166},
-    {166, 166, 166},
-    {168, 168, 168},
-    {168, 168, 168},
-    {171, 171, 171},
-    {171, 171, 171},
-    {173, 173, 173},
-    {173, 173, 173},
-    {176, 176, 176},
-    {176, 176, 176},
-    {179, 179, 179},
-    {179, 179, 179},
-    {181, 181, 181},
-    {181, 181, 181},
-    {184, 184, 184},
-    {184, 184, 184},
-    {186, 186, 186},
-    {186, 186, 186},
-    {189, 189, 189},
-    {189, 189, 189},
-    {191, 191, 191},
-    {191, 191, 191},
-    {194, 194, 194},
-    {194, 194, 194},
-    {196, 196, 196},
-    {196, 196, 196},
-    {199, 199, 199},
-    {199, 199, 199},
-    {201, 201, 201},
-    {201, 201, 201},
-    {204, 204, 204},
-    {204, 204, 204},
-    {207, 207, 207},
-    {207, 207, 207},
-    {209, 209, 209},
-    {209, 209, 209},
-    {212, 212, 212},
-    {212, 212, 212},
-    {214, 214, 214},
-    {214, 214, 214},
-    {217, 217, 217},
-    {217, 217, 217},
-    {219, 219, 219},
-    {219, 219, 219},
-    {222, 222, 222},
-    {222, 222, 222},
-    {224, 224, 224},
-    {224, 224, 224},
-    {227, 227, 227},
-    {227, 227, 227},
-    {229, 229, 229},
-    {229, 229, 229},
-    {232, 232, 232},
-    {232, 232, 232},
-    {235, 235, 235},
-    {235, 235, 235},
-    {237, 237, 237},
-    {237, 237, 237},
-    {240, 240, 240},
-    {240, 240, 240},
-    {242, 242, 242},
-    {242, 242, 242},
-    {245, 245, 245},
-    {245, 245, 245},
-    {247, 247, 247},
-    {247, 247, 247},
-    {250, 250, 250},
-    {250, 250, 250},
-    {252, 252, 252},
-    {252, 252, 252},
-    {255, 255, 255},
-    {255, 255, 255},
-    {169, 169, 169},
-    {169, 169, 169},
-    {169, 169, 169},
-    {169, 169, 169},
-    {0, 0, 139},
-    {0, 0, 139},
-    {0, 139, 139},
-    {0, 139, 139},
-    {139, 0, 139},
-    {139, 0, 139},
-    {139, 0, 0},
-    {139, 0, 0},
-    {144, 238, 144},
-    {144, 238, 144}
-};
+#line 21 "name2rgb.gperf"
 
-void name2rgb(char* color, double* _pdblRGB)
+#include <name2rgb.h>
+#include "strlen.h"
+
+struct color {char* name; int red; int green; int blue;};
+#line 36 "name2rgb.gperf"
+struct color;
+
+#define TOTAL_KEYWORDS 796
+#define MIN_WORD_LENGTH 3
+#define MAX_WORD_LENGTH 22
+#define MIN_HASH_VALUE 57
+#define MAX_HASH_VALUE 3612
+/* maximum key range = 3556, duplicates = 0 */
+
+#ifndef GPERF_DOWNCASE
+#define GPERF_DOWNCASE 1
+static unsigned char gperf_downcase[256] =
+  {
+      0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
+     15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
+     30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
+     45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+     60,  61,  62,  63,  64,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106,
+    107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
+    122,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104,
+    105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+    120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134,
+    135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
+    150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
+    165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
+    180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194,
+    195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209,
+    210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224,
+    225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
+    240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254,
+    255
+  };
+#endif
+
+#ifndef GPERF_CASE_STRCMP
+#define GPERF_CASE_STRCMP 1
+static int
+gperf_case_strcmp (s1, s2)
+     register const char *s1;
+     register const char *s2;
 {
-    int i = 0;
-    int colorSize = sizeof(colorName) / sizeof(char*);
-    int colorSize2 = sizeof(colorRGB) / (sizeof(int) * 3);
-    for (i = 0 ; i < colorSize ; i++)
+  for (;;)
     {
-        if (stricmp(colorName[i], color) == 0)
+      unsigned char c1 = gperf_downcase[(unsigned char)*s1++];
+      unsigned char c2 = gperf_downcase[(unsigned char)*s2++];
+      if (c1 != 0 && c1 == c2)
+        continue;
+      return (int)c1 - (int)c2;
+    }
+}
+#endif
+
+#ifdef __GNUC__
+__inline
+#else
+#ifdef __cplusplus
+inline
+#endif
+#endif
+static unsigned int
+hash (str, len)
+     register const char *str;
+     register unsigned int len;
+{
+  static const unsigned short asso_values[] =
+    {
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613,  480, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,  805,   18,
+        17,   14,   13, 1148,  990,  936,  436,  188, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613,   43,   44,  711,   86,   13,
+        36,   13,  207,  587,   13,  400,   81,  157,   30,   85,
+       416,   85,   15,   13,  155,  279, 1100, 1179, 3613,  295,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613,   43,   44,  711,
+        86,   13,   36,   13,  207,  587,   13,  400,   81,  157,
+        30,   85,  416,   85,   15,   13,  155,  279, 1100, 1179,
+      3613,  295, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613, 3613,
+      3613, 3613, 3613, 3613, 3613, 3613
+    };
+  register int hval = len;
+
+  switch (hval)
+    {
+      default:
+        hval += asso_values[(unsigned char)str[14]];
+      /*FALLTHROUGH*/
+      case 14:
+        hval += asso_values[(unsigned char)str[13]];
+      /*FALLTHROUGH*/
+      case 13:
+        hval += asso_values[(unsigned char)str[12]];
+      /*FALLTHROUGH*/
+      case 12:
+        hval += asso_values[(unsigned char)str[11]];
+      /*FALLTHROUGH*/
+      case 11:
+      case 10:
+      case 9:
+        hval += asso_values[(unsigned char)str[8]];
+      /*FALLTHROUGH*/
+      case 8:
+        hval += asso_values[(unsigned char)str[7]];
+      /*FALLTHROUGH*/
+      case 7:
+        hval += asso_values[(unsigned char)str[6]];
+      /*FALLTHROUGH*/
+      case 6:
+        hval += asso_values[(unsigned char)str[5]];
+      /*FALLTHROUGH*/
+      case 5:
+        hval += asso_values[(unsigned char)str[4]];
+      /*FALLTHROUGH*/
+      case 4:
+      case 3:
+        hval += asso_values[(unsigned char)str[2]];
+      /*FALLTHROUGH*/
+      case 2:
+      case 1:
+        hval += asso_values[(unsigned char)str[0]];
+        break;
+    }
+  return hval + asso_values[(unsigned char)str[len - 1]];
+}
+
+static const struct color colorlist[] =
+  {
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""},
+#line 627 "name2rgb.gperf"
+    {"grey4", 10, 10, 10},
+    {""},
+#line 625 "name2rgb.gperf"
+    {"grey3", 8, 8, 8},
+    {""}, {""}, {""}, {""}, {""},
+#line 623 "name2rgb.gperf"
+    {"grey2", 5, 5, 5},
+    {""},
+#line 621 "name2rgb.gperf"
+    {"grey1", 3, 3, 3},
+    {""}, {""}, {""},
+#line 707 "name2rgb.gperf"
+    {"grey44", 112, 112, 112},
+#line 687 "name2rgb.gperf"
+    {"grey34", 87, 87, 87},
+#line 705 "name2rgb.gperf"
+    {"grey43", 110, 110, 110},
+#line 685 "name2rgb.gperf"
+    {"grey33", 84, 84, 84},
+#line 667 "name2rgb.gperf"
+    {"grey24", 61, 61, 61},
+#line 647 "name2rgb.gperf"
+    {"grey14", 36, 36, 36},
+#line 665 "name2rgb.gperf"
+    {"grey23", 59, 59, 59},
+#line 645 "name2rgb.gperf"
+    {"grey13", 33, 33, 33},
+#line 703 "name2rgb.gperf"
+    {"grey42", 107, 107, 107},
+#line 683 "name2rgb.gperf"
+    {"grey32", 82, 82, 82},
+#line 701 "name2rgb.gperf"
+    {"grey41", 105, 105, 105},
+#line 681 "name2rgb.gperf"
+    {"grey31", 79, 79, 79},
+#line 663 "name2rgb.gperf"
+    {"grey22", 56, 56, 56},
+#line 643 "name2rgb.gperf"
+    {"grey12", 31, 31, 31},
+#line 661 "name2rgb.gperf"
+    {"grey21", 54, 54, 54},
+#line 641 "name2rgb.gperf"
+    {"grey11", 28, 28, 28},
+#line 626 "name2rgb.gperf"
+    {"gray4", 10, 10, 10},
+#line 449 "name2rgb.gperf"
+    {"green4", 0, 139, 0},
+#line 624 "name2rgb.gperf"
+    {"gray3", 8, 8, 8},
+#line 448 "name2rgb.gperf"
+    {"green3", 0, 205, 0},
+#line 214 "name2rgb.gperf"
+    {"green", 0, 255, 0},
+    {""}, {""}, {""},
+#line 622 "name2rgb.gperf"
+    {"gray2", 5, 5, 5},
+#line 447 "name2rgb.gperf"
+    {"green2", 0, 238, 0},
+#line 620 "name2rgb.gperf"
+    {"gray1", 3, 3, 3},
+#line 446 "name2rgb.gperf"
+    {"green1", 0, 255, 0},
+    {""}, {""},
+#line 706 "name2rgb.gperf"
+    {"gray44", 112, 112, 112},
+#line 686 "name2rgb.gperf"
+    {"gray34", 87, 87, 87},
+#line 704 "name2rgb.gperf"
+    {"gray43", 110, 110, 110},
+#line 684 "name2rgb.gperf"
+    {"gray33", 84, 84, 84},
+#line 666 "name2rgb.gperf"
+    {"gray24", 61, 61, 61},
+#line 646 "name2rgb.gperf"
+    {"gray14", 36, 36, 36},
+#line 664 "name2rgb.gperf"
+    {"gray23", 59, 59, 59},
+#line 644 "name2rgb.gperf"
+    {"gray13", 33, 33, 33},
+#line 702 "name2rgb.gperf"
+    {"gray42", 107, 107, 107},
+#line 682 "name2rgb.gperf"
+    {"gray32", 82, 82, 82},
+#line 700 "name2rgb.gperf"
+    {"gray41", 105, 105, 105},
+#line 680 "name2rgb.gperf"
+    {"gray31", 79, 79, 79},
+#line 662 "name2rgb.gperf"
+    {"gray22", 56, 56, 56},
+#line 642 "name2rgb.gperf"
+    {"gray12", 31, 31, 31},
+#line 660 "name2rgb.gperf"
+    {"gray21", 54, 54, 54},
+#line 640 "name2rgb.gperf"
+    {"gray11", 28, 28, 28},
+    {""},
+#line 557 "name2rgb.gperf"
+    {"red4", 139, 0, 0},
+#line 556 "name2rgb.gperf"
+    {"red3", 205, 0, 0},
+    {""}, {""},
+#line 555 "name2rgb.gperf"
+    {"red2", 238, 0, 0},
+#line 554 "name2rgb.gperf"
+    {"red1", 255, 0, 0},
+    {""},
+#line 481 "name2rgb.gperf"
+    {"gold4", 139, 117, 0},
+    {""},
+#line 480 "name2rgb.gperf"
+    {"gold3", 205, 173, 0},
+    {""},
+#line 309 "name2rgb.gperf"
+    {"snow4", 139, 137, 137},
+    {""},
+#line 308 "name2rgb.gperf"
+    {"snow3", 205, 201, 201},
+#line 501 "name2rgb.gperf"
+    {"sienna4", 139, 71, 38},
+#line 479 "name2rgb.gperf"
+    {"gold2", 238, 201, 0},
+#line 500 "name2rgb.gperf"
+    {"sienna3", 205, 104, 57},
+#line 478 "name2rgb.gperf"
+    {"gold1", 255, 215, 0},
+    {""},
+#line 307 "name2rgb.gperf"
+    {"snow2", 238, 233, 233},
+    {""},
+#line 306 "name2rgb.gperf"
+    {"snow1", 255, 250, 250},
+#line 499 "name2rgb.gperf"
+    {"sienna2", 238, 121, 66},
+    {""},
+#line 498 "name2rgb.gperf"
+    {"sienna1", 255, 130, 71},
+    {""}, {""}, {""}, {""}, {""},
+#line 250 "name2rgb.gperf"
+    {"sienna", 160, 82, 45},
+    {""},
+#line 445 "name2rgb.gperf"
+    {"springgreen4", 0, 139, 69},
+    {""},
+#line 444 "name2rgb.gperf"
+    {"springgreen3", 0, 205, 102},
+#line 211 "name2rgb.gperf"
+    {"springgreen", 0, 255, 127},
+    {""}, {""}, {""}, {""},
+#line 443 "name2rgb.gperf"
+    {"springgreen2", 0, 238, 118},
+    {""},
+#line 442 "name2rgb.gperf"
+    {"springgreen1", 0, 255, 127},
+    {""},
+#line 437 "name2rgb.gperf"
+    {"seagreen4", 46, 139, 87},
+    {""},
+#line 436 "name2rgb.gperf"
+    {"seagreen3", 67, 205, 128},
+#line 203 "name2rgb.gperf"
+    {"seagreen", 46, 139, 87},
+    {""}, {""}, {""}, {""},
+#line 435 "name2rgb.gperf"
+    {"seagreen2", 78, 238, 148},
+    {""},
+#line 434 "name2rgb.gperf"
+    {"seagreen1", 84, 255, 159},
+#line 266 "name2rgb.gperf"
+    {"orange", 255, 165, 0},
+    {""}, {""},
+#line 92 "name2rgb.gperf"
+    {"linen", 250, 240, 230},
+    {""}, {""},
+#line 202 "name2rgb.gperf"
+    {"sea green", 46, 139, 87},
+    {""}, {""}, {""}, {""},
+#line 238 "name2rgb.gperf"
+    {"gold", 255, 215, 0},
+    {""}, {""},
+#line 537 "name2rgb.gperf"
+    {"orange4", 139, 90, 0},
+    {""},
+#line 536 "name2rgb.gperf"
+    {"orange3", 205, 133, 0},
+#line 275 "name2rgb.gperf"
+    {"red", 255, 0, 0},
+#line 525 "name2rgb.gperf"
+    {"brown4", 139, 35, 35},
+    {""},
+#line 524 "name2rgb.gperf"
+    {"brown3", 205, 51, 51},
+#line 260 "name2rgb.gperf"
+    {"brown", 165, 42, 42},
+#line 535 "name2rgb.gperf"
+    {"orange2", 238, 154, 0},
+    {""},
+#line 534 "name2rgb.gperf"
+    {"orange1", 255, 165, 0},
+    {""},
+#line 523 "name2rgb.gperf"
+    {"brown2", 238, 59, 59},
+    {""},
+#line 522 "name2rgb.gperf"
+    {"brown1", 255, 64, 64},
+#line 513 "name2rgb.gperf"
+    {"tan4", 139, 90, 43},
+#line 512 "name2rgb.gperf"
+    {"tan3", 205, 133, 63},
+    {""}, {""},
+#line 511 "name2rgb.gperf"
+    {"tan2", 238, 154, 73},
+#line 510 "name2rgb.gperf"
+    {"tan1", 255, 165, 79},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""},
+#line 257 "name2rgb.gperf"
+    {"tan", 210, 180, 140},
+    {""}, {""}, {""}, {""}, {""},
+#line 197 "name2rgb.gperf"
+    {"darkgreen", 0, 100, 0},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 529 "name2rgb.gperf"
+    {"salmon4", 139, 76, 57},
+    {""},
+#line 528 "name2rgb.gperf"
+    {"salmon3", 205, 112, 84},
+#line 263 "name2rgb.gperf"
+    {"salmon", 250, 128, 114},
+#line 807 "name2rgb.gperf"
+    {"grey94", 240, 240, 240},
+    {""},
+#line 805 "name2rgb.gperf"
+    {"grey93", 237, 237, 237},
+    {""},
+#line 527 "name2rgb.gperf"
+    {"salmon2", 238, 130, 98},
+    {""},
+#line 526 "name2rgb.gperf"
+    {"salmon1", 255, 140, 105},
+    {""},
+#line 803 "name2rgb.gperf"
+    {"grey92", 235, 235, 235},
+    {""},
+#line 801 "name2rgb.gperf"
+    {"grey91", 232, 232, 232},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""},
+#line 433 "name2rgb.gperf"
+    {"darkseagreen4", 105, 139, 105},
+    {""},
+#line 432 "name2rgb.gperf"
+    {"darkseagreen3", 155, 205, 155},
+#line 201 "name2rgb.gperf"
+    {"darkseagreen", 143, 188, 143},
+    {""}, {""}, {""}, {""},
+#line 431 "name2rgb.gperf"
+    {"darkseagreen2", 180, 238, 180},
+#line 806 "name2rgb.gperf"
+    {"gray94", 240, 240, 240},
+#line 430 "name2rgb.gperf"
+    {"darkseagreen1", 193, 255, 193},
+#line 804 "name2rgb.gperf"
+    {"gray93", 237, 237, 237},
+    {""}, {""}, {""}, {""}, {""},
+#line 802 "name2rgb.gperf"
+    {"gray92", 235, 235, 235},
+    {""},
+#line 800 "name2rgb.gperf"
+    {"gray91", 232, 232, 232},
+    {""}, {""}, {""}, {""},
+#line 553 "name2rgb.gperf"
+    {"orangered4", 139, 37, 0},
+#line 552 "name2rgb.gperf"
+    {"orangered3", 205, 55, 0},
+    {""}, {""},
+#line 551 "name2rgb.gperf"
+    {"orangered2", 238, 64, 0},
+#line 550 "name2rgb.gperf"
+    {"orangered1", 255, 69, 0},
+    {""}, {""}, {""}, {""},
+#line 225 "name2rgb.gperf"
+    {"forestgreen", 34, 139, 34},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 831 "name2rgb.gperf"
+    {"darkred", 139, 0, 0},
+    {""},
+#line 268 "name2rgb.gperf"
+    {"darkorange", 255, 140, 0},
+#line 541 "name2rgb.gperf"
+    {"darkorange4", 139, 69, 0},
+#line 540 "name2rgb.gperf"
+    {"darkorange3", 205, 102, 0},
+    {""}, {""},
+#line 539 "name2rgb.gperf"
+    {"darkorange2", 238, 118, 0},
+#line 538 "name2rgb.gperf"
+    {"darkorange1", 255, 127, 0},
+    {""}, {""}, {""},
+#line 581 "name2rgb.gperf"
+    {"maroon4", 139, 28, 98},
+    {""},
+#line 580 "name2rgb.gperf"
+    {"maroon3", 205, 41, 144},
+#line 285 "name2rgb.gperf"
+    {"maroon", 176, 48, 96},
+    {""},
+#line 140 "name2rgb.gperf"
+    {"grey", 190, 190, 190},
+    {""}, {""},
+#line 579 "name2rgb.gperf"
+    {"maroon2", 238, 48, 167},
+    {""},
+#line 578 "name2rgb.gperf"
+    {"maroon1", 255, 52, 179},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 164 "name2rgb.gperf"
+    {"blue", 0, 0, 255},
+    {""}, {""},
+#line 833 "name2rgb.gperf"
+    {"lightgreen", 144, 238, 144},
+    {""}, {""},
+#line 485 "name2rgb.gperf"
+    {"goldenrod4", 139, 105, 20},
+#line 484 "name2rgb.gperf"
+    {"goldenrod3", 205, 155, 29},
+    {""}, {""},
+#line 483 "name2rgb.gperf"
+    {"goldenrod2", 238, 180, 34},
+#line 482 "name2rgb.gperf"
+    {"goldenrod1", 255, 193, 37},
+    {""},
+#line 113 "name2rgb.gperf"
+    {"azure", 240, 255, 255},
+#line 369 "name2rgb.gperf"
+    {"blue4", 0, 0, 139},
+#line 139 "name2rgb.gperf"
+    {"gray", 190, 190, 190},
+#line 368 "name2rgb.gperf"
+    {"blue3", 0, 0, 205},
+    {""}, {""}, {""}, {""},
+#line 221 "name2rgb.gperf"
+    {"limegreen", 50, 205, 50},
+#line 367 "name2rgb.gperf"
+    {"blue2", 0, 0, 238},
+#line 274 "name2rgb.gperf"
+    {"orangered", 255, 69, 0},
+#line 366 "name2rgb.gperf"
+    {"blue1", 0, 0, 255},
+    {""}, {""},
+#line 357 "name2rgb.gperf"
+    {"azure4", 131, 139, 139},
+#line 99 "name2rgb.gperf"
+    {"bisque", 255, 228, 196},
+#line 356 "name2rgb.gperf"
+    {"azure3", 193, 205, 205},
+    {""}, {""}, {""}, {""}, {""},
+#line 355 "name2rgb.gperf"
+    {"azure2", 224, 238, 238},
+    {""},
+#line 354 "name2rgb.gperf"
+    {"azure1", 240, 255, 255},
+#line 249 "name2rgb.gperf"
+    {"saddlebrown", 139, 69, 19},
+    {""}, {""}, {""},
+#line 321 "name2rgb.gperf"
+    {"bisque4", 139, 125, 107},
+    {""},
+#line 320 "name2rgb.gperf"
+    {"bisque3", 205, 183, 158},
+    {""}, {""}, {""}, {""}, {""},
+#line 319 "name2rgb.gperf"
+    {"bisque2", 238, 213, 183},
+    {""},
+#line 318 "name2rgb.gperf"
+    {"bisque1", 255, 228, 196},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""},
+#line 637 "name2rgb.gperf"
+    {"grey9", 23, 23, 23},
+    {""}, {""}, {""},
+#line 829 "name2rgb.gperf"
+    {"darkmagenta", 139, 0, 139},
+    {""}, {""}, {""}, {""}, {""},
+#line 207 "name2rgb.gperf"
+    {"lightseagreen", 32, 178, 170},
+#line 241 "name2rgb.gperf"
+    {"goldenrod", 218, 165, 32},
+    {""}, {""},
+#line 717 "name2rgb.gperf"
+    {"grey49", 125, 125, 125},
+#line 697 "name2rgb.gperf"
+    {"grey39", 99, 99, 99},
+    {""}, {""},
+#line 677 "name2rgb.gperf"
+    {"grey29", 74, 74, 74},
+#line 657 "name2rgb.gperf"
+    {"grey19", 48, 48, 48},
+    {""}, {""}, {""}, {""}, {""},
+#line 589 "name2rgb.gperf"
+    {"magenta4", 139, 0, 139},
+    {""},
+#line 588 "name2rgb.gperf"
+    {"magenta3", 205, 0, 205},
+    {""}, {""},
+#line 636 "name2rgb.gperf"
+    {"gray9", 23, 23, 23},
+    {""}, {""},
+#line 587 "name2rgb.gperf"
+    {"magenta2", 238, 0, 238},
+    {""},
+#line 586 "name2rgb.gperf"
+    {"magenta1", 255, 0, 255},
+    {""}, {""}, {""}, {""}, {""},
+#line 290 "name2rgb.gperf"
+    {"magenta", 255, 0, 255},
+    {""}, {""},
+#line 716 "name2rgb.gperf"
+    {"gray49", 125, 125, 125},
+#line 696 "name2rgb.gperf"
+    {"gray39", 99, 99, 99},
+    {""}, {""},
+#line 676 "name2rgb.gperf"
+    {"gray29", 74, 74, 74},
+#line 656 "name2rgb.gperf"
+    {"gray19", 48, 48, 48},
+    {""},
+#line 393 "name2rgb.gperf"
+    {"slategray4", 108, 123, 139},
+#line 392 "name2rgb.gperf"
+    {"slategray3", 159, 182, 205},
+    {""}, {""},
+#line 391 "name2rgb.gperf"
+    {"slategray2", 185, 211, 238},
+#line 390 "name2rgb.gperf"
+    {"slategray1", 198, 226, 255},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 313 "name2rgb.gperf"
+    {"seashell4", 139, 134, 130},
+    {""},
+#line 312 "name2rgb.gperf"
+    {"seashell3", 205, 197, 191},
+    {""},
+#line 569 "name2rgb.gperf"
+    {"pink4", 139, 99, 108},
+    {""},
+#line 568 "name2rgb.gperf"
+    {"pink3", 205, 145, 158},
+    {""},
+#line 311 "name2rgb.gperf"
+    {"seashell2", 238, 229, 222},
+    {""},
+#line 310 "name2rgb.gperf"
+    {"seashell1", 255, 245, 238},
+    {""},
+#line 567 "name2rgb.gperf"
+    {"pink2", 238, 169, 184},
+    {""},
+#line 566 "name2rgb.gperf"
+    {"pink1", 255, 181, 197},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 787 "name2rgb.gperf"
+    {"grey84", 214, 214, 214},
+    {""},
+#line 785 "name2rgb.gperf"
+    {"grey83", 212, 212, 212},
+    {""}, {""}, {""}, {""}, {""},
+#line 783 "name2rgb.gperf"
+    {"grey82", 209, 209, 209},
+    {""},
+#line 781 "name2rgb.gperf"
+    {"grey81", 207, 207, 207},
+    {""}, {""}, {""},
+#line 155 "name2rgb.gperf"
+    {"slateblue", 106, 90, 205},
+#line 361 "name2rgb.gperf"
+    {"slateblue4", 71, 60, 139},
+#line 360 "name2rgb.gperf"
+    {"slateblue3", 105, 89, 205},
+    {""}, {""},
+#line 359 "name2rgb.gperf"
+    {"slateblue2", 122, 103, 238},
+#line 358 "name2rgb.gperf"
+    {"slateblue1", 131, 111, 255},
+    {""}, {""}, {""}, {""}, {""},
+#line 262 "name2rgb.gperf"
+    {"darksalmon", 233, 150, 122},
+    {""}, {""}, {""},
+#line 786 "name2rgb.gperf"
+    {"gray84", 214, 214, 214},
+    {""},
+#line 784 "name2rgb.gperf"
+    {"gray83", 212, 212, 212},
+#line 109 "name2rgb.gperf"
+    {"seashell", 255, 245, 238},
+    {""}, {""}, {""}, {""},
+#line 782 "name2rgb.gperf"
+    {"gray82", 209, 209, 209},
+    {""},
+#line 780 "name2rgb.gperf"
+    {"gray81", 207, 207, 207},
+    {""}, {""}, {""}, {""},
+#line 825 "name2rgb.gperf"
+    {"darkblue", 0, 0, 139},
+    {""}, {""}, {""}, {""},
+#line 302 "name2rgb.gperf"
+    {"purple", 160, 32, 240},
+    {""},
+#line 174 "name2rgb.gperf"
+    {"steelblue", 70, 130, 180},
+#line 377 "name2rgb.gperf"
+    {"steelblue4", 54, 100, 139},
+#line 376 "name2rgb.gperf"
+    {"steelblue3", 79, 148, 205},
+    {""}, {""},
+#line 375 "name2rgb.gperf"
+    {"steelblue2", 92, 172, 238},
+#line 374 "name2rgb.gperf"
+    {"steelblue1", 99, 184, 255},
+    {""}, {""}, {""}, {""}, {""},
+#line 609 "name2rgb.gperf"
+    {"purple4", 85, 26, 139},
+    {""},
+#line 608 "name2rgb.gperf"
+    {"purple3", 125, 38, 205},
+    {""}, {""}, {""}, {""}, {""},
+#line 607 "name2rgb.gperf"
+    {"purple2", 145, 44, 238},
+    {""},
+#line 606 "name2rgb.gperf"
+    {"purple1", 155, 48, 255},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""},
+#line 533 "name2rgb.gperf"
+    {"lightsalmon4", 139, 87, 66},
+    {""},
+#line 532 "name2rgb.gperf"
+    {"lightsalmon3", 205, 129, 98},
+#line 265 "name2rgb.gperf"
+    {"lightsalmon", 255, 160, 122},
+#line 549 "name2rgb.gperf"
+    {"tomato4", 139, 54, 38},
+    {""},
+#line 548 "name2rgb.gperf"
+    {"tomato3", 205, 79, 57},
+    {""},
+#line 531 "name2rgb.gperf"
+    {"lightsalmon2", 238, 149, 114},
+#line 489 "name2rgb.gperf"
+    {"darkgoldenrod4", 139, 101, 8},
+#line 530 "name2rgb.gperf"
+    {"lightsalmon1", 255, 160, 122},
+#line 488 "name2rgb.gperf"
+    {"darkgoldenrod3", 205, 149, 12},
+#line 547 "name2rgb.gperf"
+    {"tomato2", 238, 92, 66},
+    {""},
+#line 546 "name2rgb.gperf"
+    {"tomato1", 255, 99, 71},
+#line 817 "name2rgb.gperf"
+    {"grey99", 252, 252, 252},
+    {""},
+#line 487 "name2rgb.gperf"
+    {"darkgoldenrod2", 238, 173, 14},
+    {""},
+#line 486 "name2rgb.gperf"
+    {"darkgoldenrod1", 255, 185, 15},
+    {""}, {""}, {""},
+#line 441 "name2rgb.gperf"
+    {"palegreen4", 84, 139, 84},
+#line 440 "name2rgb.gperf"
+    {"palegreen3", 124, 205, 124},
+    {""}, {""},
+#line 439 "name2rgb.gperf"
+    {"palegreen2", 144, 238, 144},
+#line 438 "name2rgb.gperf"
+    {"palegreen1", 154, 255, 154},
+    {""}, {""}, {""},
+#line 120 "name2rgb.gperf"
+    {"mistyrose", 255, 228, 225},
+#line 353 "name2rgb.gperf"
+    {"mistyrose4", 139, 125, 123},
+#line 352 "name2rgb.gperf"
+    {"mistyrose3", 205, 183, 181},
+    {""}, {""},
+#line 351 "name2rgb.gperf"
+    {"mistyrose2", 238, 213, 210},
+#line 350 "name2rgb.gperf"
+    {"mistyrose1", 255, 228, 225},
+#line 209 "name2rgb.gperf"
+    {"palegreen", 152, 251, 152},
+    {""}, {""}, {""}, {""}, {""},
+#line 816 "name2rgb.gperf"
+    {"gray99", 252, 252, 252},
+#line 166 "name2rgb.gperf"
+    {"dodgerblue", 30, 144, 255},
+#line 373 "name2rgb.gperf"
+    {"dodgerblue4", 16, 78, 139},
+#line 372 "name2rgb.gperf"
+    {"dodgerblue3", 24, 116, 205},
+    {""}, {""},
+#line 371 "name2rgb.gperf"
+    {"dodgerblue2", 28, 134, 238},
+#line 370 "name2rgb.gperf"
+    {"dodgerblue1", 30, 144, 255},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 272 "name2rgb.gperf"
+    {"tomato", 255, 99, 71},
+    {""}, {""}, {""}, {""}, {""},
+#line 243 "name2rgb.gperf"
+    {"darkgoldenrod", 184, 134, 11},
+    {""},
+#line 210 "name2rgb.gperf"
+    {"spring green", 0, 255, 127},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""},
+#line 253 "name2rgb.gperf"
+    {"beige", 245, 245, 220},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""},
+#line 196 "name2rgb.gperf"
+    {"dark green", 0, 100, 0},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""},
+#line 178 "name2rgb.gperf"
+    {"lightblue", 173, 216, 230},
+#line 401 "name2rgb.gperf"
+    {"lightblue4", 104, 131, 139},
+#line 400 "name2rgb.gperf"
+    {"lightblue3", 154, 192, 205},
+    {""}, {""},
+#line 399 "name2rgb.gperf"
+    {"lightblue2", 178, 223, 238},
+#line 398 "name2rgb.gperf"
+    {"lightblue1", 191, 239, 255},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 170 "name2rgb.gperf"
+    {"skyblue", 135, 206, 235},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 134 "name2rgb.gperf"
+    {"slategrey", 112, 128, 144},
+    {""}, {""}, {""}, {""},
+#line 251 "name2rgb.gperf"
+    {"peru", 205, 133, 63},
+#line 385 "name2rgb.gperf"
+    {"skyblue4", 74, 112, 139},
+    {""},
+#line 384 "name2rgb.gperf"
+    {"skyblue3", 108, 166, 205},
+    {""}, {""}, {""}, {""}, {""},
+#line 383 "name2rgb.gperf"
+    {"skyblue2", 126, 192, 238},
+#line 153 "name2rgb.gperf"
+    {"darkslateblue", 72, 61, 139},
+#line 382 "name2rgb.gperf"
+    {"skyblue1", 135, 206, 255},
+#line 597 "name2rgb.gperf"
+    {"plum4", 139, 102, 139},
+    {""},
+#line 596 "name2rgb.gperf"
+    {"plum3", 205, 150, 205},
+    {""}, {""}, {""}, {""}, {""},
+#line 595 "name2rgb.gperf"
+    {"plum2", 238, 174, 238},
+    {""},
+#line 594 "name2rgb.gperf"
+    {"plum1", 255, 187, 255},
+    {""}, {""},
+#line 132 "name2rgb.gperf"
+    {"slategray", 112, 128, 144},
+#line 821 "name2rgb.gperf"
+    {"darkgrey", 169, 169, 169},
+#line 469 "name2rgb.gperf"
+    {"lightgoldenrod4", 139, 129, 76},
+    {""},
+#line 468 "name2rgb.gperf"
+    {"lightgoldenrod3", 205, 190, 112},
+    {""}, {""},
+#line 169 "name2rgb.gperf"
+    {"sky blue", 135, 206, 235},
+    {""}, {""},
+#line 467 "name2rgb.gperf"
+    {"lightgoldenrod2", 238, 220, 130},
+    {""},
+#line 466 "name2rgb.gperf"
+    {"lightgoldenrod1", 255, 236, 139},
+    {""}, {""}, {""}, {""}, {""},
+#line 473 "name2rgb.gperf"
+    {"lightyellow4", 139, 139, 122},
+#line 273 "name2rgb.gperf"
+    {"orange red", 255, 69, 0},
+#line 472 "name2rgb.gperf"
+    {"lightyellow3", 205, 205, 180},
+    {""}, {""}, {""}, {""}, {""},
+#line 471 "name2rgb.gperf"
+    {"lightyellow2", 238, 238, 209},
+#line 45 "name2rgb.gperf"
+    {"scilabgreen4", 0, 144, 0},
+#line 470 "name2rgb.gperf"
+    {"lightyellow1", 255, 255, 224},
+#line 47 "name2rgb.gperf"
+    {"scilabgreen3", 0, 176, 0},
+    {""},
+#line 823 "name2rgb.gperf"
+    {"darkgray", 169, 169, 169},
+    {""}, {""}, {""},
+#line 49 "name2rgb.gperf"
+    {"scilabgreen2", 0, 208, 0},
+    {""}, {""}, {""},
+#line 267 "name2rgb.gperf"
+    {"dark orange", 255, 140, 0},
+    {""}, {""}, {""}, {""}, {""},
+#line 425 "name2rgb.gperf"
+    {"darkslategray4", 82, 139, 139},
+#line 421 "name2rgb.gperf"
+    {"cyan4", 0, 139, 139},
+#line 424 "name2rgb.gperf"
+    {"darkslategray3", 121, 205, 205},
+#line 420 "name2rgb.gperf"
+    {"cyan3", 0, 205, 205},
+#line 188 "name2rgb.gperf"
+    {"cyan", 0, 255, 255},
+#line 830 "name2rgb.gperf"
+    {"dark red", 139, 0, 0},
+    {""}, {""},
+#line 423 "name2rgb.gperf"
+    {"darkslategray2", 141, 238, 238},
+#line 419 "name2rgb.gperf"
+    {"cyan2", 0, 238, 238},
+#line 422 "name2rgb.gperf"
+    {"darkslategray1", 151, 255, 255},
+#line 418 "name2rgb.gperf"
+    {"cyan1", 0, 255, 255},
+    {""}, {""}, {""},
+#line 224 "name2rgb.gperf"
+    {"forest green", 34, 139, 34},
+#line 240 "name2rgb.gperf"
+    {"lightgoldenrod", 238, 221, 130},
+    {""}, {""}, {""},
+#line 248 "name2rgb.gperf"
+    {"saddle brown", 139, 69, 19},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 832 "name2rgb.gperf"
+    {"light green", 144, 238, 144},
+#line 220 "name2rgb.gperf"
+    {"lime green", 50, 205, 50},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 57 "name2rgb.gperf"
+    {"scilabred4", 144, 0, 0},
+#line 59 "name2rgb.gperf"
+    {"scilabred3", 176, 0, 0},
+    {""}, {""},
+#line 61 "name2rgb.gperf"
+    {"scilabred2", 208, 0, 0},
+#line 165 "name2rgb.gperf"
+    {"dodger blue", 30, 144, 255},
+#line 163 "name2rgb.gperf"
+    {"royalblue", 65, 105, 225},
+#line 365 "name2rgb.gperf"
+    {"royalblue4", 39, 64, 139},
+#line 364 "name2rgb.gperf"
+    {"royalblue3", 58, 95, 205},
+    {""}, {""},
+#line 363 "name2rgb.gperf"
+    {"royalblue2", 67, 110, 238},
+#line 362 "name2rgb.gperf"
+    {"royalblue1", 72, 118, 255},
+    {""}, {""},
+#line 545 "name2rgb.gperf"
+    {"coral4", 139, 62, 47},
+    {""},
+#line 544 "name2rgb.gperf"
+    {"coral3", 205, 91, 69},
+    {""},
+#line 176 "name2rgb.gperf"
+    {"lightsteelblue", 176, 196, 222},
+#line 797 "name2rgb.gperf"
+    {"grey89", 227, 227, 227},
+    {""}, {""},
+#line 543 "name2rgb.gperf"
+    {"coral2", 238, 106, 80},
+#line 205 "name2rgb.gperf"
+    {"mediumseagreen", 60, 179, 113},
+#line 542 "name2rgb.gperf"
+    {"coral1", 255, 114, 86},
+#line 280 "name2rgb.gperf"
+    {"pink", 255, 192, 203},
+    {""}, {""}, {""}, {""}, {""},
+#line 292 "name2rgb.gperf"
+    {"plum", 221, 160, 221},
+#line 397 "name2rgb.gperf"
+    {"lightsteelblue4", 110, 123, 139},
+    {""},
+#line 396 "name2rgb.gperf"
+    {"lightsteelblue3", 162, 181, 205},
+    {""}, {""}, {""}, {""}, {""},
+#line 395 "name2rgb.gperf"
+    {"lightsteelblue2", 188, 210, 238},
+    {""},
+#line 394 "name2rgb.gperf"
+    {"lightsteelblue1", 202, 225, 255},
+#line 130 "name2rgb.gperf"
+    {"dimgrey", 105, 105, 105},
+#line 69 "name2rgb.gperf"
+    {"scilabbrown4", 128, 48, 0},
+    {""},
+#line 71 "name2rgb.gperf"
+    {"scilabbrown3", 160, 64, 0},
+    {""}, {""},
+#line 796 "name2rgb.gperf"
+    {"gray89", 227, 227, 227},
+    {""}, {""},
+#line 73 "name2rgb.gperf"
+    {"scilabbrown2", 192, 96, 0},
+    {""}, {""}, {""}, {""},
+#line 129 "name2rgb.gperf"
+    {"dim grey", 105, 105, 105},
+#line 497 "name2rgb.gperf"
+    {"indianred4", 139, 58, 58},
+#line 496 "name2rgb.gperf"
+    {"indianred3", 205, 85, 85},
+    {""}, {""},
+#line 495 "name2rgb.gperf"
+    {"indianred2", 238, 99, 99},
+#line 494 "name2rgb.gperf"
+    {"indianred1", 255, 106, 106},
+#line 142 "name2rgb.gperf"
+    {"lightgrey", 211, 211, 211},
+    {""}, {""},
+#line 122 "name2rgb.gperf"
+    {"black", 0, 0, 0},
+#line 269 "name2rgb.gperf"
+    {"coral", 255, 127, 80},
+    {""},
+#line 133 "name2rgb.gperf"
+    {"slate grey", 112, 128, 144},
+#line 457 "name2rgb.gperf"
+    {"olivedrab4", 105, 139, 34},
+#line 456 "name2rgb.gperf"
+    {"olivedrab3", 154, 205, 50},
+#line 128 "name2rgb.gperf"
+    {"dimgray", 105, 105, 105},
+    {""},
+#line 455 "name2rgb.gperf"
+    {"olivedrab2", 179, 238, 58},
+#line 454 "name2rgb.gperf"
+    {"olivedrab1", 192, 255, 62},
+    {""},
+#line 635 "name2rgb.gperf"
+    {"grey8", 20, 20, 20},
+    {""},
+#line 828 "name2rgb.gperf"
+    {"dark magenta", 139, 0, 139},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 127 "name2rgb.gperf"
+    {"dim gray", 105, 105, 105},
+    {""},
+#line 206 "name2rgb.gperf"
+    {"light sea green", 32, 178, 170},
+    {""},
+#line 261 "name2rgb.gperf"
+    {"dark salmon", 233, 150, 122},
+#line 715 "name2rgb.gperf"
+    {"grey48", 122, 122, 122},
+#line 695 "name2rgb.gperf"
+    {"grey38", 97, 97, 97},
+#line 144 "name2rgb.gperf"
+    {"lightgray", 211, 211, 211},
+    {""},
+#line 675 "name2rgb.gperf"
+    {"grey28", 71, 71, 71},
+#line 655 "name2rgb.gperf"
+    {"grey18", 46, 46, 46},
+    {""}, {""},
+#line 131 "name2rgb.gperf"
+    {"slate gray", 112, 128, 144},
+#line 227 "name2rgb.gperf"
+    {"olivedrab", 107, 142, 35},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 634 "name2rgb.gperf"
+    {"gray8", 20, 20, 20},
+    {""}, {""},
+#line 87 "name2rgb.gperf"
+    {"gainsboro", 220, 220, 220},
+    {""},
+#line 264 "name2rgb.gperf"
+    {"light salmon", 255, 160, 122},
+    {""}, {""},
+#line 159 "name2rgb.gperf"
+    {"lightslateblue", 132, 112, 255},
+    {""}, {""}, {""}, {""}, {""},
+#line 714 "name2rgb.gperf"
+    {"gray48", 122, 122, 122},
+#line 694 "name2rgb.gperf"
+    {"gray38", 97, 97, 97},
+    {""}, {""},
+#line 674 "name2rgb.gperf"
+    {"gray28", 71, 71, 71},
+#line 654 "name2rgb.gperf"
+    {"gray18", 46, 46, 46},
+    {""}, {""},
+#line 247 "name2rgb.gperf"
+    {"indianred", 205, 92, 92},
+#line 168 "name2rgb.gperf"
+    {"deepskyblue", 0, 191, 255},
+    {""},
+#line 91 "name2rgb.gperf"
+    {"oldlace", 253, 245, 230},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 184 "name2rgb.gperf"
+    {"darkturquoise", 0, 206, 209},
+    {""}, {""}, {""},
+#line 381 "name2rgb.gperf"
+    {"deepskyblue4", 0, 104, 139},
+    {""},
+#line 380 "name2rgb.gperf"
+    {"deepskyblue3", 0, 154, 205},
+    {""}, {""}, {""},
+#line 154 "name2rgb.gperf"
+    {"slate blue", 106, 90, 205},
+    {""},
+#line 379 "name2rgb.gperf"
+    {"deepskyblue2", 0, 178, 238},
+    {""},
+#line 378 "name2rgb.gperf"
+    {"deepskyblue1", 0, 191, 255},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""},
+#line 767 "name2rgb.gperf"
+    {"grey74", 189, 189, 189},
+    {""},
+#line 765 "name2rgb.gperf"
+    {"grey73", 186, 186, 186},
+    {""}, {""},
+#line 341 "name2rgb.gperf"
+    {"ivory4", 139, 139, 131},
+    {""},
+#line 340 "name2rgb.gperf"
+    {"ivory3", 205, 205, 193},
+#line 763 "name2rgb.gperf"
+    {"grey72", 184, 184, 184},
+#line 255 "name2rgb.gperf"
+    {"sandy brown", 244, 164, 96},
+#line 761 "name2rgb.gperf"
+    {"grey71", 181, 181, 181},
+    {""}, {""},
+#line 339 "name2rgb.gperf"
+    {"ivory2", 238, 238, 224},
+    {""},
+#line 338 "name2rgb.gperf"
+    {"ivory1", 255, 255, 240},
+    {""},
+#line 305 "name2rgb.gperf"
+    {"thistle", 216, 191, 216},
+    {""}, {""},
+#line 173 "name2rgb.gperf"
+    {"steel blue", 70, 130, 180},
+    {""}, {""}, {""}, {""}, {""},
+#line 824 "name2rgb.gperf"
+    {"dark blue", 0, 0, 139},
+    {""},
+#line 126 "name2rgb.gperf"
+    {"darkslategrey", 47, 79, 79},
+    {""},
+#line 766 "name2rgb.gperf"
+    {"gray74", 189, 189, 189},
+#line 617 "name2rgb.gperf"
+    {"thistle4", 139, 123, 139},
+#line 764 "name2rgb.gperf"
+    {"gray73", 186, 186, 186},
+#line 616 "name2rgb.gperf"
+    {"thistle3", 205, 181, 205},
+    {""}, {""}, {""}, {""},
+#line 762 "name2rgb.gperf"
+    {"gray72", 184, 184, 184},
+#line 615 "name2rgb.gperf"
+    {"thistle2", 238, 210, 238},
+#line 760 "name2rgb.gperf"
+    {"gray71", 181, 181, 181},
+#line 614 "name2rgb.gperf"
+    {"thistle1", 255, 225, 255},
+    {""}, {""}, {""},
+#line 172 "name2rgb.gperf"
+    {"lightskyblue", 135, 206, 250},
+#line 90 "name2rgb.gperf"
+    {"old lace", 253, 245, 230},
+    {""}, {""}, {""}, {""},
+#line 232 "name2rgb.gperf"
+    {"palegoldenrod", 238, 232, 170},
+    {""}, {""},
+#line 747 "name2rgb.gperf"
+    {"grey64", 163, 163, 163},
+    {""},
+#line 745 "name2rgb.gperf"
+    {"grey63", 161, 161, 161},
+    {""},
+#line 124 "name2rgb.gperf"
+    {"darkslategray", 47, 79, 79},
+#line 389 "name2rgb.gperf"
+    {"lightskyblue4", 96, 123, 139},
+    {""},
+#line 388 "name2rgb.gperf"
+    {"lightskyblue3", 141, 182, 205},
+#line 743 "name2rgb.gperf"
+    {"grey62", 158, 158, 158},
+    {""},
+#line 741 "name2rgb.gperf"
+    {"grey61", 156, 156, 156},
+    {""}, {""},
+#line 387 "name2rgb.gperf"
+    {"lightskyblue2", 164, 211, 238},
+#line 465 "name2rgb.gperf"
+    {"khaki4", 139, 134, 78},
+#line 386 "name2rgb.gperf"
+    {"lightskyblue1", 176, 226, 255},
+#line 464 "name2rgb.gperf"
+    {"khaki3", 205, 198, 115},
+    {""}, {""}, {""}, {""}, {""},
+#line 463 "name2rgb.gperf"
+    {"khaki2", 238, 230, 133},
+#line 208 "name2rgb.gperf"
+    {"pale green", 152, 251, 152},
+#line 462 "name2rgb.gperf"
+    {"khaki1", 255, 246, 143},
+    {""}, {""},
+#line 141 "name2rgb.gperf"
+    {"light grey", 211, 211, 211},
+    {""}, {""},
+#line 746 "name2rgb.gperf"
+    {"gray64", 163, 163, 163},
+    {""},
+#line 744 "name2rgb.gperf"
+    {"gray63", 161, 161, 161},
+#line 119 "name2rgb.gperf"
+    {"misty rose", 255, 228, 225},
+#line 115 "name2rgb.gperf"
+    {"aliceblue", 240, 248, 255},
+    {""}, {""}, {""},
+#line 742 "name2rgb.gperf"
+    {"gray62", 158, 158, 158},
+    {""},
+#line 740 "name2rgb.gperf"
+    {"gray61", 156, 156, 156},
+    {""}, {""}, {""},
+#line 815 "name2rgb.gperf"
+    {"grey98", 250, 250, 250},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""},
+#line 143 "name2rgb.gperf"
+    {"light gray", 211, 211, 211},
+#line 161 "name2rgb.gperf"
+    {"mediumblue", 0, 0, 205},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 39 "name2rgb.gperf"
+    {"scilabblue4", 0, 0, 144},
+#line 41 "name2rgb.gperf"
+    {"scilabblue3", 0, 0, 176},
+    {""}, {""},
+#line 43 "name2rgb.gperf"
+    {"scilabblue2", 0, 0, 208},
+    {""}, {""},
+#line 814 "name2rgb.gperf"
+    {"gray98", 250, 250, 250},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 242 "name2rgb.gperf"
+    {"dark goldenrod", 184, 134, 11},
+    {""}, {""}, {""}, {""}, {""},
+#line 63 "name2rgb.gperf"
+    {"scilabmagenta4", 144, 0, 144},
+    {""},
+#line 65 "name2rgb.gperf"
+    {"scilabmagenta3", 176, 0, 176},
+    {""}, {""}, {""}, {""}, {""},
+#line 67 "name2rgb.gperf"
+    {"scilabmagenta2", 208, 0, 208},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 177 "name2rgb.gperf"
+    {"light blue", 173, 216, 230},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""},
+#line 187 "name2rgb.gperf"
+    {"turquoise", 64, 224, 208},
+#line 417 "name2rgb.gperf"
+    {"turquoise4", 0, 134, 139},
+#line 416 "name2rgb.gperf"
+    {"turquoise3", 0, 197, 205},
+    {""},
+#line 138 "name2rgb.gperf"
+    {"lightslategrey", 119, 136, 153},
+#line 415 "name2rgb.gperf"
+    {"turquoise2", 0, 229, 238},
+#line 414 "name2rgb.gperf"
+    {"turquoise1", 0, 245, 255},
+    {""},
+#line 195 "name2rgb.gperf"
+    {"aquamarine", 127, 255, 212},
+#line 429 "name2rgb.gperf"
+    {"aquamarine4", 69, 139, 116},
+#line 428 "name2rgb.gperf"
+    {"aquamarine3", 102, 205, 170},
+    {""}, {""},
+#line 427 "name2rgb.gperf"
+    {"aquamarine2", 118, 238, 198},
+#line 426 "name2rgb.gperf"
+    {"aquamarine1", 127, 255, 212},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""},
+#line 271 "name2rgb.gperf"
+    {"lightcoral", 240, 128, 128},
+#line 258 "name2rgb.gperf"
+    {"chocolate", 210, 105, 30},
+#line 517 "name2rgb.gperf"
+    {"chocolate4", 139, 69, 19},
+#line 516 "name2rgb.gperf"
+    {"chocolate3", 205, 102, 29},
+    {""}, {""},
+#line 515 "name2rgb.gperf"
+    {"chocolate2", 238, 118, 33},
+#line 514 "name2rgb.gperf"
+    {"chocolate1", 255, 127, 36},
+    {""},
+#line 136 "name2rgb.gperf"
+    {"lightslategray", 119, 136, 153},
+    {""}, {""},
+#line 727 "name2rgb.gperf"
+    {"grey54", 138, 138, 138},
+    {""},
+#line 725 "name2rgb.gperf"
+    {"grey53", 135, 135, 135},
+    {""}, {""}, {""}, {""}, {""},
+#line 723 "name2rgb.gperf"
+    {"grey52", 133, 133, 133},
+    {""},
+#line 721 "name2rgb.gperf"
+    {"grey51", 130, 130, 130},
+    {""},
+#line 827 "name2rgb.gperf"
+    {"darkcyan", 0, 139, 139},
+#line 56 "name2rgb.gperf"
+    {"scilab red4", 144, 0, 0},
+#line 58 "name2rgb.gperf"
+    {"scilab red3", 176, 0, 0},
+#line 820 "name2rgb.gperf"
+    {"dark grey", 169, 169, 169},
+    {""},
+#line 60 "name2rgb.gperf"
+    {"scilab red2", 208, 0, 0},
+#line 217 "name2rgb.gperf"
+    {"mediumspringgreen", 0, 250, 154},
+#line 239 "name2rgb.gperf"
+    {"light goldenrod", 238, 221, 130},
+    {""}, {""}, {""}, {""},
+#line 200 "name2rgb.gperf"
+    {"dark sea green", 143, 188, 143},
+    {""}, {""}, {""}, {""}, {""},
+#line 726 "name2rgb.gperf"
+    {"gray54", 138, 138, 138},
+    {""},
+#line 724 "name2rgb.gperf"
+    {"gray53", 135, 135, 135},
+    {""}, {""}, {""}, {""}, {""},
+#line 722 "name2rgb.gperf"
+    {"gray52", 133, 133, 133},
+    {""},
+#line 720 "name2rgb.gperf"
+    {"gray51", 130, 130, 130},
+    {""}, {""}, {""}, {""},
+#line 822 "name2rgb.gperf"
+    {"dark gray", 169, 169, 169},
+#line 215 "name2rgb.gperf"
+    {"chartreuse", 127, 255, 0},
+#line 453 "name2rgb.gperf"
+    {"chartreuse4", 69, 139, 0},
+#line 452 "name2rgb.gperf"
+    {"chartreuse3", 102, 205, 0},
+    {""}, {""},
+#line 451 "name2rgb.gperf"
+    {"chartreuse2", 118, 238, 0},
+#line 450 "name2rgb.gperf"
+    {"chartreuse1", 127, 255, 0},
+    {""}, {""},
+#line 157 "name2rgb.gperf"
+    {"mediumslateblue", 123, 104, 238},
+    {""}, {""},
+#line 44 "name2rgb.gperf"
+    {"scilab green4", 0, 144, 0},
+    {""},
+#line 46 "name2rgb.gperf"
+    {"scilab green3", 0, 176, 0},
+#line 106 "name2rgb.gperf"
+    {"ivory", 255, 255, 240},
+    {""}, {""}, {""}, {""},
+#line 48 "name2rgb.gperf"
+    {"scilab green2", 0, 208, 0},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 82 "name2rgb.gperf"
+    {"snow", 255, 250, 250},
+    {""}, {""}, {""},
+#line 204 "name2rgb.gperf"
+    {"medium sea green", 60, 179, 113},
+    {""},
+#line 146 "name2rgb.gperf"
+    {"midnightblue", 25, 25, 112},
+    {""}, {""}, {""}, {""},
+#line 112 "name2rgb.gperf"
+    {"mintcream", 245, 255, 250},
+    {""}, {""},
+#line 68 "name2rgb.gperf"
+    {"scilab brown4", 128, 48, 0},
+    {""},
+#line 70 "name2rgb.gperf"
+    {"scilab brown3", 160, 64, 0},
+#line 162 "name2rgb.gperf"
+    {"royal blue", 65, 105, 225},
+    {""}, {""}, {""}, {""},
+#line 72 "name2rgb.gperf"
+    {"scilab brown2", 192, 96, 0},
+    {""}, {""}, {""}, {""},
+#line 160 "name2rgb.gperf"
+    {"medium blue", 0, 0, 205},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 152 "name2rgb.gperf"
+    {"dark slate blue", 72, 61, 139},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 38 "name2rgb.gperf"
+    {"scilab blue4", 0, 0, 144},
+    {""},
+#line 40 "name2rgb.gperf"
+    {"scilab blue3", 0, 0, 176},
+    {""}, {""}, {""}, {""}, {""},
+#line 42 "name2rgb.gperf"
+    {"scilab blue2", 0, 0, 208},
+    {""},
+#line 795 "name2rgb.gperf"
+    {"grey88", 224, 224, 224},
+    {""}, {""}, {""},
+#line 777 "name2rgb.gperf"
+    {"grey79", 201, 201, 201},
+    {""}, {""}, {""},
+#line 116 "name2rgb.gperf"
+    {"lavender", 230, 230, 250},
+    {""},
+#line 246 "name2rgb.gperf"
+    {"indian red", 205, 92, 92},
+#line 405 "name2rgb.gperf"
+    {"lightcyan4", 122, 139, 139},
+#line 404 "name2rgb.gperf"
+    {"lightcyan3", 180, 205, 205},
+    {""}, {""},
+#line 403 "name2rgb.gperf"
+    {"lightcyan2", 209, 238, 238},
+#line 402 "name2rgb.gperf"
+    {"lightcyan1", 224, 255, 255},
+    {""}, {""}, {""}, {""}, {""},
+#line 182 "name2rgb.gperf"
+    {"paleturquoise", 175, 238, 238},
+#line 226 "name2rgb.gperf"
+    {"olive drab", 107, 142, 35},
+    {""}, {""}, {""},
+#line 190 "name2rgb.gperf"
+    {"lightcyan", 224, 255, 255},
+    {""}, {""},
+#line 794 "name2rgb.gperf"
+    {"gray88", 224, 224, 224},
+    {""}, {""}, {""},
+#line 776 "name2rgb.gperf"
+    {"gray79", 201, 201, 201},
+    {""},
+#line 409 "name2rgb.gperf"
+    {"paleturquoise4", 102, 139, 139},
+    {""},
+#line 408 "name2rgb.gperf"
+    {"paleturquoise3", 150, 205, 205},
+#line 509 "name2rgb.gperf"
+    {"wheat4", 139, 126, 102},
+    {""},
+#line 508 "name2rgb.gperf"
+    {"wheat3", 205, 186, 150},
+    {""},
+#line 213 "name2rgb.gperf"
+    {"lawngreen", 124, 252, 0},
+#line 407 "name2rgb.gperf"
+    {"paleturquoise2", 174, 238, 238},
+    {""},
+#line 406 "name2rgb.gperf"
+    {"paleturquoise1", 187, 255, 255},
+#line 507 "name2rgb.gperf"
+    {"wheat2", 238, 216, 174},
+    {""},
+#line 506 "name2rgb.gperf"
+    {"wheat1", 255, 231, 186},
+    {""},
+#line 192 "name2rgb.gperf"
+    {"cadetblue", 95, 158, 160},
+#line 413 "name2rgb.gperf"
+    {"cadetblue4", 83, 134, 139},
+#line 412 "name2rgb.gperf"
+    {"cadetblue3", 122, 197, 205},
+    {""}, {""},
+#line 411 "name2rgb.gperf"
+    {"cadetblue2", 142, 229, 238},
+#line 410 "name2rgb.gperf"
+    {"cadetblue1", 152, 245, 255},
+#line 757 "name2rgb.gperf"
+    {"grey69", 176, 176, 176},
+    {""}, {""}, {""}, {""}, {""},
+#line 493 "name2rgb.gperf"
+    {"rosybrown4", 139, 105, 105},
+#line 492 "name2rgb.gperf"
+    {"rosybrown3", 205, 155, 155},
+    {""}, {""},
+#line 491 "name2rgb.gperf"
+    {"rosybrown2", 238, 180, 180},
+#line 490 "name2rgb.gperf"
+    {"rosybrown1", 255, 193, 193},
+    {""}, {""}, {""},
+#line 565 "name2rgb.gperf"
+    {"hotpink4", 139, 58, 98},
+    {""},
+#line 564 "name2rgb.gperf"
+    {"hotpink3", 205, 96, 144},
+    {""}, {""}, {""}, {""},
+#line 245 "name2rgb.gperf"
+    {"rosybrown", 188, 143, 143},
+#line 563 "name2rgb.gperf"
+    {"hotpink2", 238, 106, 167},
+    {""},
+#line 562 "name2rgb.gperf"
+    {"hotpink1", 255, 110, 180},
+    {""}, {""}, {""},
+#line 304 "name2rgb.gperf"
+    {"mediumpurple", 147, 112, 219},
+#line 756 "name2rgb.gperf"
+    {"gray69", 176, 176, 176},
+#line 147 "name2rgb.gperf"
+    {"navy", 0, 0, 128},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 613 "name2rgb.gperf"
+    {"mediumpurple4", 93, 71, 139},
+    {""},
+#line 612 "name2rgb.gperf"
+    {"mediumpurple3", 137, 104, 205},
+    {""}, {""}, {""}, {""},
+#line 98 "name2rgb.gperf"
+    {"blanchedalmond", 255, 235, 205},
+#line 611 "name2rgb.gperf"
+    {"mediumpurple2", 159, 121, 238},
+    {""},
+#line 610 "name2rgb.gperf"
+    {"mediumpurple1", 171, 130, 255},
+    {""}, {""}, {""}, {""},
+#line 325 "name2rgb.gperf"
+    {"peachpuff4", 139, 119, 101},
+#line 324 "name2rgb.gperf"
+    {"peachpuff3", 205, 175, 149},
+    {""}, {""},
+#line 323 "name2rgb.gperf"
+    {"peachpuff2", 238, 203, 173},
+#line 322 "name2rgb.gperf"
+    {"peachpuff1", 255, 218, 185},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 101 "name2rgb.gperf"
+    {"peachpuff", 255, 218, 185},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 585 "name2rgb.gperf"
+    {"violetred4", 139, 34, 82},
+#line 584 "name2rgb.gperf"
+    {"violetred3", 205, 50, 120},
+    {""}, {""},
+#line 583 "name2rgb.gperf"
+    {"violetred2", 238, 58, 140},
+#line 582 "name2rgb.gperf"
+    {"violetred1", 255, 62, 150},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 593 "name2rgb.gperf"
+    {"orchid4", 139, 71, 137},
+    {""},
+#line 592 "name2rgb.gperf"
+    {"orchid3", 205, 105, 201},
+    {""}, {""},
+#line 254 "name2rgb.gperf"
+    {"wheat", 245, 222, 179},
+    {""}, {""},
+#line 591 "name2rgb.gperf"
+    {"orchid2", 238, 122, 233},
+    {""},
+#line 590 "name2rgb.gperf"
+    {"orchid1", 255, 131, 250},
+    {""},
+#line 291 "name2rgb.gperf"
+    {"violet", 238, 130, 238},
+    {""}, {""}, {""}, {""},
+#line 125 "name2rgb.gperf"
+    {"dark slate grey", 47, 79, 79},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 231 "name2rgb.gperf"
+    {"pale goldenrod", 238, 232, 170},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 123 "name2rgb.gperf"
+    {"dark slate gray", 47, 79, 79},
+#line 114 "name2rgb.gperf"
+    {"alice blue", 240, 248, 255},
+    {""}, {""}, {""}, {""}, {""},
+#line 737 "name2rgb.gperf"
+    {"grey59", 150, 150, 150},
+    {""}, {""}, {""}, {""},
+#line 293 "name2rgb.gperf"
+    {"orchid", 218, 112, 214},
+#line 289 "name2rgb.gperf"
+    {"violetred", 208, 32, 144},
+    {""}, {""}, {""}, {""},
+#line 561 "name2rgb.gperf"
+    {"deeppink4", 139, 10, 80},
+#line 149 "name2rgb.gperf"
+    {"navyblue", 0, 0, 128},
+#line 560 "name2rgb.gperf"
+    {"deeppink3", 205, 16, 118},
+    {""}, {""}, {""}, {""}, {""},
+#line 559 "name2rgb.gperf"
+    {"deeppink2", 238, 18, 137},
+    {""},
+#line 558 "name2rgb.gperf"
+    {"deeppink1", 255, 20, 147},
+    {""},
+#line 104 "name2rgb.gperf"
+    {"moccasin", 255, 228, 181},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 736 "name2rgb.gperf"
+    {"gray59", 150, 150, 150},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""},
+#line 601 "name2rgb.gperf"
+    {"mediumorchid4", 122, 55, 139},
+#line 111 "name2rgb.gperf"
+    {"mint cream", 245, 255, 250},
+#line 600 "name2rgb.gperf"
+    {"mediumorchid3", 180, 82, 205},
+    {""}, {""}, {""}, {""},
+#line 230 "name2rgb.gperf"
+    {"khaki", 240, 230, 140},
+#line 599 "name2rgb.gperf"
+    {"mediumorchid2", 209, 95, 238},
+    {""},
+#line 598 "name2rgb.gperf"
+    {"mediumorchid1", 224, 102, 255},
+    {""}, {""}, {""},
+#line 349 "name2rgb.gperf"
+    {"lavenderblush4", 139, 131, 134},
+    {""},
+#line 348 "name2rgb.gperf"
+    {"lavenderblush3", 205, 193, 197},
+#line 270 "name2rgb.gperf"
+    {"light coral", 240, 128, 128},
+    {""}, {""}, {""},
+#line 62 "name2rgb.gperf"
+    {"scilab magenta4", 144, 0, 144},
+#line 347 "name2rgb.gperf"
+    {"lavenderblush2", 238, 224, 229},
+#line 64 "name2rgb.gperf"
+    {"scilab magenta3", 176, 0, 176},
+#line 346 "name2rgb.gperf"
+    {"lavenderblush1", 255, 240, 245},
+    {""},
+#line 619 "name2rgb.gperf"
+    {"grey0", 0, 0, 0},
+    {""}, {""},
+#line 66 "name2rgb.gperf"
+    {"scilab magenta2", 208, 0, 208},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""},
+#line 699 "name2rgb.gperf"
+    {"grey40", 102, 102, 102},
+#line 679 "name2rgb.gperf"
+    {"grey30", 77, 77, 77},
+    {""}, {""},
+#line 659 "name2rgb.gperf"
+    {"grey20", 51, 51, 51},
+#line 639 "name2rgb.gperf"
+    {"grey10", 26, 26, 26},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""},
+#line 618 "name2rgb.gperf"
+    {"gray0", 0, 0, 0},
+    {""},
+#line 477 "name2rgb.gperf"
+    {"yellow4", 139, 139, 0},
+#line 295 "name2rgb.gperf"
+    {"mediumorchid", 186, 85, 211},
+#line 476 "name2rgb.gperf"
+    {"yellow3", 205, 205, 0},
+    {""}, {""}, {""}, {""}, {""},
+#line 475 "name2rgb.gperf"
+    {"yellow2", 238, 238, 0},
+    {""},
+#line 474 "name2rgb.gperf"
+    {"yellow1", 255, 255, 0},
+    {""},
+#line 698 "name2rgb.gperf"
+    {"gray40", 102, 102, 102},
+#line 678 "name2rgb.gperf"
+    {"gray30", 77, 77, 77},
+    {""}, {""},
+#line 658 "name2rgb.gperf"
+    {"gray20", 51, 51, 51},
+#line 638 "name2rgb.gperf"
+    {"gray10", 26, 26, 26},
+    {""}, {""}, {""}, {""}, {""},
+#line 296 "name2rgb.gperf"
+    {"dark orchid", 153, 50, 204},
+    {""},
+#line 137 "name2rgb.gperf"
+    {"light slate grey", 119, 136, 153},
+#line 826 "name2rgb.gperf"
+    {"dark cyan", 0, 139, 139},
+    {""},
+#line 256 "name2rgb.gperf"
+    {"sandybrown", 244, 164, 96},
+    {""}, {""}, {""},
+#line 573 "name2rgb.gperf"
+    {"lightpink4", 139, 95, 101},
+#line 572 "name2rgb.gperf"
+    {"lightpink3", 205, 140, 149},
+    {""}, {""},
+#line 571 "name2rgb.gperf"
+    {"lightpink2", 238, 162, 173},
+#line 570 "name2rgb.gperf"
+    {"lightpink1", 255, 174, 185},
+    {""}, {""}, {""}, {""}, {""},
+#line 219 "name2rgb.gperf"
+    {"greenyellow", 173, 255, 47},
+    {""}, {""}, {""}, {""}, {""},
+#line 223 "name2rgb.gperf"
+    {"yellowgreen", 154, 205, 50},
+    {""}, {""}, {""}, {""}, {""},
+#line 135 "name2rgb.gperf"
+    {"light slate gray", 119, 136, 153},
+    {""},
+#line 605 "name2rgb.gperf"
+    {"darkorchid4", 104, 34, 139},
+#line 604 "name2rgb.gperf"
+    {"darkorchid3", 154, 50, 205},
+    {""}, {""},
+#line 603 "name2rgb.gperf"
+    {"darkorchid2", 178, 58, 238},
+#line 602 "name2rgb.gperf"
+    {"darkorchid1", 191, 62, 255},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 75 "name2rgb.gperf"
+    {"scilabpink4", 255, 128, 128},
+#line 77 "name2rgb.gperf"
+    {"scilabpink3", 255, 160, 160},
+    {""}, {""},
+#line 79 "name2rgb.gperf"
+    {"scilabpink2", 255, 192, 192},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 183 "name2rgb.gperf"
+    {"dark turquoise", 0, 206, 209},
+    {""}, {""}, {""}, {""},
+#line 51 "name2rgb.gperf"
+    {"scilabcyan4", 0, 144, 144},
+#line 53 "name2rgb.gperf"
+    {"scilabcyan3", 0, 176, 176},
+    {""}, {""},
+#line 55 "name2rgb.gperf"
+    {"scilabcyan2", 0, 208, 208},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""},
+#line 158 "name2rgb.gperf"
+    {"light slate blue", 132, 112, 255},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 277 "name2rgb.gperf"
+    {"hotpink", 255, 105, 180},
+    {""}, {""}, {""},
+#line 194 "name2rgb.gperf"
+    {"mediumaquamarine", 102, 205, 170},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 121 "name2rgb.gperf"
+    {"white", 255, 255, 255},
+    {""}, {""}, {""}, {""},
+#line 297 "name2rgb.gperf"
+    {"darkorchid", 153, 50, 204},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 118 "name2rgb.gperf"
+    {"lavenderblush", 255, 240, 245},
+    {""}, {""},
+#line 505 "name2rgb.gperf"
+    {"burlywood4", 139, 115, 85},
+#line 504 "name2rgb.gperf"
+    {"burlywood3", 205, 170, 125},
+    {""}, {""},
+#line 503 "name2rgb.gperf"
+    {"burlywood2", 238, 197, 145},
+#line 502 "name2rgb.gperf"
+    {"burlywood1", 255, 211, 155},
+#line 189 "name2rgb.gperf"
+    {"light cyan", 224, 255, 255},
+    {""}, {""}, {""}, {""},
+#line 175 "name2rgb.gperf"
+    {"light steel blue", 176, 196, 222},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 799 "name2rgb.gperf"
+    {"grey90", 229, 229, 229},
+#line 521 "name2rgb.gperf"
+    {"firebrick4", 139, 26, 26},
+#line 520 "name2rgb.gperf"
+    {"firebrick3", 205, 38, 38},
+    {""},
+#line 212 "name2rgb.gperf"
+    {"lawn green", 124, 252, 0},
+#line 519 "name2rgb.gperf"
+    {"firebrick2", 238, 44, 44},
+#line 518 "name2rgb.gperf"
+    {"firebrick1", 255, 48, 48},
+#line 171 "name2rgb.gperf"
+    {"light sky blue", 135, 206, 250},
+    {""}, {""},
+#line 775 "name2rgb.gperf"
+    {"grey78", 199, 199, 199},
+    {""},
+#line 337 "name2rgb.gperf"
+    {"cornsilk4", 139, 136, 120},
+    {""},
+#line 336 "name2rgb.gperf"
+    {"cornsilk3", 205, 200, 177},
+#line 345 "name2rgb.gperf"
+    {"honeydew4", 131, 139, 131},
+    {""},
+#line 344 "name2rgb.gperf"
+    {"honeydew3", 193, 205, 193},
+    {""}, {""},
+#line 335 "name2rgb.gperf"
+    {"cornsilk2", 238, 232, 205},
+    {""},
+#line 334 "name2rgb.gperf"
+    {"cornsilk1", 255, 248, 220},
+#line 343 "name2rgb.gperf"
+    {"honeydew2", 224, 238, 224},
+#line 186 "name2rgb.gperf"
+    {"mediumturquoise", 72, 209, 204},
+#line 342 "name2rgb.gperf"
+    {"honeydew1", 240, 255, 240},
+    {""}, {""}, {""},
+#line 191 "name2rgb.gperf"
+    {"cadet blue", 95, 158, 160},
+#line 798 "name2rgb.gperf"
+    {"gray90", 229, 229, 229},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 774 "name2rgb.gperf"
+    {"gray78", 199, 199, 199},
+#line 244 "name2rgb.gperf"
+    {"rosy brown", 188, 143, 143},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 333 "name2rgb.gperf"
+    {"lemonchiffon4", 139, 137, 112},
+    {""},
+#line 332 "name2rgb.gperf"
+    {"lemonchiffon3", 205, 201, 165},
+#line 108 "name2rgb.gperf"
+    {"lemonchiffon", 255, 250, 205},
+    {""}, {""},
+#line 252 "name2rgb.gperf"
+    {"burlywood", 222, 184, 135},
+    {""},
+#line 331 "name2rgb.gperf"
+    {"lemonchiffon2", 238, 233, 191},
+    {""},
+#line 330 "name2rgb.gperf"
+    {"lemonchiffon1", 255, 250, 205},
+    {""}, {""}, {""}, {""}, {""},
+#line 755 "name2rgb.gperf"
+    {"grey68", 173, 173, 173},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 156 "name2rgb.gperf"
+    {"medium slate blue", 123, 104, 238},
+    {""},
+#line 633 "name2rgb.gperf"
+    {"grey7", 18, 18, 18},
+    {""}, {""}, {""}, {""}, {""},
+#line 236 "name2rgb.gperf"
+    {"lightyellow", 255, 255, 224},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 713 "name2rgb.gperf"
+    {"grey47", 120, 120, 120},
+#line 693 "name2rgb.gperf"
+    {"grey37", 94, 94, 94},
+    {""}, {""},
+#line 673 "name2rgb.gperf"
+    {"grey27", 69, 69, 69},
+#line 653 "name2rgb.gperf"
+    {"grey17", 43, 43, 43},
+#line 100 "name2rgb.gperf"
+    {"peach puff", 255, 218, 185},
+#line 754 "name2rgb.gperf"
+    {"gray68", 173, 173, 173},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 632 "name2rgb.gperf"
+    {"gray7", 18, 18, 18},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 279 "name2rgb.gperf"
+    {"deeppink", 255, 20, 147},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 712 "name2rgb.gperf"
+    {"gray47", 120, 120, 120},
+#line 692 "name2rgb.gperf"
+    {"gray37", 94, 94, 94},
+    {""}, {""},
+#line 672 "name2rgb.gperf"
+    {"gray27", 69, 69, 69},
+#line 652 "name2rgb.gperf"
+    {"gray17", 43, 43, 43},
+    {""}, {""}, {""}, {""},
+#line 288 "name2rgb.gperf"
+    {"violet red", 208, 32, 144},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 303 "name2rgb.gperf"
+    {"medium purple", 147, 112, 219},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 94 "name2rgb.gperf"
+    {"antiquewhite", 250, 235, 215},
+    {""}, {""}, {""},
+#line 145 "name2rgb.gperf"
+    {"midnight blue", 25, 25, 112},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 631 "name2rgb.gperf"
+    {"grey6", 15, 15, 15},
+    {""},
+#line 317 "name2rgb.gperf"
+    {"antiquewhite4", 139, 131, 120},
+    {""},
+#line 316 "name2rgb.gperf"
+    {"antiquewhite3", 205, 192, 176},
+    {""}, {""}, {""}, {""}, {""},
+#line 315 "name2rgb.gperf"
+    {"antiquewhite2", 238, 223, 204},
+    {""},
+#line 314 "name2rgb.gperf"
+    {"antiquewhite1", 255, 239, 219},
+    {""},
+#line 711 "name2rgb.gperf"
+    {"grey46", 117, 117, 117},
+#line 691 "name2rgb.gperf"
+    {"grey36", 92, 92, 92},
+    {""}, {""},
+#line 671 "name2rgb.gperf"
+    {"grey26", 66, 66, 66},
+#line 651 "name2rgb.gperf"
+    {"grey16", 41, 41, 41},
+#line 294 "name2rgb.gperf"
+    {"medium orchid", 186, 85, 211},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 630 "name2rgb.gperf"
+    {"gray6", 15, 15, 15},
+    {""},
+#line 97 "name2rgb.gperf"
+    {"blanched almond", 255, 235, 205},
+    {""}, {""}, {""}, {""}, {""},
+#line 148 "name2rgb.gperf"
+    {"navy blue", 0, 0, 128},
+#line 180 "name2rgb.gperf"
+    {"powderblue", 176, 224, 230},
+    {""},
+#line 735 "name2rgb.gperf"
+    {"grey58", 148, 148, 148},
+    {""}, {""},
+#line 710 "name2rgb.gperf"
+    {"gray46", 117, 117, 117},
+#line 690 "name2rgb.gperf"
+    {"gray36", 92, 92, 92},
+    {""}, {""},
+#line 670 "name2rgb.gperf"
+    {"gray26", 66, 66, 66},
+#line 650 "name2rgb.gperf"
+    {"gray16", 41, 41, 41},
+    {""}, {""}, {""},
+#line 461 "name2rgb.gperf"
+    {"darkolivegreen4", 110, 139, 61},
+    {""},
+#line 460 "name2rgb.gperf"
+    {"darkolivegreen3", 162, 205, 90},
+#line 199 "name2rgb.gperf"
+    {"darkolivegreen", 85, 107, 47},
+    {""}, {""}, {""}, {""},
+#line 459 "name2rgb.gperf"
+    {"darkolivegreen2", 188, 238, 104},
+    {""},
+#line 458 "name2rgb.gperf"
+    {"darkolivegreen1", 202, 255, 112},
+    {""}, {""}, {""},
+#line 779 "name2rgb.gperf"
+    {"grey80", 204, 204, 204},
+    {""}, {""}, {""},
+#line 734 "name2rgb.gperf"
+    {"gray58", 148, 148, 148},
+    {""}, {""},
+#line 167 "name2rgb.gperf"
+    {"deep sky blue", 0, 191, 255},
+    {""}, {""}, {""}, {""}, {""},
+#line 282 "name2rgb.gperf"
+    {"lightpink", 255, 182, 193},
+#line 813 "name2rgb.gperf"
+    {"grey97", 247, 247, 247},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 778 "name2rgb.gperf"
+    {"gray80", 204, 204, 204},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""},
+#line 193 "name2rgb.gperf"
+    {"medium aquamarine", 102, 205, 170},
+    {""}, {""},
+#line 812 "name2rgb.gperf"
+    {"gray97", 247, 247, 247},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 81 "name2rgb.gperf"
+    {"scilabpink", 255, 224, 224},
+    {""},
+#line 299 "name2rgb.gperf"
+    {"darkviolet", 148, 0, 211},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 88 "name2rgb.gperf"
+    {"floral white", 255, 250, 240},
+    {""},
+#line 181 "name2rgb.gperf"
+    {"pale turquoise", 175, 238, 238},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 281 "name2rgb.gperf"
+    {"light pink", 255, 182, 193},
+#line 216 "name2rgb.gperf"
+    {"medium spring green", 0, 250, 154},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 234 "name2rgb.gperf"
+    {"lightgoldenrodyellow", 250, 250, 210},
+    {""}, {""}, {""}, {""}, {""},
+#line 811 "name2rgb.gperf"
+    {"grey96", 245, 245, 245},
+    {""}, {""},
+#line 276 "name2rgb.gperf"
+    {"hot pink", 255, 105, 180},
+    {""}, {""}, {""}, {""},
+#line 74 "name2rgb.gperf"
+    {"scilab pink4", 255, 128, 128},
+    {""},
+#line 76 "name2rgb.gperf"
+    {"scilab pink3", 255, 160, 160},
+#line 50 "name2rgb.gperf"
+    {"scilab cyan4", 0, 144, 144},
+    {""},
+#line 52 "name2rgb.gperf"
+    {"scilab cyan3", 0, 176, 176},
+    {""},
+#line 105 "name2rgb.gperf"
+    {"cornsilk", 255, 248, 220},
+#line 78 "name2rgb.gperf"
+    {"scilab pink2", 255, 192, 192},
+#line 259 "name2rgb.gperf"
+    {"firebrick", 178, 34, 34},
+    {""},
+#line 54 "name2rgb.gperf"
+    {"scilab cyan2", 0, 208, 208},
+#line 222 "name2rgb.gperf"
+    {"yellow green", 154, 205, 50},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 228 "name2rgb.gperf"
+    {"dark khaki", 189, 183, 107},
+    {""},
+#line 810 "name2rgb.gperf"
+    {"gray96", 245, 245, 245},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 89 "name2rgb.gperf"
+    {"floralwhite", 255, 250, 240},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 179 "name2rgb.gperf"
+    {"powder blue", 176, 224, 230},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 233 "name2rgb.gperf"
+    {"light goldenrod yellow", 250, 250, 210},
+    {""},
+#line 629 "name2rgb.gperf"
+    {"grey5", 13, 13, 13},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 229 "name2rgb.gperf"
+    {"darkkhaki", 189, 183, 107},
+    {""}, {""}, {""}, {""}, {""},
+#line 793 "name2rgb.gperf"
+    {"grey87", 222, 222, 222},
+#line 709 "name2rgb.gperf"
+    {"grey45", 115, 115, 115},
+#line 689 "name2rgb.gperf"
+    {"grey35", 89, 89, 89},
+    {""}, {""},
+#line 669 "name2rgb.gperf"
+    {"grey25", 64, 64, 64},
+#line 649 "name2rgb.gperf"
+    {"grey15", 38, 38, 38},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 301 "name2rgb.gperf"
+    {"blueviolet", 138, 43, 226},
+    {""}, {""},
+#line 628 "name2rgb.gperf"
+    {"gray5", 13, 13, 13},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""},
+#line 792 "name2rgb.gperf"
+    {"gray87", 222, 222, 222},
+#line 708 "name2rgb.gperf"
+    {"gray45", 115, 115, 115},
+#line 688 "name2rgb.gperf"
+    {"gray35", 89, 89, 89},
+    {""}, {""},
+#line 668 "name2rgb.gperf"
+    {"gray25", 64, 64, 64},
+#line 648 "name2rgb.gperf"
+    {"gray15", 38, 38, 38},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 84 "name2rgb.gperf"
+    {"ghostwhite", 248, 248, 255},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 107 "name2rgb.gperf"
+    {"lemon chiffon", 255, 250, 205},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 278 "name2rgb.gperf"
+    {"deep pink", 255, 20, 147},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 93 "name2rgb.gperf"
+    {"antique white", 250, 235, 215},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""},
+#line 791 "name2rgb.gperf"
+    {"grey86", 219, 219, 219},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 86 "name2rgb.gperf"
+    {"whitesmoke", 245, 245, 245},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 819 "name2rgb.gperf"
+    {"grey100", 255, 255, 255},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 790 "name2rgb.gperf"
+    {"gray86", 219, 219, 219},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 818 "name2rgb.gperf"
+    {"gray100", 255, 255, 255},
+    {""}, {""}, {""}, {""}, {""},
+#line 577 "name2rgb.gperf"
+    {"palevioletred4", 139, 71, 93},
+    {""},
+#line 576 "name2rgb.gperf"
+    {"palevioletred3", 205, 104, 137},
+    {""}, {""}, {""}, {""}, {""},
+#line 575 "name2rgb.gperf"
+    {"palevioletred2", 238, 121, 159},
+    {""},
+#line 574 "name2rgb.gperf"
+    {"palevioletred1", 255, 130, 171},
+    {""}, {""}, {""},
+#line 809 "name2rgb.gperf"
+    {"grey95", 242, 242, 242},
+    {""}, {""}, {""},
+#line 151 "name2rgb.gperf"
+    {"cornflowerblue", 100, 149, 237},
+    {""}, {""}, {""}, {""},
+#line 117 "name2rgb.gperf"
+    {"lavender blush", 255, 240, 245},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 198 "name2rgb.gperf"
+    {"dark olive green", 85, 107, 47},
+    {""}, {""}, {""},
+#line 85 "name2rgb.gperf"
+    {"white smoke", 245, 245, 245},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 808 "name2rgb.gperf"
+    {"gray95", 242, 242, 242},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""},
+#line 284 "name2rgb.gperf"
+    {"palevioletred", 219, 112, 147},
+    {""}, {""}, {""},
+#line 150 "name2rgb.gperf"
+    {"cornflower blue", 100, 149, 237},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""},
+#line 759 "name2rgb.gperf"
+    {"grey70", 179, 179, 179},
+    {""}, {""},
+#line 80 "name2rgb.gperf"
+    {"scilab pink", 255, 224, 224},
+    {""}, {""}, {""}, {""},
+#line 185 "name2rgb.gperf"
+    {"medium turquoise", 72, 209, 204},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""},
+#line 298 "name2rgb.gperf"
+    {"dark violet", 148, 0, 211},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 758 "name2rgb.gperf"
+    {"gray70", 179, 179, 179},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""},
+#line 739 "name2rgb.gperf"
+    {"grey60", 153, 153, 153},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 738 "name2rgb.gperf"
+    {"gray60", 153, 153, 153},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""},
+#line 83 "name2rgb.gperf"
+    {"ghost white", 248, 248, 255},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 789 "name2rgb.gperf"
+    {"grey85", 217, 217, 217},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 719 "name2rgb.gperf"
+    {"grey50", 127, 127, 127},
+    {""}, {""}, {""},
+#line 788 "name2rgb.gperf"
+    {"gray85", 217, 217, 217},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 718 "name2rgb.gperf"
+    {"gray50", 127, 127, 127},
+#line 287 "name2rgb.gperf"
+    {"mediumvioletred", 199, 21, 133},
+#line 300 "name2rgb.gperf"
+    {"blue violet", 138, 43, 226},
+    {""}, {""},
+#line 237 "name2rgb.gperf"
+    {"yellow", 255, 255, 0},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""},
+#line 773 "name2rgb.gperf"
+    {"grey77", 196, 196, 196},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 772 "name2rgb.gperf"
+    {"gray77", 196, 196, 196},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""},
+#line 753 "name2rgb.gperf"
+    {"grey67", 171, 171, 171},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 752 "name2rgb.gperf"
+    {"gray67", 171, 171, 171},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""},
+#line 771 "name2rgb.gperf"
+    {"grey76", 194, 194, 194},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 770 "name2rgb.gperf"
+    {"gray76", 194, 194, 194},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 110 "name2rgb.gperf"
+    {"honeydew", 240, 255, 240},
+    {""}, {""}, {""}, {""},
+#line 751 "name2rgb.gperf"
+    {"grey66", 168, 168, 168},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 750 "name2rgb.gperf"
+    {"gray66", 168, 168, 168},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""},
+#line 733 "name2rgb.gperf"
+    {"grey57", 145, 145, 145},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 732 "name2rgb.gperf"
+    {"gray57", 145, 145, 145},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""},
+#line 102 "name2rgb.gperf"
+    {"navajo white", 255, 222, 173},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 731 "name2rgb.gperf"
+    {"grey56", 143, 143, 143},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 730 "name2rgb.gperf"
+    {"gray56", 143, 143, 143},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 103 "name2rgb.gperf"
+    {"navajowhite", 255, 222, 173},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""},
+#line 329 "name2rgb.gperf"
+    {"navajowhite4", 139, 121, 94},
+    {""},
+#line 328 "name2rgb.gperf"
+    {"navajowhite3", 205, 179, 139},
+    {""}, {""}, {""}, {""}, {""},
+#line 327 "name2rgb.gperf"
+    {"navajowhite2", 238, 207, 161},
+    {""},
+#line 326 "name2rgb.gperf"
+    {"navajowhite1", 255, 222, 173},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""},
+#line 769 "name2rgb.gperf"
+    {"grey75", 191, 191, 191},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 768 "name2rgb.gperf"
+    {"gray75", 191, 191, 191},
+#line 218 "name2rgb.gperf"
+    {"green yellow", 173, 255, 47},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""},
+#line 749 "name2rgb.gperf"
+    {"grey65", 166, 166, 166},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 748 "name2rgb.gperf"
+    {"gray65", 166, 166, 166},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 95 "name2rgb.gperf"
+    {"papaya whip", 255, 239, 213},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""},
+#line 729 "name2rgb.gperf"
+    {"grey55", 140, 140, 140},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""},
+#line 235 "name2rgb.gperf"
+    {"light yellow", 255, 255, 224},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 728 "name2rgb.gperf"
+    {"gray55", 140, 140, 140},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 283 "name2rgb.gperf"
+    {"pale violet red", 219, 112, 147},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 96 "name2rgb.gperf"
+    {"papayawhip", 255, 239, 213},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+    {""}, {""}, {""}, {""}, {""}, {""},
+#line 286 "name2rgb.gperf"
+    {"medium violet red", 199, 21, 133}
+  };
+
+#ifdef __GNUC__
+__inline
+#if defined __GNUC_STDC_INLINE__ || defined __GNUC_GNU_INLINE__
+__attribute__ ((__gnu_inline__))
+#endif
+#endif
+const struct color *
+lookup_color (str, len)
+     register const char *str;
+     register unsigned int len;
+{
+  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
+    {
+      register int key = hash (str, len);
+
+      if (key <= MAX_HASH_VALUE && key >= 0)
         {
-            _pdblRGB[0] = (double)colorRGB[i][0];
-            _pdblRGB[1] = (double)colorRGB[i][1];
-            _pdblRGB[2] = (double)colorRGB[i][2];
-            return;
+          register const char *s = colorlist[key].name;
+
+          if ((((unsigned char)*str ^ (unsigned char)*s) & ~32) == 0 && !gperf_case_strcmp (str, s))
+            return &colorlist[key];
         }
     }
+  return 0;
+}
+#line 834 "name2rgb.gperf"
 
-    _pdblRGB[0] = (double) - 1;
-    _pdblRGB[1] = (double) - 1;
-    _pdblRGB[2] = (double) - 1;
+void name2rgb(char* name, double* rgb)
+{
+    const struct color* c = lookup_color(name, balisc_strlen(name));
+
+    if (c)
+    {
+        rgb[0] = (double)(c->red);
+        rgb[1] = (double)(c->green);
+        rgb[2] = (double)(c->blue);
+    }
+    else
+    {
+        rgb[0] = -1.0;
+        rgb[1] = -1.0;
+        rgb[2] = -1.0;
+    }
 }

--- a/scilab/modules/graphics/src/c/name2rgb.gperf
+++ b/scilab/modules/graphics/src/c/name2rgb.gperf
@@ -1,0 +1,851 @@
+/* Balisc (https://github.com/rdbyk/balisc/)
+ * 
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 
+ * 02110-1301, USA.
+ */
+
+%{
+#include <name2rgb.h>
+#include "strlen.h"
+
+struct color {char* name; int red; int green; int blue;};
+%}
+
+%ignore-case
+%readonly-tables
+%global-table
+%define string-pool-name colornames
+%define word-array-name colorlist
+%define lookup-function-name lookup_color
+%struct-type
+
+struct color
+%%
+scilab blue4, 0, 0, 144
+scilabblue4, 0, 0, 144
+scilab blue3, 0, 0, 176
+scilabblue3, 0, 0, 176
+scilab blue2, 0, 0, 208
+scilabblue2, 0, 0, 208
+scilab green4, 0, 144, 0
+scilabgreen4, 0, 144, 0
+scilab green3, 0, 176, 0
+scilabgreen3, 0, 176, 0
+scilab green2, 0, 208, 0
+scilabgreen2, 0, 208, 0
+scilab cyan4, 0, 144, 144
+scilabcyan4, 0, 144, 144
+scilab cyan3, 0, 176, 176
+scilabcyan3, 0, 176, 176
+scilab cyan2, 0, 208, 208
+scilabcyan2, 0, 208, 208
+scilab red4, 144, 0, 0
+scilabred4, 144, 0, 0
+scilab red3, 176, 0, 0
+scilabred3, 176, 0, 0
+scilab red2, 208, 0, 0
+scilabred2, 208, 0, 0
+scilab magenta4, 144, 0, 144
+scilabmagenta4, 144, 0, 144
+scilab magenta3, 176, 0, 176
+scilabmagenta3, 176, 0, 176
+scilab magenta2, 208, 0, 208
+scilabmagenta2, 208, 0, 208
+scilab brown4, 128, 48, 0
+scilabbrown4, 128, 48, 0
+scilab brown3, 160, 64, 0
+scilabbrown3, 160, 64, 0
+scilab brown2, 192, 96, 0
+scilabbrown2, 192, 96, 0
+scilab pink4, 255, 128, 128
+scilabpink4, 255, 128, 128
+scilab pink3, 255, 160, 160
+scilabpink3, 255, 160, 160
+scilab pink2, 255, 192, 192
+scilabpink2, 255, 192, 192
+scilab pink, 255, 224, 224
+scilabpink, 255, 224, 224
+snow, 255, 250, 250
+ghost white, 248, 248, 255
+ghostwhite, 248, 248, 255
+white smoke, 245, 245, 245
+whitesmoke, 245, 245, 245
+gainsboro, 220, 220, 220
+floral white, 255, 250, 240
+floralwhite, 255, 250, 240
+old lace, 253, 245, 230
+oldlace, 253, 245, 230
+linen, 250, 240, 230
+antique white, 250, 235, 215
+antiquewhite, 250, 235, 215
+papaya whip, 255, 239, 213
+papayawhip, 255, 239, 213
+blanched almond, 255, 235, 205
+blanchedalmond, 255, 235, 205
+bisque, 255, 228, 196
+peach puff, 255, 218, 185
+peachpuff, 255, 218, 185
+navajo white, 255, 222, 173
+navajowhite, 255, 222, 173
+moccasin, 255, 228, 181
+cornsilk, 255, 248, 220
+ivory, 255, 255, 240
+lemon chiffon, 255, 250, 205
+lemonchiffon, 255, 250, 205
+seashell, 255, 245, 238
+honeydew, 240, 255, 240
+mint cream, 245, 255, 250
+mintcream, 245, 255, 250
+azure, 240, 255, 255
+alice blue, 240, 248, 255
+aliceblue, 240, 248, 255
+lavender, 230, 230, 250
+lavender blush, 255, 240, 245
+lavenderblush, 255, 240, 245
+misty rose, 255, 228, 225
+mistyrose, 255, 228, 225
+white, 255, 255, 255
+black, 0, 0, 0
+dark slate gray, 47, 79, 79
+darkslategray, 47, 79, 79
+dark slate grey, 47, 79, 79
+darkslategrey, 47, 79, 79
+dim gray, 105, 105, 105
+dimgray, 105, 105, 105
+dim grey, 105, 105, 105
+dimgrey, 105, 105, 105
+slate gray, 112, 128, 144
+slategray, 112, 128, 144
+slate grey, 112, 128, 144
+slategrey, 112, 128, 144
+light slate gray, 119, 136, 153
+lightslategray, 119, 136, 153
+light slate grey, 119, 136, 153
+lightslategrey, 119, 136, 153
+gray, 190, 190, 190
+grey, 190, 190, 190
+light grey, 211, 211, 211
+lightgrey, 211, 211, 211
+light gray, 211, 211, 211
+lightgray, 211, 211, 211
+midnight blue, 25, 25, 112
+midnightblue, 25, 25, 112
+navy, 0, 0, 128
+navy blue, 0, 0, 128
+navyblue, 0, 0, 128
+cornflower blue, 100, 149, 237
+cornflowerblue, 100, 149, 237
+dark slate blue, 72, 61, 139
+darkslateblue, 72, 61, 139
+slate blue, 106, 90, 205
+slateblue, 106, 90, 205
+medium slate blue, 123, 104, 238
+mediumslateblue, 123, 104, 238
+light slate blue, 132, 112, 255
+lightslateblue, 132, 112, 255
+medium blue, 0, 0, 205
+mediumblue, 0, 0, 205
+royal blue, 65, 105, 225
+royalblue, 65, 105, 225
+blue, 0, 0, 255
+dodger blue, 30, 144, 255
+dodgerblue, 30, 144, 255
+deep sky blue, 0, 191, 255
+deepskyblue, 0, 191, 255
+sky blue, 135, 206, 235
+skyblue, 135, 206, 235
+light sky blue, 135, 206, 250
+lightskyblue, 135, 206, 250
+steel blue, 70, 130, 180
+steelblue, 70, 130, 180
+light steel blue, 176, 196, 222
+lightsteelblue, 176, 196, 222
+light blue, 173, 216, 230
+lightblue, 173, 216, 230
+powder blue, 176, 224, 230
+powderblue, 176, 224, 230
+pale turquoise, 175, 238, 238
+paleturquoise, 175, 238, 238
+dark turquoise, 0, 206, 209
+darkturquoise, 0, 206, 209
+medium turquoise, 72, 209, 204
+mediumturquoise, 72, 209, 204
+turquoise, 64, 224, 208
+cyan, 0, 255, 255
+light cyan, 224, 255, 255
+lightcyan, 224, 255, 255
+cadet blue, 95, 158, 160
+cadetblue, 95, 158, 160
+medium aquamarine, 102, 205, 170
+mediumaquamarine, 102, 205, 170
+aquamarine, 127, 255, 212
+dark green, 0, 100, 0
+darkgreen, 0, 100, 0
+dark olive green, 85, 107, 47
+darkolivegreen, 85, 107, 47
+dark sea green, 143, 188, 143
+darkseagreen, 143, 188, 143
+sea green, 46, 139, 87
+seagreen, 46, 139, 87
+medium sea green, 60, 179, 113
+mediumseagreen, 60, 179, 113
+light sea green, 32, 178, 170
+lightseagreen, 32, 178, 170
+pale green, 152, 251, 152
+palegreen, 152, 251, 152
+spring green, 0, 255, 127
+springgreen, 0, 255, 127
+lawn green, 124, 252, 0
+lawngreen, 124, 252, 0
+green, 0, 255, 0
+chartreuse, 127, 255, 0
+medium spring green, 0, 250, 154
+mediumspringgreen, 0, 250, 154
+green yellow, 173, 255, 47
+greenyellow, 173, 255, 47
+lime green, 50, 205, 50
+limegreen, 50, 205, 50
+yellow green, 154, 205, 50
+yellowgreen, 154, 205, 50
+forest green, 34, 139, 34
+forestgreen, 34, 139, 34
+olive drab, 107, 142, 35
+olivedrab, 107, 142, 35
+dark khaki, 189, 183, 107
+darkkhaki, 189, 183, 107
+khaki, 240, 230, 140
+pale goldenrod, 238, 232, 170
+palegoldenrod, 238, 232, 170
+light goldenrod yellow, 250, 250, 210
+lightgoldenrodyellow, 250, 250, 210
+light yellow, 255, 255, 224
+lightyellow, 255, 255, 224
+yellow, 255, 255, 0
+gold, 255, 215, 0
+light goldenrod, 238, 221, 130
+lightgoldenrod, 238, 221, 130
+goldenrod, 218, 165, 32
+dark goldenrod, 184, 134, 11
+darkgoldenrod, 184, 134, 11
+rosy brown, 188, 143, 143
+rosybrown, 188, 143, 143
+indian red, 205, 92, 92
+indianred, 205, 92, 92
+saddle brown, 139, 69, 19
+saddlebrown, 139, 69, 19
+sienna, 160, 82, 45
+peru, 205, 133, 63
+burlywood, 222, 184, 135
+beige, 245, 245, 220
+wheat, 245, 222, 179
+sandy brown, 244, 164, 96
+sandybrown, 244, 164, 96
+tan, 210, 180, 140
+chocolate, 210, 105, 30
+firebrick, 178, 34, 34
+brown, 165, 42, 42
+dark salmon, 233, 150, 122
+darksalmon, 233, 150, 122
+salmon, 250, 128, 114
+light salmon, 255, 160, 122
+lightsalmon, 255, 160, 122
+orange, 255, 165, 0
+dark orange, 255, 140, 0
+darkorange, 255, 140, 0
+coral, 255, 127, 80
+light coral, 240, 128, 128
+lightcoral, 240, 128, 128
+tomato, 255, 99, 71
+orange red, 255, 69, 0
+orangered, 255, 69, 0
+red, 255, 0, 0
+hot pink, 255, 105, 180
+hotpink, 255, 105, 180
+deep pink, 255, 20, 147
+deeppink, 255, 20, 147
+pink, 255, 192, 203
+light pink, 255, 182, 193
+lightpink, 255, 182, 193
+pale violet red, 219, 112, 147
+palevioletred, 219, 112, 147
+maroon, 176, 48, 96
+medium violet red, 199, 21, 133
+mediumvioletred, 199, 21, 133
+violet red, 208, 32, 144
+violetred, 208, 32, 144
+magenta, 255, 0, 255
+violet, 238, 130, 238
+plum, 221, 160, 221
+orchid, 218, 112, 214
+medium orchid, 186, 85, 211
+mediumorchid, 186, 85, 211
+dark orchid, 153, 50, 204
+darkorchid, 153, 50, 204
+dark violet, 148, 0, 211
+darkviolet, 148, 0, 211
+blue violet, 138, 43, 226
+blueviolet, 138, 43, 226
+purple, 160, 32, 240
+medium purple, 147, 112, 219
+mediumpurple, 147, 112, 219
+thistle, 216, 191, 216
+snow1, 255, 250, 250
+snow2, 238, 233, 233
+snow3, 205, 201, 201
+snow4, 139, 137, 137
+seashell1, 255, 245, 238
+seashell2, 238, 229, 222
+seashell3, 205, 197, 191
+seashell4, 139, 134, 130
+antiquewhite1, 255, 239, 219
+antiquewhite2, 238, 223, 204
+antiquewhite3, 205, 192, 176
+antiquewhite4, 139, 131, 120
+bisque1, 255, 228, 196
+bisque2, 238, 213, 183
+bisque3, 205, 183, 158
+bisque4, 139, 125, 107
+peachpuff1, 255, 218, 185
+peachpuff2, 238, 203, 173
+peachpuff3, 205, 175, 149
+peachpuff4, 139, 119, 101
+navajowhite1, 255, 222, 173
+navajowhite2, 238, 207, 161
+navajowhite3, 205, 179, 139
+navajowhite4, 139, 121, 94
+lemonchiffon1, 255, 250, 205
+lemonchiffon2, 238, 233, 191
+lemonchiffon3, 205, 201, 165
+lemonchiffon4, 139, 137, 112
+cornsilk1, 255, 248, 220
+cornsilk2, 238, 232, 205
+cornsilk3, 205, 200, 177
+cornsilk4, 139, 136, 120
+ivory1, 255, 255, 240
+ivory2, 238, 238, 224
+ivory3, 205, 205, 193
+ivory4, 139, 139, 131
+honeydew1, 240, 255, 240
+honeydew2, 224, 238, 224
+honeydew3, 193, 205, 193
+honeydew4, 131, 139, 131
+lavenderblush1, 255, 240, 245
+lavenderblush2, 238, 224, 229
+lavenderblush3, 205, 193, 197
+lavenderblush4, 139, 131, 134
+mistyrose1, 255, 228, 225
+mistyrose2, 238, 213, 210
+mistyrose3, 205, 183, 181
+mistyrose4, 139, 125, 123
+azure1, 240, 255, 255
+azure2, 224, 238, 238
+azure3, 193, 205, 205
+azure4, 131, 139, 139
+slateblue1, 131, 111, 255
+slateblue2, 122, 103, 238
+slateblue3, 105, 89, 205
+slateblue4, 71, 60, 139
+royalblue1, 72, 118, 255
+royalblue2, 67, 110, 238
+royalblue3, 58, 95, 205
+royalblue4, 39, 64, 139
+blue1, 0, 0, 255
+blue2, 0, 0, 238
+blue3, 0, 0, 205
+blue4, 0, 0, 139
+dodgerblue1, 30, 144, 255
+dodgerblue2, 28, 134, 238
+dodgerblue3, 24, 116, 205
+dodgerblue4, 16, 78, 139
+steelblue1, 99, 184, 255
+steelblue2, 92, 172, 238
+steelblue3, 79, 148, 205
+steelblue4, 54, 100, 139
+deepskyblue1, 0, 191, 255
+deepskyblue2, 0, 178, 238
+deepskyblue3, 0, 154, 205
+deepskyblue4, 0, 104, 139
+skyblue1, 135, 206, 255
+skyblue2, 126, 192, 238
+skyblue3, 108, 166, 205
+skyblue4, 74, 112, 139
+lightskyblue1, 176, 226, 255
+lightskyblue2, 164, 211, 238
+lightskyblue3, 141, 182, 205
+lightskyblue4, 96, 123, 139
+slategray1, 198, 226, 255
+slategray2, 185, 211, 238
+slategray3, 159, 182, 205
+slategray4, 108, 123, 139
+lightsteelblue1, 202, 225, 255
+lightsteelblue2, 188, 210, 238
+lightsteelblue3, 162, 181, 205
+lightsteelblue4, 110, 123, 139
+lightblue1, 191, 239, 255
+lightblue2, 178, 223, 238
+lightblue3, 154, 192, 205
+lightblue4, 104, 131, 139
+lightcyan1, 224, 255, 255
+lightcyan2, 209, 238, 238
+lightcyan3, 180, 205, 205
+lightcyan4, 122, 139, 139
+paleturquoise1, 187, 255, 255
+paleturquoise2, 174, 238, 238
+paleturquoise3, 150, 205, 205
+paleturquoise4, 102, 139, 139
+cadetblue1, 152, 245, 255
+cadetblue2, 142, 229, 238
+cadetblue3, 122, 197, 205
+cadetblue4, 83, 134, 139
+turquoise1, 0, 245, 255
+turquoise2, 0, 229, 238
+turquoise3, 0, 197, 205
+turquoise4, 0, 134, 139
+cyan1, 0, 255, 255
+cyan2, 0, 238, 238
+cyan3, 0, 205, 205
+cyan4, 0, 139, 139
+darkslategray1, 151, 255, 255
+darkslategray2, 141, 238, 238
+darkslategray3, 121, 205, 205
+darkslategray4, 82, 139, 139
+aquamarine1, 127, 255, 212
+aquamarine2, 118, 238, 198
+aquamarine3, 102, 205, 170
+aquamarine4, 69, 139, 116
+darkseagreen1, 193, 255, 193
+darkseagreen2, 180, 238, 180
+darkseagreen3, 155, 205, 155
+darkseagreen4, 105, 139, 105
+seagreen1, 84, 255, 159
+seagreen2, 78, 238, 148
+seagreen3, 67, 205, 128
+seagreen4, 46, 139, 87
+palegreen1, 154, 255, 154
+palegreen2, 144, 238, 144
+palegreen3, 124, 205, 124
+palegreen4, 84, 139, 84
+springgreen1, 0, 255, 127
+springgreen2, 0, 238, 118
+springgreen3, 0, 205, 102
+springgreen4, 0, 139, 69
+green1, 0, 255, 0
+green2, 0, 238, 0
+green3, 0, 205, 0
+green4, 0, 139, 0
+chartreuse1, 127, 255, 0
+chartreuse2, 118, 238, 0
+chartreuse3, 102, 205, 0
+chartreuse4, 69, 139, 0
+olivedrab1, 192, 255, 62
+olivedrab2, 179, 238, 58
+olivedrab3, 154, 205, 50
+olivedrab4, 105, 139, 34
+darkolivegreen1, 202, 255, 112
+darkolivegreen2, 188, 238, 104
+darkolivegreen3, 162, 205, 90
+darkolivegreen4, 110, 139, 61
+khaki1, 255, 246, 143
+khaki2, 238, 230, 133
+khaki3, 205, 198, 115
+khaki4, 139, 134, 78
+lightgoldenrod1, 255, 236, 139
+lightgoldenrod2, 238, 220, 130
+lightgoldenrod3, 205, 190, 112
+lightgoldenrod4, 139, 129, 76
+lightyellow1, 255, 255, 224
+lightyellow2, 238, 238, 209
+lightyellow3, 205, 205, 180
+lightyellow4, 139, 139, 122
+yellow1, 255, 255, 0
+yellow2, 238, 238, 0
+yellow3, 205, 205, 0
+yellow4, 139, 139, 0
+gold1, 255, 215, 0
+gold2, 238, 201, 0
+gold3, 205, 173, 0
+gold4, 139, 117, 0
+goldenrod1, 255, 193, 37
+goldenrod2, 238, 180, 34
+goldenrod3, 205, 155, 29
+goldenrod4, 139, 105, 20
+darkgoldenrod1, 255, 185, 15
+darkgoldenrod2, 238, 173, 14
+darkgoldenrod3, 205, 149, 12
+darkgoldenrod4, 139, 101, 8
+rosybrown1, 255, 193, 193
+rosybrown2, 238, 180, 180
+rosybrown3, 205, 155, 155
+rosybrown4, 139, 105, 105
+indianred1, 255, 106, 106
+indianred2, 238, 99, 99
+indianred3, 205, 85, 85
+indianred4, 139, 58, 58
+sienna1, 255, 130, 71
+sienna2, 238, 121, 66
+sienna3, 205, 104, 57
+sienna4, 139, 71, 38
+burlywood1, 255, 211, 155
+burlywood2, 238, 197, 145
+burlywood3, 205, 170, 125
+burlywood4, 139, 115, 85
+wheat1, 255, 231, 186
+wheat2, 238, 216, 174
+wheat3, 205, 186, 150
+wheat4, 139, 126, 102
+tan1, 255, 165, 79
+tan2, 238, 154, 73
+tan3, 205, 133, 63
+tan4, 139, 90, 43
+chocolate1, 255, 127, 36
+chocolate2, 238, 118, 33
+chocolate3, 205, 102, 29
+chocolate4, 139, 69, 19
+firebrick1, 255, 48, 48
+firebrick2, 238, 44, 44
+firebrick3, 205, 38, 38
+firebrick4, 139, 26, 26
+brown1, 255, 64, 64
+brown2, 238, 59, 59
+brown3, 205, 51, 51
+brown4, 139, 35, 35
+salmon1, 255, 140, 105
+salmon2, 238, 130, 98
+salmon3, 205, 112, 84
+salmon4, 139, 76, 57
+lightsalmon1, 255, 160, 122
+lightsalmon2, 238, 149, 114
+lightsalmon3, 205, 129, 98
+lightsalmon4, 139, 87, 66
+orange1, 255, 165, 0
+orange2, 238, 154, 0
+orange3, 205, 133, 0
+orange4, 139, 90, 0
+darkorange1, 255, 127, 0
+darkorange2, 238, 118, 0
+darkorange3, 205, 102, 0
+darkorange4, 139, 69, 0
+coral1, 255, 114, 86
+coral2, 238, 106, 80
+coral3, 205, 91, 69
+coral4, 139, 62, 47
+tomato1, 255, 99, 71
+tomato2, 238, 92, 66
+tomato3, 205, 79, 57
+tomato4, 139, 54, 38
+orangered1, 255, 69, 0
+orangered2, 238, 64, 0
+orangered3, 205, 55, 0
+orangered4, 139, 37, 0
+red1, 255, 0, 0
+red2, 238, 0, 0
+red3, 205, 0, 0
+red4, 139, 0, 0
+deeppink1, 255, 20, 147
+deeppink2, 238, 18, 137
+deeppink3, 205, 16, 118
+deeppink4, 139, 10, 80
+hotpink1, 255, 110, 180
+hotpink2, 238, 106, 167
+hotpink3, 205, 96, 144
+hotpink4, 139, 58, 98
+pink1, 255, 181, 197
+pink2, 238, 169, 184
+pink3, 205, 145, 158
+pink4, 139, 99, 108
+lightpink1, 255, 174, 185
+lightpink2, 238, 162, 173
+lightpink3, 205, 140, 149
+lightpink4, 139, 95, 101
+palevioletred1, 255, 130, 171
+palevioletred2, 238, 121, 159
+palevioletred3, 205, 104, 137
+palevioletred4, 139, 71, 93
+maroon1, 255, 52, 179
+maroon2, 238, 48, 167
+maroon3, 205, 41, 144
+maroon4, 139, 28, 98
+violetred1, 255, 62, 150
+violetred2, 238, 58, 140
+violetred3, 205, 50, 120
+violetred4, 139, 34, 82
+magenta1, 255, 0, 255
+magenta2, 238, 0, 238
+magenta3, 205, 0, 205
+magenta4, 139, 0, 139
+orchid1, 255, 131, 250
+orchid2, 238, 122, 233
+orchid3, 205, 105, 201
+orchid4, 139, 71, 137
+plum1, 255, 187, 255
+plum2, 238, 174, 238
+plum3, 205, 150, 205
+plum4, 139, 102, 139
+mediumorchid1, 224, 102, 255
+mediumorchid2, 209, 95, 238
+mediumorchid3, 180, 82, 205
+mediumorchid4, 122, 55, 139
+darkorchid1, 191, 62, 255
+darkorchid2, 178, 58, 238
+darkorchid3, 154, 50, 205
+darkorchid4, 104, 34, 139
+purple1, 155, 48, 255
+purple2, 145, 44, 238
+purple3, 125, 38, 205
+purple4, 85, 26, 139
+mediumpurple1, 171, 130, 255
+mediumpurple2, 159, 121, 238
+mediumpurple3, 137, 104, 205
+mediumpurple4, 93, 71, 139
+thistle1, 255, 225, 255
+thistle2, 238, 210, 238
+thistle3, 205, 181, 205
+thistle4, 139, 123, 139
+gray0, 0, 0, 0
+grey0, 0, 0, 0
+gray1, 3, 3, 3
+grey1, 3, 3, 3
+gray2, 5, 5, 5
+grey2, 5, 5, 5
+gray3, 8, 8, 8
+grey3, 8, 8, 8
+gray4, 10, 10, 10
+grey4, 10, 10, 10
+gray5, 13, 13, 13
+grey5, 13, 13, 13
+gray6, 15, 15, 15
+grey6, 15, 15, 15
+gray7, 18, 18, 18
+grey7, 18, 18, 18
+gray8, 20, 20, 20
+grey8, 20, 20, 20
+gray9, 23, 23, 23
+grey9, 23, 23, 23
+gray10, 26, 26, 26
+grey10, 26, 26, 26
+gray11, 28, 28, 28
+grey11, 28, 28, 28
+gray12, 31, 31, 31
+grey12, 31, 31, 31
+gray13, 33, 33, 33
+grey13, 33, 33, 33
+gray14, 36, 36, 36
+grey14, 36, 36, 36
+gray15, 38, 38, 38
+grey15, 38, 38, 38
+gray16, 41, 41, 41
+grey16, 41, 41, 41
+gray17, 43, 43, 43
+grey17, 43, 43, 43
+gray18, 46, 46, 46
+grey18, 46, 46, 46
+gray19, 48, 48, 48
+grey19, 48, 48, 48
+gray20, 51, 51, 51
+grey20, 51, 51, 51
+gray21, 54, 54, 54
+grey21, 54, 54, 54
+gray22, 56, 56, 56
+grey22, 56, 56, 56
+gray23, 59, 59, 59
+grey23, 59, 59, 59
+gray24, 61, 61, 61
+grey24, 61, 61, 61
+gray25, 64, 64, 64
+grey25, 64, 64, 64
+gray26, 66, 66, 66
+grey26, 66, 66, 66
+gray27, 69, 69, 69
+grey27, 69, 69, 69
+gray28, 71, 71, 71
+grey28, 71, 71, 71
+gray29, 74, 74, 74
+grey29, 74, 74, 74
+gray30, 77, 77, 77
+grey30, 77, 77, 77
+gray31, 79, 79, 79
+grey31, 79, 79, 79
+gray32, 82, 82, 82
+grey32, 82, 82, 82
+gray33, 84, 84, 84
+grey33, 84, 84, 84
+gray34, 87, 87, 87
+grey34, 87, 87, 87
+gray35, 89, 89, 89
+grey35, 89, 89, 89
+gray36, 92, 92, 92
+grey36, 92, 92, 92
+gray37, 94, 94, 94
+grey37, 94, 94, 94
+gray38, 97, 97, 97
+grey38, 97, 97, 97
+gray39, 99, 99, 99
+grey39, 99, 99, 99
+gray40, 102, 102, 102
+grey40, 102, 102, 102
+gray41, 105, 105, 105
+grey41, 105, 105, 105
+gray42, 107, 107, 107
+grey42, 107, 107, 107
+gray43, 110, 110, 110
+grey43, 110, 110, 110
+gray44, 112, 112, 112
+grey44, 112, 112, 112
+gray45, 115, 115, 115
+grey45, 115, 115, 115
+gray46, 117, 117, 117
+grey46, 117, 117, 117
+gray47, 120, 120, 120
+grey47, 120, 120, 120
+gray48, 122, 122, 122
+grey48, 122, 122, 122
+gray49, 125, 125, 125
+grey49, 125, 125, 125
+gray50, 127, 127, 127
+grey50, 127, 127, 127
+gray51, 130, 130, 130
+grey51, 130, 130, 130
+gray52, 133, 133, 133
+grey52, 133, 133, 133
+gray53, 135, 135, 135
+grey53, 135, 135, 135
+gray54, 138, 138, 138
+grey54, 138, 138, 138
+gray55, 140, 140, 140
+grey55, 140, 140, 140
+gray56, 143, 143, 143
+grey56, 143, 143, 143
+gray57, 145, 145, 145
+grey57, 145, 145, 145
+gray58, 148, 148, 148
+grey58, 148, 148, 148
+gray59, 150, 150, 150
+grey59, 150, 150, 150
+gray60, 153, 153, 153
+grey60, 153, 153, 153
+gray61, 156, 156, 156
+grey61, 156, 156, 156
+gray62, 158, 158, 158
+grey62, 158, 158, 158
+gray63, 161, 161, 161
+grey63, 161, 161, 161
+gray64, 163, 163, 163
+grey64, 163, 163, 163
+gray65, 166, 166, 166
+grey65, 166, 166, 166
+gray66, 168, 168, 168
+grey66, 168, 168, 168
+gray67, 171, 171, 171
+grey67, 171, 171, 171
+gray68, 173, 173, 173
+grey68, 173, 173, 173
+gray69, 176, 176, 176
+grey69, 176, 176, 176
+gray70, 179, 179, 179
+grey70, 179, 179, 179
+gray71, 181, 181, 181
+grey71, 181, 181, 181
+gray72, 184, 184, 184
+grey72, 184, 184, 184
+gray73, 186, 186, 186
+grey73, 186, 186, 186
+gray74, 189, 189, 189
+grey74, 189, 189, 189
+gray75, 191, 191, 191
+grey75, 191, 191, 191
+gray76, 194, 194, 194
+grey76, 194, 194, 194
+gray77, 196, 196, 196
+grey77, 196, 196, 196
+gray78, 199, 199, 199
+grey78, 199, 199, 199
+gray79, 201, 201, 201
+grey79, 201, 201, 201
+gray80, 204, 204, 204
+grey80, 204, 204, 204
+gray81, 207, 207, 207
+grey81, 207, 207, 207
+gray82, 209, 209, 209
+grey82, 209, 209, 209
+gray83, 212, 212, 212
+grey83, 212, 212, 212
+gray84, 214, 214, 214
+grey84, 214, 214, 214
+gray85, 217, 217, 217
+grey85, 217, 217, 217
+gray86, 219, 219, 219
+grey86, 219, 219, 219
+gray87, 222, 222, 222
+grey87, 222, 222, 222
+gray88, 224, 224, 224
+grey88, 224, 224, 224
+gray89, 227, 227, 227
+grey89, 227, 227, 227
+gray90, 229, 229, 229
+grey90, 229, 229, 229
+gray91, 232, 232, 232
+grey91, 232, 232, 232
+gray92, 235, 235, 235
+grey92, 235, 235, 235
+gray93, 237, 237, 237
+grey93, 237, 237, 237
+gray94, 240, 240, 240
+grey94, 240, 240, 240
+gray95, 242, 242, 242
+grey95, 242, 242, 242
+gray96, 245, 245, 245
+grey96, 245, 245, 245
+gray97, 247, 247, 247
+grey97, 247, 247, 247
+gray98, 250, 250, 250
+grey98, 250, 250, 250
+gray99, 252, 252, 252
+grey99, 252, 252, 252
+gray100, 255, 255, 255
+grey100, 255, 255, 255
+dark grey, 169, 169, 169
+darkgrey, 169, 169, 169
+dark gray, 169, 169, 169
+darkgray, 169, 169, 169
+dark blue, 0, 0, 139
+darkblue, 0, 0, 139
+dark cyan, 0, 139, 139
+darkcyan, 0, 139, 139
+dark magenta, 139, 0, 139
+darkmagenta, 139, 0, 139
+dark red, 139, 0, 0
+darkred, 139, 0, 0
+light green, 144, 238, 144
+lightgreen, 144, 238, 144
+%%
+void name2rgb(char* name, double* rgb)
+{
+    const struct color* c = lookup_color(name, balisc_strlen(name));
+
+    if (c)
+    {
+        rgb[0] = (double)(c->red);
+        rgb[1] = (double)(c->green);
+        rgb[2] = (double)(c->blue);
+    }
+    else
+    {
+        rgb[0] = -1.0;
+        rgb[1] = -1.0;
+        rgb[2] = -1.0;
+    }
+}


### PR DESCRIPTION
this significantly improves the speed of color lookups by name, e.g.

- `name2rgb("red")` (40-70%)
-  `color("black")` (20-60%)

Furthermore, the lookup speed is now almost independent of the color name, e.g. in Scilab 6.x lookup "scilab blue4" was fast in comparision to the lookup of "lightgreen". Thanks to the perfect hash function generated by `gperf`.