### PR TITLE
Implementation of New functions "isprotected", "protect", and "unprotect""

### DIFF
--- a/scilab/Makefile.in
+++ b/scilab/Makefile.in
@@ -2222,9 +2222,8 @@ doc-web: javadoc $(top_builddir)/scilab-bin $(top_builddir)/bin/scilab-adv-cli
 @BUILD_HELP_TRUE@		done; \
 @BUILD_HELP_TRUE@	else \
 @BUILD_HELP_TRUE@		echo "Cannot find Scilab-adv-cli binary"; \
-@BUILD_HELP_TRUE@	fi \
-@BUILD_HELP_TRUE@else
-@BUILD_HELP_TRUE@	@echo "Cannot buid help. Add --enable-build-help to the ./configure if you want to build it."
+@BUILD_HELP_TRUE@	fi
+@BUILD_HELP_FALSE@	@echo "Cannot buid help. Add --enable-build-help to the ./configure if you want to build it."
 
 $(top_builddir)/modules/helptools/data/pages/CHANGES.html: $(top_builddir)/CHANGES.md
 	sed -n '1,/html rendered CHANGES.md/{p;}' $@ >$@~

--- a/scilab/modules/Makefile.in
+++ b/scilab/modules/Makefile.in
@@ -179,7 +179,8 @@ am__installdirs = "$(DESTDIR)$(pkglibdir)"
 LTLIBRARIES = $(pkglib_LTLIBRARIES)
 am__DEPENDENCIES_1 =
 libscilab_cli_la_DEPENDENCIES = $(ENGINE_LIBS) $(NO_GUI_LIBS) \
