### PR TITLE
Fixed #254

### DIFF
--- a/scilab/modules/fileio/src/cpp/expandPathVariable.gperf
+++ b/scilab/modules/fileio/src/cpp/expandPathVariable.gperf
@@ -1,36 +1,24 @@
-/* C++ code produced by gperf version 3.0.4 */
-/* Command-line: gperf -m 50 expandPathVariable.gperf  */
-/* Computed positions: -k'1' */
+/* Balisc (https://github.com/rdbyk/balisc/)
+ * 
+ * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
 
-#if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
-      && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
-      && (')' == 41) && ('*' == 42) && ('+' == 43) && (',' == 44) \
-      && ('-' == 45) && ('.' == 46) && ('/' == 47) && ('0' == 48) \
-      && ('1' == 49) && ('2' == 50) && ('3' == 51) && ('4' == 52) \
-      && ('5' == 53) && ('6' == 54) && ('7' == 55) && ('8' == 56) \
-      && ('9' == 57) && (':' == 58) && (';' == 59) && ('<' == 60) \
-      && ('=' == 61) && ('>' == 62) && ('?' == 63) && ('A' == 65) \
-      && ('B' == 66) && ('C' == 67) && ('D' == 68) && ('E' == 69) \
-      && ('F' == 70) && ('G' == 71) && ('H' == 72) && ('I' == 73) \
-      && ('J' == 74) && ('K' == 75) && ('L' == 76) && ('M' == 77) \
-      && ('N' == 78) && ('O' == 79) && ('P' == 80) && ('Q' == 81) \
-      && ('R' == 82) && ('S' == 83) && ('T' == 84) && ('U' == 85) \
-      && ('V' == 86) && ('W' == 87) && ('X' == 88) && ('Y' == 89) \
-      && ('Z' == 90) && ('[' == 91) && ('\\' == 92) && (']' == 93) \
-      && ('^' == 94) && ('_' == 95) && ('a' == 97) && ('b' == 98) \
-      && ('c' == 99) && ('d' == 100) && ('e' == 101) && ('f' == 102) \
-      && ('g' == 103) && ('h' == 104) && ('i' == 105) && ('j' == 106) \
-      && ('k' == 107) && ('l' == 108) && ('m' == 109) && ('n' == 110) \
-      && ('o' == 111) && ('p' == 112) && ('q' == 113) && ('r' == 114) \
-      && ('s' == 115) && ('t' == 116) && ('u' == 117) && ('v' == 118) \
-      && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
-      && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
-/* The character set is not based on ISO-646.  */
-#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
-#endif
-
-#line 21 "expandPathVariable.gperf"
-
+%{
 // Balisc (https://github.com/rdbyk/balisc/)
 //
 // Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
@@ -85,98 +73,28 @@ extern "C"
 #define FILESEPS_WSTR L"/\\"
 
 struct alias {char *name; wchar_t *true_name; symbol::Variable* variable;};
-#line 86 "expandPathVariable.gperf"
-struct alias;
+%}
 
-#define TOTAL_KEYWORDS 7
-#define MIN_WORD_LENGTH 1
-#define MAX_WORD_LENGTH 7
-#define MIN_HASH_VALUE 1
-#define MAX_HASH_VALUE 8
-/* maximum key range = 8, duplicates = 0 */
+%language=C++
+%global-table
+%define string-pool-name aliases
+%define word-array-name aliaslist
+%define lookup-function-name lookup_alias
+%define class-name Hash
+%struct-type
 
-class Hash
-{
-private:
-  static inline unsigned int hash (const char *str, unsigned int len);
-public:
-  static struct alias *lookup_alias (const char *str, unsigned int len);
-};
-
-inline unsigned int
-Hash::hash (register const char *str, register unsigned int len)
-{
-  static unsigned char asso_values[] =
-    {
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 4, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 0, 0, 9, 9, 1, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 0, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 0, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
-      9, 9, 9, 9, 9, 9
-    };
-  return len + asso_values[(unsigned char)str[0]];
-}
-
-static struct alias aliaslist[] =
-  {
-    {""},
-#line 93 "expandPathVariable.gperf"
-    {"~", L"home", NULL},
-    {""},
-#line 89 "expandPathVariable.gperf"
-    {"SCI", L"SCI", NULL},
-#line 95 "expandPathVariable.gperf"
-    {"home", L"home", NULL},
-#line 91 "expandPathVariable.gperf"
-    {"WSCI", L"WSCI", NULL},
-#line 96 "expandPathVariable.gperf"
-    {"TMPDIR", L"TMPDIR", NULL},
-#line 88 "expandPathVariable.gperf"
-    {"SCIHOME", L"SCIHOME", NULL},
-#line 94 "expandPathVariable.gperf"
-    {"HOME", L"home", NULL}
-  };
-
-struct alias *
-Hash::lookup_alias (register const char *str, register unsigned int len)
-{
-  if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
-    {
-      register int key = hash (str, len);
-
-      if (key <= MAX_HASH_VALUE && key >= 0)
-        {
-          register const char *s = aliaslist[key].name;
-
-          if (*str == *s && !strcmp (str + 1, s + 1))
-            return &aliaslist[key];
-        }
-    }
-  return 0;
-}
-#line 97 "expandPathVariable.gperf"
-
+struct alias
+%%
+SCIHOME, L"SCIHOME", NULL
+SCI, L"SCI", NULL
+#ifdef _WIN64
+WSCI, L"WSCI", NULL
+#endif
+"~", L"home", NULL
+HOME, L"home", NULL
+home, L"home", NULL
+TMPDIR, L"TMPDIR", NULL
+%%
 static wchar_t *getVariableValueDefinedInScilab(struct alias* a);
 
 wchar_t *expandPathVariableW(const wchar_t *wcstr)


### PR DESCRIPTION
Fixes #254 and improves speed (e.g. `fullpath` is approx. 30-40% faster cf. below).

Scilab 6.x:
```
--> tic;for i=1:1e6;fullpath("SCIHOME/A/B/C");end;toc
 ans  =
   7.35621
--> tic;for i=1:1e6;fullpath("TMPDIR/A/B/C");end;toc
 ans  =
   7.396255
--> tic;for i=1:1e6;fullpath("/SCIHOME/A/B/C");end;toc
 ans  =
   4.101849
--> tic;for i=1:1e6;fullpath("/TMPDIR/A/B/C");end;toc
 ans  =
   4.064267

```
Balisc:
```
--> tic;for i=1:1e6;fullpath("SCIHOME/A/B/C");end;toc
 ans  =
   4.504423
--> tic;for i=1:1e6;fullpath("TMPDIR/A/B/C");end;toc
 ans  =
   4.594983
--> tic;for i=1:1e6;fullpath("/SCIHOME/A/B/C");end;toc
 ans  =
   2.499993
--> tic;for i=1:1e6;fullpath("/TMPDIR/A/B/C");end;toc
 ans  =
   2.517441
```
