### PR TITLE
Refactored "log2" (approx. 50% faster for scalar args)

### DIFF
--- a/scilab/modules/elementary_functions/macros/log2.sci
+++ b/scilab/modules/elementary_functions/macros/log2.sci
@@ -1,8 +1,8 @@
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) INRIA
 // Copyright (C) DIGITEO - 2011 - Allan CORNET
-//
 // Copyright (C) 2012 - 2016 - Scilab Enterprises
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 // This file is hereby licensed under the terms of the GNU GPL v2.0,
 // pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -13,13 +13,13 @@
 
 function [f, e] = log2(x)
     // x may be positive, negative, or complex
-    [lhs, rhs] = argn(0)
-    if rhs <> 1 then
+    if nargin <> 1 then
         msg = gettext("%s: Wrong number of input argument(s): %d expected.\n")
         error(msprintf(msg, "log2", 1))
     end
-    if argn(1) == 1 then
-        f = log(x) / log(2)
+    if nargout == 1 then
+        // 1/log(2) = 1.4426950408889633870047
+        f = log(x) * 1.4426950408889633870047
     else
         [f, e] = frexp(x)
     end


### PR DESCRIPTION
Scilab 6.x
```
--> tic;for i=1:1e5;log2(100);end;toc
 ans  =
   1.48636
```
Balisc
```
--> tic;for i=1:1e5;log2(100);end;toc
 ans  =
   0.615714
```