-	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
+	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1) \
+	$(am__DEPENDENCIES_1)
 am_libscilab_cli_la_OBJECTS =
 libscilab_cli_la_OBJECTS = $(am_libscilab_cli_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
@@ -192,7 +193,8 @@ libscilab_cli_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	-o $@
 libscilab_la_DEPENDENCIES = $(am__append_7) $(am__append_8) \
 	$(top_builddir)/modules/libscilab-cli.la $(am__append_9) \
-	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
+	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1) \
+	$(am__DEPENDENCIES_1)
 am_libscilab_la_OBJECTS =
 libscilab_la_OBJECTS = $(am_libscilab_la_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
@@ -730,7 +732,8 @@ ENGINE_LIBS_DYNAMIC_LOAD = \
 # Core modules
 libscilab_la_LIBADD = $(am__append_7) $(am__append_8) \
 	$(top_builddir)/modules/libscilab-cli.la $(OTHER_LIBS) \
-	$(EXTERNAL_LIBS) $(am__append_9) $(FLIBS) $(LAPACK_LIBS) $(BLAS_LIBS)
+	$(EXTERNAL_LIBS) $(am__append_9) $(FLIBS) $(LAPACK_LIBS) \
+	$(BLAS_LIBS)
 
 ################## libscilab-cli  ##################
 libscilab_cli_la_SOURCES = 

--- a/scilab/modules/cacsd/Makefile.in
+++ b/scilab/modules/cacsd/Makefile.in
@@ -232,7 +232,9 @@ am__v_lt_0 = --silent
 am__v_lt_1 = 
 @MAINTAINER_MODE_FALSE@am_libscicacsd_algo_la_rpath =
 @MAINTAINER_MODE_TRUE@am_libscicacsd_algo_la_rpath =
-libscicacsd_la_DEPENDENCIES = libscicacsd-algo.la
+am__DEPENDENCIES_1 =
+libscicacsd_la_DEPENDENCIES = libscicacsd-algo.la \
+	$(am__DEPENDENCIES_1)
 am__objects_4 = sci_gateway/c/libscicacsd_la-gw_cacsd.lo \
 	sci_gateway/c/libscicacsd_la-sci_contr.lo \
 	sci_gateway/c/libscicacsd_la-sci_dhinf.lo \

--- a/scilab/modules/core/Makefile.am
+++ b/scilab/modules/core/Makefile.am
@@ -117,6 +117,9 @@ GATEWAY_CPP_SOURCES = \
 	sci_gateway/cpp/sci_tlist.cpp \
 	sci_gateway/cpp/sci_mlist.cpp \
 	sci_gateway/cpp/sci_isfield.cpp \
+	sci_gateway/cpp/sci_isprotected.cpp \
+	sci_gateway/cpp/sci_protect.cpp \
+	sci_gateway/cpp/sci_unprotect.cpp \
 	sci_gateway/cpp/sci_oldEmptyBehaviour.cpp \
 	sci_gateway/cpp/sci_fieldnames.cpp
 

--- a/scilab/modules/core/Makefile.in
+++ b/scilab/modules/core/Makefile.in
@@ -244,7 +244,8 @@ am__v_lt_1 =
 @MAINTAINER_MODE_FALSE@am_libscicore_algo_la_rpath =
 @MAINTAINER_MODE_TRUE@am_libscicore_algo_la_rpath =
 am__DEPENDENCIES_1 =
-libscicore_la_DEPENDENCIES = libscicore-algo.la $(am__DEPENDENCIES_1)
+libscicore_la_DEPENDENCIES = libscicore-algo.la $(am__DEPENDENCIES_1) \
+	$(am__DEPENDENCIES_1)
 am__libscicore_la_SOURCES_DIST = sci_gateway/c/sci_getdebuginfo.c \
 	sci_gateway/cpp/core_gw.cpp sci_gateway/cpp/sci_getmodules.cpp \
 	sci_gateway/cpp/sci_clear.cpp sci_gateway/cpp/sci_clearfun.cpp \
@@ -279,6 +280,9 @@ am__libscicore_la_SOURCES_DIST = sci_gateway/c/sci_getdebuginfo.c \
 	sci_gateway/cpp/sci_makecell.cpp \
 	sci_gateway/cpp/sci_typeof.cpp sci_gateway/cpp/sci_tlist.cpp \
 	sci_gateway/cpp/sci_mlist.cpp sci_gateway/cpp/sci_isfield.cpp \
+	sci_gateway/cpp/sci_isprotected.cpp \
+	sci_gateway/cpp/sci_protect.cpp \
+	sci_gateway/cpp/sci_unprotect.cpp \
 	sci_gateway/cpp/sci_oldEmptyBehaviour.cpp \
 	sci_gateway/cpp/sci_fieldnames.cpp \
 	sci_gateway/cpp/sci_inspectorDeleteUnreferencedItems.cpp \
@@ -348,6 +352,9 @@ am__objects_6 = sci_gateway/cpp/libscicore_la-core_gw.lo \
 	sci_gateway/cpp/libscicore_la-sci_tlist.lo \
 	sci_gateway/cpp/libscicore_la-sci_mlist.lo \
 	sci_gateway/cpp/libscicore_la-sci_isfield.lo \
+	sci_gateway/cpp/libscicore_la-sci_isprotected.lo \
+	sci_gateway/cpp/libscicore_la-sci_protect.lo \
+	sci_gateway/cpp/libscicore_la-sci_unprotect.lo \
 	sci_gateway/cpp/libscicore_la-sci_oldEmptyBehaviour.lo \
 	sci_gateway/cpp/libscicore_la-sci_fieldnames.lo \
 	$(am__objects_5)
@@ -839,6 +846,9 @@ GATEWAY_CPP_SOURCES = sci_gateway/cpp/core_gw.cpp \
 	sci_gateway/cpp/sci_makecell.cpp \
 	sci_gateway/cpp/sci_typeof.cpp sci_gateway/cpp/sci_tlist.cpp \
 	sci_gateway/cpp/sci_mlist.cpp sci_gateway/cpp/sci_isfield.cpp \
+	sci_gateway/cpp/sci_isprotected.cpp \
+	sci_gateway/cpp/sci_protect.cpp \
+	sci_gateway/cpp/sci_unprotect.cpp \
 	sci_gateway/cpp/sci_oldEmptyBehaviour.cpp \
 	sci_gateway/cpp/sci_fieldnames.cpp $(am__append_1)
 libscicore_la_CPPFLAGS = -I$(srcdir)/includes/ -I$(srcdir)/src/c/ \
@@ -1378,6 +1388,15 @@ sci_gateway/cpp/libscicore_la-sci_mlist.lo:  \
 sci_gateway/cpp/libscicore_la-sci_isfield.lo:  \
 	sci_gateway/cpp/$(am__dirstamp) \
 	sci_gateway/cpp/$(DEPDIR)/$(am__dirstamp)
+sci_gateway/cpp/libscicore_la-sci_isprotected.lo:  \
+	sci_gateway/cpp/$(am__dirstamp) \
+	sci_gateway/cpp/$(DEPDIR)/$(am__dirstamp)
+sci_gateway/cpp/libscicore_la-sci_protect.lo:  \
+	sci_gateway/cpp/$(am__dirstamp) \
+	sci_gateway/cpp/$(DEPDIR)/$(am__dirstamp)
+sci_gateway/cpp/libscicore_la-sci_unprotect.lo:  \
+	sci_gateway/cpp/$(am__dirstamp) \
+	sci_gateway/cpp/$(DEPDIR)/$(am__dirstamp)
 sci_gateway/cpp/libscicore_la-sci_oldEmptyBehaviour.lo:  \
 	sci_gateway/cpp/$(am__dirstamp) \
 	sci_gateway/cpp/$(DEPDIR)/$(am__dirstamp)
@@ -1465,6 +1484,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_intppty.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_isfield.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_isglobal.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_isprotected.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_lasterror.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_list.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_macr2tree.Plo@am__quote@
@@ -1476,6 +1496,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_oldEmptyBehaviour.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_pause.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_predef.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_protect.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_quit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_recursionlimit.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_sciargs.Plo@am__quote@
@@ -1484,6 +1505,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_type.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_typename.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_typeof.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_unprotect.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_warning.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_what.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_where.Plo@am__quote@
@@ -2196,6 +2218,27 @@ sci_gateway/cpp/libscicore_la-sci_isfield.lo: sci_gateway/cpp/sci_isfield.cpp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='sci_gateway/cpp/sci_isfield.cpp' object='sci_gateway/cpp/libscicore_la-sci_isfield.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o sci_gateway/cpp/libscicore_la-sci_isfield.lo `test -f 'sci_gateway/cpp/sci_isfield.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_isfield.cpp
+
+sci_gateway/cpp/libscicore_la-sci_isprotected.lo: sci_gateway/cpp/sci_isprotected.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT sci_gateway/cpp/libscicore_la-sci_isprotected.lo -MD -MP -MF sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_isprotected.Tpo -c -o sci_gateway/cpp/libscicore_la-sci_isprotected.lo `test -f 'sci_gateway/cpp/sci_isprotected.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_isprotected.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_isprotected.Tpo sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_isprotected.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='sci_gateway/cpp/sci_isprotected.cpp' object='sci_gateway/cpp/libscicore_la-sci_isprotected.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o sci_gateway/cpp/libscicore_la-sci_isprotected.lo `test -f 'sci_gateway/cpp/sci_isprotected.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_isprotected.cpp
+
+sci_gateway/cpp/libscicore_la-sci_protect.lo: sci_gateway/cpp/sci_protect.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT sci_gateway/cpp/libscicore_la-sci_protect.lo -MD -MP -MF sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_protect.Tpo -c -o sci_gateway/cpp/libscicore_la-sci_protect.lo `test -f 'sci_gateway/cpp/sci_protect.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_protect.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_protect.Tpo sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_protect.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='sci_gateway/cpp/sci_protect.cpp' object='sci_gateway/cpp/libscicore_la-sci_protect.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o sci_gateway/cpp/libscicore_la-sci_protect.lo `test -f 'sci_gateway/cpp/sci_protect.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_protect.cpp
+
+sci_gateway/cpp/libscicore_la-sci_unprotect.lo: sci_gateway/cpp/sci_unprotect.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT sci_gateway/cpp/libscicore_la-sci_unprotect.lo -MD -MP -MF sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_unprotect.Tpo -c -o sci_gateway/cpp/libscicore_la-sci_unprotect.lo `test -f 'sci_gateway/cpp/sci_unprotect.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_unprotect.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_unprotect.Tpo sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_unprotect.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='sci_gateway/cpp/sci_unprotect.cpp' object='sci_gateway/cpp/libscicore_la-sci_unprotect.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o sci_gateway/cpp/libscicore_la-sci_unprotect.lo `test -f 'sci_gateway/cpp/sci_unprotect.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_unprotect.cpp
 
 sci_gateway/cpp/libscicore_la-sci_oldEmptyBehaviour.lo: sci_gateway/cpp/sci_oldEmptyBehaviour.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT sci_gateway/cpp/libscicore_la-sci_oldEmptyBehaviour.lo -MD -MP -MF sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_oldEmptyBehaviour.Tpo -c -o sci_gateway/cpp/libscicore_la-sci_oldEmptyBehaviour.lo `test -f 'sci_gateway/cpp/sci_oldEmptyBehaviour.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_oldEmptyBehaviour.cpp

--- a/scilab/modules/core/includes/core_gw.hxx
+++ b/scilab/modules/core/includes/core_gw.hxx
@@ -3,7 +3,7 @@
  * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2011-2011 - DIGITEO - Bruno JOFRET
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -84,6 +84,9 @@ CPP_GATEWAY_PROTOTYPE(sci_typeof);
 CPP_GATEWAY_PROTOTYPE(sci_tlist_gw);
 CPP_GATEWAY_PROTOTYPE(sci_mlist_gw);
 CPP_GATEWAY_PROTOTYPE(sci_isfield);
+CPP_GATEWAY_PROTOTYPE(sci_isprotected);
+CPP_GATEWAY_PROTOTYPE(sci_protect);
+CPP_GATEWAY_PROTOTYPE(sci_unprotect);
 CPP_GATEWAY_PROTOTYPE(sci_fieldnames);
 CPP_GATEWAY_PROTOTYPE(sci_oldEmptyBehaviour);
 

--- a/scilab/modules/core/sci_gateway/cpp/core_gw.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/core_gw.cpp
@@ -1,8 +1,8 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 #include "core_gw.hxx"
 #include "context.hxx"
@@ -79,6 +79,9 @@ int CoreModule::Load()
     symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"isfield", &sci_isfield, MODULE_NAME));
     symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"fieldnames", &sci_fieldnames, MODULE_NAME));
     symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"oldEmptyBehaviour", &sci_oldEmptyBehaviour, MODULE_NAME));
+    symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"isprotected", &sci_isprotected, MODULE_NAME));
+    symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"protect", &sci_protect, MODULE_NAME));
+    symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"unprotect", &sci_unprotect, MODULE_NAME));
 
 #ifndef NDEBUG
     symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"inspectorGetItemCount", &sci_inspectorGetItemCount, MODULE_NAME));

--- a/scilab/modules/core/sci_gateway/cpp/sci_isprotected.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_isprotected.cpp
@@ -1,0 +1,89 @@
+// Balisc (https://github.com/rdbyk/balisc/)
+// 
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 
+// 02110-1301, USA.
+
+#include "core_gw.hxx"
+#include "function.hxx"
+#include "context.hxx"
+#include "string.hxx"
+
+extern "C"
+{
+#include "Scierror.h"
+#include "localization.h"
+}
+
+using types::Bool;
+using types::Double;
+using types::Function;
+using types::String;
+using types::typed_list;
+using symbol::Context;
+using symbol::Symbol;
+
+static const char fname[] = "isprotected";
+
+Function::ReturnValue sci_isprotected(typed_list &in, int _iRetCount, typed_list &out)
+{
+    if (in.size() != 1)
+    {
+        Scierror(77, _("%s: Wrong number of input argument(s): %d expected.\n"), fname, 1);
+        return types::Function::Error;
+    }
+
+    if (in[0]->isString() == false)
+    {
+        Scierror(999, _("%s: Wrong type for input argument #%d: A String expected.\n"), fname, 1);
+        return types::Function::Error;
+    }
+    
+    String* pS = in[0]->getAs<String>();
+    
+    if (pS->getSize() == 0)
+    {
+        out.push_back(
+        Double::Empty());
+        return Function::OK;
+    }
+
+    Context *pCtx = Context::getInstance();
+
+    for (int i = 0; i < pS->getSize(); ++i)
+    {
+        wchar_t* wcsVarName = pS->get(i);
+
+        if (pCtx->isValidVariableName(wcsVarName) == false)
+        {
+            char* pstrVarName = wide_string_to_UTF8(wcsVarName);
+            Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, 1);
+            FREE(pstrVarName);
+            return Function::Error;
+        }
+    }
+
+    Bool* pB = new Bool(pS->getDims(), pS->getDimsArray());
+    int* pb = pB->get();
+
+    for (int i = 0; i < pS->getSize(); ++i)
+    {
+        pb[i] = pCtx->isprotected(Symbol(pS->get(i)));
+    }
+    
+    out.push_back(pB);
+    return Function::OK;
+}

--- a/scilab/modules/core/sci_gateway/cpp/sci_protect.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_protect.cpp
@@ -1,0 +1,103 @@
+// Balisc (https://github.com/rdbyk/balisc/)
+// 
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 
+// 02110-1301, USA.
+
+#include "core_gw.hxx"
+#include "function.hxx"
+#include "context.hxx"
+#include "string.hxx"
+
+extern "C"
+{
+#include "Scierror.h"
+#include "localization.h"
+}
+
+using types::Bool;
+using types::Double;
+using types::Function;
+using types::String;
+using types::typed_list;
+using symbol::Context;
+using symbol::Symbol;
+using symbol::Variable;
+using symbol::ScopedVariable;
+
+static const char fname[] = "protect";
+
+Function::ReturnValue sci_protect(typed_list &in, int _iRetCount, typed_list &out)
+{
+    if (in.size() != 1)
+    {
+        Scierror(77, _("%s: Wrong number of input argument(s): %d expected.\n"), fname, 1);
+        return types::Function::Error;
+    }
+
+    if (in[0]->isString() == false)
+    {
+        Scierror(999, _("%s: Wrong type for input argument #%d: A String expected.\n"), fname, 1);
+        return types::Function::Error;
+    }
+    
+    String* pS = in[0]->getAs<String>();
+    
+    if (pS->getSize() == 0)
+    {
+        out.push_back(
+        Double::Empty());
+        return Function::OK;
+    }
+
+    Context *pCtx = Context::getInstance();
+    
+    for (int i = 0; i < pS->getSize(); ++i)
+    {
+        wchar_t* wcsVarName = pS->get(i);
+
+        if (pCtx->isValidVariableName(wcsVarName) == false)
+        {
+            char* pstrVarName = wide_string_to_UTF8(wcsVarName);
+            Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, 1);
+            FREE(pstrVarName);
+            return Function::Error;
+        }
+        
+        if (pCtx->get(Symbol(wcsVarName)) == NULL)
+        {
+            char* pstrVarName = wide_string_to_UTF8(wcsVarName);
+            Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: An existent variable expected.\n"), fname, pstrVarName, 1);
+            FREE(pstrVarName);
+            return Function::Error;
+        }
+    }
+
+    for (int i = 0; i < pS->getSize(); ++i)
+    {
+        wchar_t* wcsVarName = pS->get(i);
+
+        Variable* pV = pCtx->getOrCreate(Symbol(wcsVarName));
+        
+        if (pV->empty() == false)
+        {
+            ScopedVariable* pSV = pV->top();
+            pSV->protect = true;
+        }
+    }
+
+    return Function::OK;
+}

--- a/scilab/modules/core/sci_gateway/cpp/sci_unprotect.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_unprotect.cpp
@@ -1,0 +1,103 @@
+// Balisc (https://github.com/rdbyk/balisc/)
+// 
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 
+// 02110-1301, USA.
+
+#include "core_gw.hxx"
+#include "function.hxx"
+#include "context.hxx"
+#include "string.hxx"
+
+extern "C"
+{
+#include "Scierror.h"
+#include "localization.h"
+}
+
+using types::Bool;
+using types::Double;
+using types::Function;
+using types::String;
+using types::typed_list;
+using symbol::Context;
+using symbol::Symbol;
+using symbol::Variable;
+using symbol::ScopedVariable;
+
+static const char fname[] = "unprotect";
+
+Function::ReturnValue sci_unprotect(typed_list &in, int _iRetCount, typed_list &out)
+{
+    if (in.size() != 1)
+    {
+        Scierror(77, _("%s: Wrong number of input argument(s): %d expected.\n"), fname, 1);
+        return types::Function::Error;
+    }
+
+    if (in[0]->isString() == false)
+    {
+        Scierror(999, _("%s: Wrong type for input argument #%d: A String expected.\n"), fname, 1);
+        return types::Function::Error;
+    }
+    
+    String* pS = in[0]->getAs<String>();
+    
+    if (pS->getSize() == 0)
+    {
+        out.push_back(
+        Double::Empty());
+        return Function::OK;
+    }
+
+    Context *pCtx = Context::getInstance();
+    
+    for (int i = 0; i < pS->getSize(); ++i)
+    {
+        wchar_t* wcsVarName = pS->get(i);
+
+        if (pCtx->isValidVariableName(wcsVarName) == false)
+        {
+            char* pstrVarName = wide_string_to_UTF8(wcsVarName);
+            Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, 1);
+            FREE(pstrVarName);
+            return Function::Error;
+        }
+        
+        if (pCtx->get(Symbol(wcsVarName)) == NULL)
+        {
+            char* pstrVarName = wide_string_to_UTF8(wcsVarName);
+            Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: An existent variable expected.\n"), fname, pstrVarName, 1);
+            FREE(pstrVarName);
+            return Function::Error;
+        }
+    }
+
+    for (int i = 0; i < pS->getSize(); ++i)
+    {
+        wchar_t* wcsVarName = pS->get(i);
+
+        Variable* pV = pCtx->getOrCreate(Symbol(wcsVarName));
+        
+        if (pV->empty() == false)
+        {
+            ScopedVariable* pSV = pV->top();
+            pSV->protect = false;
+        }
+    }
+
+    return Function::OK;
+}

--- a/scilab/modules/differential_equations/Makefile.in
+++ b/scilab/modules/differential_equations/Makefile.in
@@ -221,8 +221,9 @@ am__v_lt_0 = --silent
 am__v_lt_1 = 
 @MAINTAINER_MODE_FALSE@am_libscidifferential_equations_algo_la_rpath =
 @MAINTAINER_MODE_TRUE@am_libscidifferential_equations_algo_la_rpath =
+am__DEPENDENCIES_1 =
 libscidifferential_equations_la_DEPENDENCIES =  \
-	libscidifferential_equations-algo.la
+	libscidifferential_equations-algo.la $(am__DEPENDENCIES_1)
 am__objects_4 = sci_gateway/fortran/Ex-impl.lo \
 	sci_gateway/fortran/Ex-int2d.lo \
 	sci_gateway/fortran/Ex-int3d.lo sci_gateway/fortran/Ex-intg.lo \

--- a/scilab/modules/elementary_functions/Makefile.in
+++ b/scilab/modules/elementary_functions/Makefile.in
@@ -306,9 +306,10 @@ libscielementary_functions_algo_la_OBJECTS =  \
 	$(am_libscielementary_functions_algo_la_OBJECTS)
 @MAINTAINER_MODE_FALSE@am_libscielementary_functions_algo_la_rpath =
 @MAINTAINER_MODE_TRUE@am_libscielementary_functions_algo_la_rpath =
+am__DEPENDENCIES_1 =
 libscielementary_functions_la_DEPENDENCIES =  \
 	libdummy-elementary_functions.la \
-	libscielementary_functions-algo.la
+	libscielementary_functions-algo.la $(am__DEPENDENCIES_1)
 am__objects_7 = sci_gateway/c/libscielementary_functions_la-sci_number_properties.lo \
 	sci_gateway/c/libscielementary_functions_la-sci_testmatrix.lo \
 	sci_gateway/c/libscielementary_functions_la-sci_nearfloat.lo \

--- a/scilab/modules/graphic_objects/Makefile.in
+++ b/scilab/modules/graphic_objects/Makefile.in
@@ -191,8 +191,8 @@ am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
 am__DEPENDENCIES_1 =
-libscigraphic_objects_la_DEPENDENCIES =  \
-	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
+libscigraphic_objects_la_DEPENDENCIES = $(am__DEPENDENCIES_1) \
+	$(am__DEPENDENCIES_1)
 am__objects_2 = src/jni/libscigraphic_objects_la-DataLoader_wrap.lo \
 	src/jni/libscigraphic_objects_la-ScilabNativeView_wrap.lo \
 	src/jni/libscigraphic_objects_la-PolylineData_wrap.lo \

--- a/scilab/modules/interpolation/Makefile.in
+++ b/scilab/modules/interpolation/Makefile.in
@@ -186,7 +186,9 @@ AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
-libsciinterpolation_la_DEPENDENCIES = libsciinterpolation-algo.la
+am__DEPENDENCIES_1 =
+libsciinterpolation_la_DEPENDENCIES = libsciinterpolation-algo.la \
+	$(am__DEPENDENCIES_1)
 am__objects_3 =  \
 	sci_gateway/cpp/libsciinterpolation_la-sci_lsq_splin.lo \
 	sci_gateway/cpp/libsciinterpolation_la-sci_interp.lo \
@@ -648,7 +650,7 @@ CHECK_SRC = $(INTERPOLATION_C_SOURCES) $(GATEWAY_CPP_SOURCES)
 INCLUDE_FLAGS = $(libsciinterpolation_la_CFLAGS)
 libsciinterpolation_la_LIBADD = \
 	libsciinterpolation-algo.la \
-	$(FLIBS)
+	 $(FLIBS)
 
 
 #### Target ######

--- a/scilab/modules/javasci/Makefile.in
+++ b/scilab/modules/javasci/Makefile.in
@@ -1018,10 +1018,10 @@ maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
 	-test -z "$(BUILT_SOURCES)" || rm -f $(BUILT_SOURCES)
-@JAVASCI_FALSE@install-data-local:
-@JAVASCI_FALSE@install-html-local:
-@JAVASCI_FALSE@distclean-local:
 @JAVASCI_FALSE@clean-local:
+@JAVASCI_FALSE@install-html-local:
+@JAVASCI_FALSE@install-data-local:
+@JAVASCI_FALSE@distclean-local:
 clean: clean-am
 
 clean-am: clean-generic clean-libtool clean-local \

--- a/scilab/modules/linear_algebra/Makefile.in
+++ b/scilab/modules/linear_algebra/Makefile.in
@@ -197,7 +197,9 @@ am__v_lt_0 = --silent
 am__v_lt_1 = 
 @MAINTAINER_MODE_FALSE@am_libscilinear_algebra_algo_la_rpath =
 @MAINTAINER_MODE_TRUE@am_libscilinear_algebra_algo_la_rpath =
-libscilinear_algebra_la_DEPENDENCIES = libscilinear_algebra-algo.la
+am__DEPENDENCIES_1 =
+libscilinear_algebra_la_DEPENDENCIES = libscilinear_algebra-algo.la \
+	$(am__DEPENDENCIES_1)
 am__objects_4 =  \
 	sci_gateway/c/libscilinear_algebra_la-assembleEigenvectors.lo \
 	sci_gateway/c/libscilinear_algebra_la-sci_norm.lo

--- a/scilab/modules/optimization/Makefile.in
+++ b/scilab/modules/optimization/Makefile.in
@@ -222,7 +222,9 @@ AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
-libscioptimization_la_DEPENDENCIES = libscioptimization-algo.la
+am__DEPENDENCIES_1 =
+libscioptimization_la_DEPENDENCIES = libscioptimization-algo.la \
+	$(am__DEPENDENCIES_1)
 am__objects_5 = sci_gateway/cpp/libscioptimization_la-sci_optim.lo \
 	sci_gateway/cpp/libscioptimization_la-sci_fsolve.lo \
 	sci_gateway/cpp/libscioptimization_la-sci_semidef.lo \

--- a/scilab/modules/output_stream/Makefile.in
+++ b/scilab/modules/output_stream/Makefile.in
@@ -207,7 +207,9 @@ am__v_lt_0 = --silent
 am__v_lt_1 = 
 @MAINTAINER_MODE_FALSE@am_libscioutput_stream_algo_la_rpath =
 @MAINTAINER_MODE_TRUE@am_libscioutput_stream_algo_la_rpath =
-libscioutput_stream_la_DEPENDENCIES = libscioutput_stream-algo.la
+am__DEPENDENCIES_1 =
+libscioutput_stream_la_DEPENDENCIES = libscioutput_stream-algo.la \
+	$(am__DEPENDENCIES_1)
 am__objects_4 = sci_gateway/cpp/libscioutput_stream_la-sci_diary.lo \
 	sci_gateway/cpp/libscioutput_stream_la-sci_disp.lo \
 	sci_gateway/cpp/libscioutput_stream_la-output_stream_gw.lo \

--- a/scilab/modules/polynomials/Makefile.in
+++ b/scilab/modules/polynomials/Makefile.in
@@ -193,7 +193,9 @@ am__v_lt_0 = --silent
 am__v_lt_1 = 
 @MAINTAINER_MODE_FALSE@am_libscipolynomials_algo_la_rpath =
 @MAINTAINER_MODE_TRUE@am_libscipolynomials_algo_la_rpath =
-libscipolynomials_la_DEPENDENCIES = libscipolynomials-algo.la
+am__DEPENDENCIES_1 =
+libscipolynomials_la_DEPENDENCIES = libscipolynomials-algo.la \
+	$(am__DEPENDENCIES_1)
 am__objects_3 =  \
 	sci_gateway/cpp/libscipolynomials_la-polynomials_gw.lo \
 	sci_gateway/cpp/libscipolynomials_la-sci_poly.lo \

--- a/scilab/modules/scicos/Makefile.in
+++ b/scilab/modules/scicos/Makefile.in
@@ -297,7 +297,7 @@ libsciscicos_algo_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_CXXFLAGS) $(CXXFLAGS) $(libsciscicos_algo_la_LDFLAGS) \
 	$(LDFLAGS) -o $@
 libsciscicos_cli_la_DEPENDENCIES = libsciscicos-algo.la \
-	$(am__append_2)
+	$(am__DEPENDENCIES_1) $(am__append_2)
 am__libsciscicos_cli_la_SOURCES_DIST =  \
 	sci_gateway/cpp/sci_scicos_debug.cpp \
 	sci_gateway/cpp/sci_scicos_debug_count.cpp \
@@ -380,7 +380,8 @@ libsciscicos_cli_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_CXXFLAGS) $(CXXFLAGS) $(libsciscicos_cli_la_LDFLAGS) \
 	$(LDFLAGS) -o $@
 @XCOS_TRUE@am_libsciscicos_cli_la_rpath = -rpath $(pkglibdir)
-libsciscicos_la_DEPENDENCIES = libsciscicos-algo.la $(am__append_3)
+libsciscicos_la_DEPENDENCIES = libsciscicos-algo.la \
+	$(am__DEPENDENCIES_1) $(am__append_3)
 am__libsciscicos_la_SOURCES_DIST =  \
 	sci_gateway/cpp/sci_scicos_debug.cpp \
 	sci_gateway/cpp/sci_scicos_debug_count.cpp \
@@ -1097,8 +1098,9 @@ libsciscicos_algo_la_LIBADD = \
 		$(RT_LIB) \
 		$(LIBXML_LIBS)
 
-libsciscicos_cli_la_LIBADD = libsciscicos-algo.la $(am__append_2) $(FLIBS)
-libsciscicos_la_LIBADD = libsciscicos-algo.la $(am__append_3) $(FLIBS)
+libsciscicos_cli_la_LIBADD = libsciscicos-algo.la $(FLIBS) \
+	$(am__append_2)
+libsciscicos_la_LIBADD = libsciscicos-algo.la $(FLIBS) $(am__append_3)
 
 # For the code check (splint)
 CHECK_SRC = $(SCICOS_C_SOURCES) $(GATEWAY_C_SOURCES)

--- a/scilab/modules/scicos_blocks/Makefile.in
+++ b/scilab/modules/scicos_blocks/Makefile.in
@@ -185,7 +185,8 @@ am__installdirs = "$(DESTDIR)$(pkglibdir)" \
 	"$(DESTDIR)$(libsciscicos_blocks_la_includedir)"
 LTLIBRARIES = $(noinst_LTLIBRARIES) $(pkglib_LTLIBRARIES)
 am__DEPENDENCIES_1 =
-libsciscicos_blocks_algo_la_DEPENDENCIES = $(am__DEPENDENCIES_1)
+libsciscicos_blocks_algo_la_DEPENDENCIES = $(am__DEPENDENCIES_1) \
+	$(am__DEPENDENCIES_1)
 am__dirstamp = $(am__leading_dot)dirstamp
 am__objects_1 = src/c/libsciscicos_blocks_algo_la-absblk.lo \
 	src/c/libsciscicos_blocks_algo_la-absolute_value.lo \
@@ -546,7 +547,7 @@ libsciscicos_blocks_algo_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_CXXFLAGS) $(CXXFLAGS) \
 	$(libsciscicos_blocks_algo_la_LDFLAGS) $(LDFLAGS) -o $@
 libsciscicos_blocks_cli_la_DEPENDENCIES = $(am__append_3) \
-	$(am__DEPENDENCIES_1)
+	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
 am__libsciscicos_blocks_cli_la_SOURCES_DIST = src/cpp/HelpersCLI.cpp
 am__objects_6 = src/cpp/libsciscicos_blocks_cli_la-HelpersCLI.lo
 @XCOS_TRUE@am__objects_7 = $(am__objects_6)
@@ -558,7 +559,7 @@ libsciscicos_blocks_cli_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX \
 	$(AM_CXXFLAGS) $(CXXFLAGS) \
 	$(libsciscicos_blocks_cli_la_LDFLAGS) $(LDFLAGS) -o $@
 libsciscicos_blocks_la_DEPENDENCIES = $(am__append_5) \
-	$(am__DEPENDENCIES_1)
+	$(am__DEPENDENCIES_1) $(am__DEPENDENCIES_1)
 am__libsciscicos_blocks_la_SOURCES_DIST = src/cpp/HelpersJNI.cpp \
 	src/jni/AfficheBlock.cpp
 am__objects_8 = src/cpp/libsciscicos_blocks_la-HelpersJNI.lo \

--- a/scilab/modules/signal_processing/Makefile.in
+++ b/scilab/modules/signal_processing/Makefile.in
@@ -208,8 +208,9 @@ AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
+am__DEPENDENCIES_1 =
 libscisignal_processing_la_DEPENDENCIES =  \
-	libscisignal_processing-algo.la
+	libscisignal_processing-algo.la $(am__DEPENDENCIES_1)
 am__objects_4 = sci_gateway/c/libscisignal_processing_la-sci_remez.lo \
 	sci_gateway/c/libscisignal_processing_la-sci_amell.lo \
 	sci_gateway/c/libscisignal_processing_la-sci_conv2.lo

--- a/scilab/modules/sparse/Makefile.in
+++ b/scilab/modules/sparse/Makefile.in
@@ -190,7 +190,9 @@ am__v_lt_0 = --silent
 am__v_lt_1 = 
 @MAINTAINER_MODE_FALSE@am_libscisparse_algo_la_rpath =
 @MAINTAINER_MODE_TRUE@am_libscisparse_algo_la_rpath =
-libscisparse_la_DEPENDENCIES = libscisparse-algo.la
+am__DEPENDENCIES_1 =
+libscisparse_la_DEPENDENCIES = libscisparse-algo.la \
+	$(am__DEPENDENCIES_1)
 am__objects_3 = sci_gateway/cpp/libscisparse_la-sparse_gw.lo \
 	sci_gateway/cpp/libscisparse_la-sci_adj2sp.lo \
 	sci_gateway/cpp/libscisparse_la-sci_full.lo \

--- a/scilab/modules/special_functions/Makefile.in
+++ b/scilab/modules/special_functions/Makefile.in
@@ -185,8 +185,9 @@ AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
+am__DEPENDENCIES_1 =
 libscispecial_functions_la_DEPENDENCIES =  \
-	libscispecial_functions-algo.la
+	libscispecial_functions-algo.la $(am__DEPENDENCIES_1)
 am__objects_4 =  \
 	sci_gateway/c/libscispecial_functions_la-sci_bessely.lo \
 	sci_gateway/c/libscispecial_functions_la-sci_beta.lo \

--- a/scilab/modules/statistics/Makefile.in
+++ b/scilab/modules/statistics/Makefile.in
@@ -209,7 +209,9 @@ AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
-libscistatistics_la_DEPENDENCIES = libscistatistics-algo.la
+am__DEPENDENCIES_1 =
+libscistatistics_la_DEPENDENCIES = libscistatistics-algo.la \
+	$(am__DEPENDENCIES_1)
 am__objects_3 = sci_gateway/c/libscistatistics_la-sci_cdfchi.lo \
 	sci_gateway/c/libscistatistics_la-sci_cdft.lo \
 	sci_gateway/c/libscistatistics_la-sci_cdfgam.lo \


### PR DESCRIPTION
fixes #41 

`isprotected`, `protect`, and `unprotect` provide means for dealling with **protection of variables**,  each accepts one array of strings as input argument ...

```
--> protect("a")

protect: Wrong value "a" in argument #1: An existent variable expected.

--> a=123
 a  = 

   123.


--> protect a

--> isprotected("a")
 ans  =

  T


--> a=456

Redefining permanent variable.

--> a
 a  = 

   123.


--> unprotect("a")

--> isprotected("a")
 ans  =

  F


--> a=456
 a  = 

   456.


--> isprotected("%nan")
 ans  =

  T


--> unprotect("%nan") // Not a good idea at all, but will it work?

--> %nan
 %nan  = 

   Nan


--> %nan=0
 %nan  = 

   0.

--> %nan = 0/0
 %nan  = 

   Nan
```
