### PR TITLE
Fixed #379

### DIFF
--- a/scilab/modules/ast/src/cpp/types/tostring_common.cpp
+++ b/scilab/modules/ast/src/cpp/types/tostring_common.cpp
@@ -335,88 +335,26 @@ void addDoubleComplexValue(std::wostringstream * _postr, double _dblR, double _d
 {
     std::wostringstream ostemp;
 
-    /*
-     * if R && !C -> R
-     * if R && C -> R + Ci
-     * if !R && !C -> 0
-     * if(!R && C -> Ci
-     */
+    // real part
+    DoubleFormat df;
 
-    // *_postr << "|%" << _iTotalWitdh << "%|";
-    if (_dblR == 0)
+    df.iPrec = _pDFR->iPrec;
+    df.bExp = _pDFR->bExp;
+
+    addDoubleValue(&ostemp, _dblR, &df);
+
+    // imaginary part
+    df.iPrec = _pDFI->iPrec;
+    df.bExp = _pDFI->bExp;
+    df.bPrintPlusSign = true;
+    df.bPrintComplexPlusSpace = true;
+    df.bPrintOne = false;
+
+    addDoubleValue(&ostemp, _dblI, &df);
+    ostemp << std::left << SYMBOL_I;
+    if (_dblI == 1)
     {
-        //no real part
-        if (_dblI == 0)
-        {
-            //no imaginary part
-
-            //0
-            DoubleFormat df;
-
-            addDoubleValue(&ostemp, 0, &df);
-        }
-        else
-        {
-            //imaginary part
-
-            //I
-            DoubleFormat df;
-
-            df.iWidth = 0;
-            df.iPrec = _pDFI->iPrec;
-            df.bExp = _pDFI->bExp;
-            df.bPrintPlusSign = false;
-            df.bPrintOne = false;
-            addDoubleValue(&ostemp, _dblI, &df);
-            ostemp << std::left << SYMBOL_I;
-            if (_dblI == 1)
-            {
-                addSpaces(&ostemp, 1);
-            }
-
-        }
-    }
-    else
-    {
-        //real part
-        if (_dblI == 0)
-        {
-            //no imaginary part
-
-            //R
-            DoubleFormat df;
-
-            df.iWidth = 0;
-            df.iPrec = _pDFR->iPrec;
-            df.bExp = _pDFR->bExp;
-            addDoubleValue(&ostemp, _dblR, &df);
-        }
-        else
-        {
-            //imaginary part
-
-            //R
-            DoubleFormat df;
-
-            df.iPrec = _pDFR->iPrec;
-            df.bExp = _pDFR->bExp;
-
-            addDoubleValue(&ostemp, _dblR, &df);
-
-            //I
-            df.iPrec = _pDFI->iPrec;
-            df.bExp = _pDFI->bExp;
-            df.bPrintPlusSign = true;
-            df.bPrintComplexPlusSpace = true;
-            df.bPrintOne = false;
-
-            addDoubleValue(&ostemp, _dblI, &df);
-            ostemp << std::left << SYMBOL_I;
-            if (_dblI == 1)
-            {
-                addSpaces(&ostemp, 2);
-            }
-        }
+        addSpaces(&ostemp, 2);
     }
 
     configureStream(_postr, _iTotalWidth, 0, ' ');

--- a/scilab/modules/ast/src/cpp/types/tostring_common.cpp
+++ b/scilab/modules/ast/src/cpp/types/tostring_common.cpp
@@ -37,17 +37,17 @@ void addSign(std::wostringstream * _postr, double _dblVal, bool _bPrintPlusSign,
 {
     if (_bPrintPlusSign == true)
     {
-        *_postr << (_dblVal < 0 ? MINUS_STRING : PLUS_STRING);
+        *_postr << (std::signbit(_dblVal) ? MINUS_STRING : PLUS_STRING);
     }
     else
     {
         if (_bPaddSign)
         {
-            *_postr << (_dblVal < 0 ? MINUS_STRING : NO_SIGN);
+            *_postr << (std::signbit(_dblVal) ? MINUS_STRING : NO_SIGN);
         }
         else
         {
-            *_postr << (_dblVal < 0 ? MINUS_STRING : L"");
+            *_postr << (std::signbit(_dblVal) ? MINUS_STRING : L"");
         }
     }
 }

--- a/scilab/modules/ast/src/cpp/types/tostring_common.cpp
+++ b/scilab/modules/ast/src/cpp/types/tostring_common.cpp
@@ -31,7 +31,6 @@ extern "C"
 #define EXPOSANT_SIZE 2         //exposant symbol + exposant sign
 
 #define isRealZero(x) (fabs(static_cast<double>(x)) <= nc_eps())
-#define isEqual(x,y) (fabs((double)x - (double)y) <= nc_eps())
 
 void addSign(std::wostringstream * _postr, double _dblVal, bool _bPrintPlusSign, bool _bPaddSign)
 {
@@ -310,7 +309,7 @@ void addDoubleValue(std::wostringstream * _postr, double _dblVal, DoubleFormat *
         // and write a negative number, dblEnt is at most one digit
         os_swprintf(pwstOutput, 32, pwstFormat, (int)dblEnt, (long long int)dblDec, (int)dblTemp);
     }
-    else if ((_pDF->bPrintOne == true) || (isEqual(fabs(_dblVal), 1)) == false)
+    else if ((_pDF->bPrintOne == true) || std::fabs(_dblVal) != 1.0)
     {
         //do not print if _bPrintOne == false && _dblVal == 1
         if (_pDF->bPrintPoint)
@@ -332,18 +331,6 @@ void addDoubleValue(std::wostringstream * _postr, double _dblVal, DoubleFormat *
     *_postr << pwstOutput;
 }
 
-/*
-void addDoubleValue(std::wostringstream *_postr, double _dblVal, int _iWidth, int _iPrec, bool bPrintPlusSign, bool bPrintOne, bool bPaddSign)
-{
-    addSign(_postr, _dblVal, bPrintPlusSign, bPaddSign);
-    configureStream(_postr, _iWidth, _iPrec, ' ');
-
-    if(bPrintOne == true || isEqual(_dblVal, 1) == false)
-    {
-        NEWprintDoubleVar(_postr, _dblVal, _iWidth, _iPrec);
-    }
-}
-*/
 void addDoubleComplexValue(std::wostringstream * _postr, double _dblR, double _dblI, int _iTotalWidth, DoubleFormat * _pDFR, DoubleFormat * _pDFI)
 {
     std::wostringstream ostemp;


### PR DESCRIPTION
fixes #379 

- for complex encoded `Double` values now real _and_ imaginary part are always displayed in the console
- in interactive console sessions it is now clear at first glance, whether a `Double` is real or complex encoded
- no more guess work and scratching your head (cf. [here](http://mailinglists.scilab.org/template/NamlServlet.jtp?macro=search_page&node=2602239&query=imaginary+part&days=0) and[ there](http://mailinglists.scilab.org/template/NamlServlet.jtp?macro=search_page&node=2602239&query=isreal&days=0))
- furthermore the displayed signs resemble exactly the sign bit of the stored floating point numbers

Have a look at the following simple examples:
```
--> A=1
 A  = 
   1.

--> B=1+%i
 B  = 
   1. + i  

--> C=1-0*%i
 C  = 
   1. - 0.i

--> D=1+0*%i
 D  = 
   1. + 0.i

--> E=0*%i
 E  = 
   0. + 0.i

--> F=-0*%i
 F  = 
  -0. - 0.i
```
It is clear at first glance, that only `A` is a real encoded `Double` all others are complex encoded. Although some of them (`C`, `D`, `E`, `F`) have zero imaginary parts and could be converted to real encoded variables, e.g.  by using `C=real(C)`.