### PR TITLE
Improved Performance of "x==[]", "x<>[]" for Bool, Double, String (approx. 85% faster!)

### DIFF
--- a/scilab/modules/ast/includes/operations/types_comparison_eq.hxx
+++ b/scilab/modules/ast/includes/operations/types_comparison_eq.hxx
@@ -1,9 +1,9 @@
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2011-2011 - DIGITEO - Bruno JOFRET
- *  Copyright (C) 2015 - Scilab Enterprises - Sylvain GENIN
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2011-2011 - DIGITEO - Bruno JOFRET
+ * Copyright (C) 2015 - Scilab Enterprises - Sylvain GENIN
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyrigth (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -103,6 +103,12 @@ DECLARE_COMPARISON_EQUAL_PROTO(compequal_UT_UT);
 
 
 #undef DECLARE_COMPARISON_EQUAL_PROTO
+
+template<> types::InternalType* compequal_M_E<types::Bool, types::Double, types::Bool>(types::Bool* _pL, types::Double* _pR);
+
+template<> types::InternalType* compequal_M_E<types::Double, types::Double, types::Bool>(types::Double* _pL, types::Double* _pR);
+
+template<> types::InternalType* compequal_M_E<types::String, types::String, types::Bool>(types::String* _pL, types::String* _pR);
 
 template<> types::InternalType* compequal_M_M<types::Sparse, types::Sparse, types::SparseBool>(types::Sparse* _pL, types::Sparse* _pR);
 

--- a/scilab/modules/ast/includes/operations/types_comparison_ne.hxx
+++ b/scilab/modules/ast/includes/operations/types_comparison_ne.hxx
@@ -1,9 +1,9 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2011 - DIGITEO - Antoine ELIAS
-*  Copyright (C) 2015 - Scilab Enterprises - Sylvain GENIN
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2011 - DIGITEO - Antoine ELIAS
+ * Copyright (C) 2015 - Scilab Enterprises - Sylvain GENIN
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyrigth (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -11,8 +11,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 #ifndef __TYPES_COMPARISON_NO_EQUAL_HXX__
 #define __TYPES_COMPARISON_NO_EQUAL_HXX__
@@ -103,6 +103,12 @@ DECLARE_COMPARISON_NO_EQUAL_PROTO(compnoequal_UT_UT);
 
 
 #undef DECLARE_COMPARISON_NO_EQUAL_PROTO
+
+template<> types::InternalType* compnoequal_M_E<types::Bool, types::Double, types::Bool>(types::Bool* _pL, types::Double* _pR);
+
+template<> types::InternalType* compnoequal_M_E<types::Double, types::Double, types::Bool>(types::Double* _pL, types::Double* _pR);
+
+template<> types::InternalType* compnoequal_M_E<types::String, types::String, types::Bool>(types::String* _pL, types::String* _pR);
 
 template<> types::InternalType* compnoequal_M_M<types::Sparse, types::Sparse, types::SparseBool>(types::Sparse* _pL, types::Sparse* _pR);
 

--- a/scilab/modules/ast/src/cpp/operations/types_comparison_eq.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_comparison_eq.cpp
@@ -4,7 +4,7 @@
  * Copyright (C) 2015 - Scilab Enterprises - Sylvain GENIN
  * Copyright (C) 2016 - Scilab Enterprises - Pierre-Aimé AGNEL
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyrigth (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyrigth (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -2279,6 +2279,27 @@ template<class T, class U, class O>
 InternalType* compequal_E_E(T *_pL, U *_pR)
 {
     return new Bool(true);
+}
+
+// Bool == []
+template<>
+InternalType* compequal_M_E<Bool, Double, Bool>(Bool* _pL, Double* _pR)
+{
+    return new Bool(_pL->getSize() <= 0);
+}
+
+// Double == []
+template<>
+InternalType* compequal_M_E<Double, Double, Bool>(Double* _pL, Double* _pR)
+{
+    return new Bool(_pL->getSize() <= 0);
+}
+
+// String == []
+template<>
+InternalType* compequal_M_E<String, String, Bool>(String* _pL, String* _pR)
+{
+    return new Bool(_pL->getSize() <= 0);
 }
 
 //B == x

--- a/scilab/modules/ast/src/cpp/operations/types_comparison_ne.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_comparison_ne.cpp
@@ -4,7 +4,7 @@
  * Copyright (C) 2015 - Scilab Enterprises - Sylvain GENIN
  * Copyright (C) 2016 - Scilab Enterprises - Pierre-Aimé AGNEL
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyrigth (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyrigth (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -2281,6 +2281,27 @@ template<class T, class U, class O>
 InternalType* compnoequal_E_E(T *_pL, U *_pR)
 {
     return new Bool(false);
+}
+
+// Bool <> []
+template<>
+InternalType* compnoequal_M_E<Bool, Double, Bool>(Bool* _pL, Double* _pR)
+{
+    return new Bool(_pL->getSize() > 0);
+}
+
+// Double <> []
+template<>
+InternalType* compnoequal_M_E<Double, Double, Bool>(Double* _pL, Double* _pR)
+{
+    return new Bool(_pL->getSize() > 0);
+}
+
+// String <> []
+template<>
+InternalType* compnoequal_M_E<String, String, Bool>(String* _pL, String* _pR)
+{
+    return new Bool(_pL->getSize() > 0);
 }
 
 //B != x


### PR DESCRIPTION
- fixes #297 
- `x==[]` and `x<>[]` for any x of type `Bool`, `Double`, or `String` is approx. 85% faster (cf. below)

Scilab 6.x
```
--> x=ones(2,2);
--> tic;for i=1:1e6;x==[];end;toc
 ans  =
    5.547065
--> tic;for i=1:1e6;x<>[];end;toc
 ans  =
   5.67468
```

Balisc
```
--> x=ones(2,2);
--> tic;for i=1:1e6;x==[];end;toc
 ans  =
   0.681385
--> tic;for i=1:1e6;x<>[];end;toc
 ans  =
   0.676705
```