### PR TITLE
Use some AVX Optimized SLEEF Functions in "elementary_functions" Module

### DIFF
--- a/scilab/modules/elementary_functions/includes/balisc_elementary.h
+++ b/scilab/modules/elementary_functions/includes/balisc_elementary.h
@@ -74,11 +74,13 @@
 
 #if defined(__AVX__)
 
-#define balisc_acos_m256d Sleef_acosd4_u35avx
-#define balisc_asin_m256d Sleef_asind4_u35avx
-#define balisc_cos_m256d  Sleef_cosd4_u35avx
-#define balisc_sin_m256d  Sleef_sind4_u35avx
-#define balisc_tan_m256d  Sleef_tand4_u35avx
+#define balisc_acos_m256d  Sleef_acosd4_u35avx
+#define balisc_asin_m256d  Sleef_asind4_u35avx
+#define balisc_atan_m256d  Sleef_atand4_u35avx
+#define balisc_atan2_m256d Sleef_atan2d4_u35avx
+#define balisc_cos_m256d   Sleef_cosd4_u35avx
+#define balisc_sin_m256d   Sleef_sind4_u35avx
+#define balisc_tan_m256d   Sleef_tand4_u35avx
 
 #endif
 

--- a/scilab/modules/elementary_functions/includes/balisc_elementary.h
+++ b/scilab/modules/elementary_functions/includes/balisc_elementary.h
@@ -1,6 +1,6 @@
 /* Balisc (https://github.com/rdbyk/balisc/)
  * 
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -69,6 +69,12 @@
 #define balisc_sin_m128d   Sleef_sind2_u35sse2
 #define balisc_round_m128d Sleef_roundd2_sse2
 #define balisc_tan_m128d   Sleef_tand2_u35sse2 // not really fast
+
+#endif
+
+#if defined(__AVX__)
+
+#define balisc_sin_m256d  Sleef_sind4_u35avx
 
 #endif
 

--- a/scilab/modules/elementary_functions/includes/balisc_elementary.h
+++ b/scilab/modules/elementary_functions/includes/balisc_elementary.h
@@ -74,6 +74,7 @@
 
 #if defined(__AVX__)
 
+#define balisc_cos_m256d  Sleef_cosd4_u35avx
 #define balisc_sin_m256d  Sleef_sind4_u35avx
 
 #endif

--- a/scilab/modules/elementary_functions/includes/balisc_elementary.h
+++ b/scilab/modules/elementary_functions/includes/balisc_elementary.h
@@ -79,6 +79,8 @@
 #define balisc_atan_m256d  Sleef_atand4_u35avx
 #define balisc_atan2_m256d Sleef_atan2d4_u35avx
 #define balisc_cos_m256d   Sleef_cosd4_u35avx
+#define balisc_log_m256d   Sleef_logd4_u35avx
+#define balisc_log10_m256d Sleef_log10d4_u10avx
 #define balisc_sin_m256d   Sleef_sind4_u35avx
 #define balisc_tan_m256d   Sleef_tand4_u35avx
 

--- a/scilab/modules/elementary_functions/includes/balisc_elementary.h
+++ b/scilab/modules/elementary_functions/includes/balisc_elementary.h
@@ -74,8 +74,9 @@
 
 #if defined(__AVX__)
 
-#define balisc_cos_m256d  Sleef_cosd4_u35avx
-#define balisc_sin_m256d  Sleef_sind4_u35avx
+#define balisc_cos_m256d Sleef_cosd4_u35avx
+#define balisc_sin_m256d Sleef_sind4_u35avx
+#define balisc_tan_m256d Sleef_tand4_u35avx
 
 #endif
 

--- a/scilab/modules/elementary_functions/includes/balisc_elementary.h
+++ b/scilab/modules/elementary_functions/includes/balisc_elementary.h
@@ -74,9 +74,10 @@
 
 #if defined(__AVX__)
 
-#define balisc_cos_m256d Sleef_cosd4_u35avx
-#define balisc_sin_m256d Sleef_sind4_u35avx
-#define balisc_tan_m256d Sleef_tand4_u35avx
+#define balisc_acos_m256d Sleef_acosd4_u35avx
+#define balisc_cos_m256d  Sleef_cosd4_u35avx
+#define balisc_sin_m256d  Sleef_sind4_u35avx
+#define balisc_tan_m256d  Sleef_tand4_u35avx
 
 #endif
 

--- a/scilab/modules/elementary_functions/includes/balisc_elementary.h
+++ b/scilab/modules/elementary_functions/includes/balisc_elementary.h
@@ -75,6 +75,7 @@
 #if defined(__AVX__)
 
 #define balisc_acos_m256d Sleef_acosd4_u35avx
+#define balisc_asin_m256d Sleef_asind4_u35avx
 #define balisc_cos_m256d  Sleef_cosd4_u35avx
 #define balisc_sin_m256d  Sleef_sind4_u35avx
 #define balisc_tan_m256d  Sleef_tand4_u35avx

--- a/scilab/modules/elementary_functions/includes/balisc_elementary.h
+++ b/scilab/modules/elementary_functions/includes/balisc_elementary.h
@@ -79,8 +79,10 @@
 #define balisc_atan_m256d  Sleef_atand4_u35avx
 #define balisc_atan2_m256d Sleef_atan2d4_u35avx
 #define balisc_cos_m256d   Sleef_cosd4_u35avx
+#define balisc_hypot_m256d Sleef_hypotd4_u35avx
 #define balisc_log_m256d   Sleef_logd4_u35avx
 #define balisc_log10_m256d Sleef_log10d4_u10avx
+#define balisc_round_m256d Sleef_roundd4_avx
 #define balisc_sin_m256d   Sleef_sind4_u35avx
 #define balisc_tan_m256d   Sleef_tand4_u35avx
 

--- a/scilab/modules/elementary_functions/src/cpp/acos.cpp
+++ b/scilab/modules/elementary_functions/src/cpp/acos.cpp
@@ -1,6 +1,6 @@
 // Balisc (https://github.com/rdbyk/balisc/)
 // 
-// Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+// Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -130,7 +130,7 @@ Double* acos(Double* x)
                 yr[i] = balisc_acos_d(xr[i]);
             }
             return y;
-#else
+#elif !defined(balisc_acos_m256d)
             int i = 0;
             for ( ; i < n - 1; i += 2)
             {
@@ -146,6 +146,42 @@ Double* acos(Double* x)
             }
 
             return y;
+#else
+        int i = 0;
+        for ( ; i < n - 3; i += 4)
+        {
+            __m256d a = ::balisc_acos_m256d(_mm256_loadu_pd(&(xr[i])));
+            yr[i] = a[0];
+            yr[i+1] = a[1];
+            yr[i+2] = a[2];
+            yr[i+3] = a[3];
+        }
+
+        switch (n % 4)
+        {
+            case 1:
+                yr[i] = ::balisc_acos_d(xr[i]);
+                return y;
+
+            case 2:
+                {
+                    __m128d a = ::balisc_acos_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                }
+                return y;
+
+            case 3:
+                {
+                    __m128d a = ::balisc_acos_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                    yr[i+2] = ::balisc_acos_d(xr[i+2]);
+                }
+                return y;
+        }
+
+        return y;
 #endif
         }
     }

--- a/scilab/modules/elementary_functions/src/cpp/atan.cpp
+++ b/scilab/modules/elementary_functions/src/cpp/atan.cpp
@@ -1,6 +1,6 @@
 // Balisc (https://github.com/rdbyk/balisc/)
 // 
-// Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+// Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -46,7 +46,7 @@ Double* atan_real(Double* x)
                 yr[i] = balisc_atan_d(xr[i]);
             }
             return y;
-#else
+#elif !defined(balisc_atan_m256d)
             int i = 0;
             for ( ; i < n - 1; i += 2)
             {
@@ -62,6 +62,42 @@ Double* atan_real(Double* x)
             }
 
             return y;
+#else
+        int i = 0;
+        for ( ; i < n - 3; i += 4)
+        {
+            __m256d a = ::balisc_atan_m256d(_mm256_loadu_pd(&(xr[i])));
+            yr[i] = a[0];
+            yr[i+1] = a[1];
+            yr[i+2] = a[2];
+            yr[i+3] = a[3];
+        }
+
+        switch (n % 4)
+        {
+            case 1:
+                yr[i] = ::balisc_atan_d(xr[i]);
+                return y;
+
+            case 2:
+                {
+                    __m128d a = ::balisc_atan_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                }
+                return y;
+
+            case 3:
+                {
+                    __m128d a = ::balisc_atan_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                    yr[i+2] = ::balisc_atan_d(xr[i+2]);
+                }
+                return y;
+        }
+
+        return y;
 #endif
 }
 
@@ -129,7 +165,7 @@ Double* atan2(Double* x1, Double* x2)
                 yr[i] = ::balisc_atan2_d(x1r[i], x2r[i]);
             }
             return y;
-#else
+#elif !defined(balisc_atan2_m256d)
             int i = 0;
             for ( ; i < n - 1; i += 2)
             {
@@ -145,6 +181,42 @@ Double* atan2(Double* x1, Double* x2)
             }
 
             return y;
+#else
+        int i = 0;
+        for ( ; i < n - 3; i += 4)
+        {
+            __m256d a = ::balisc_atan2_m256d(_mm256_loadu_pd(&(x1r[i])), _mm256_loadu_pd(&(x2r[i])));
+            yr[i] = a[0];
+            yr[i+1] = a[1];
+            yr[i+2] = a[2];
+            yr[i+3] = a[3];
+        }
+
+        switch (n % 4)
+        {
+            case 1:
+                yr[i] = ::balisc_atan2_d(x1r[i], x2r[i]);
+                return y;
+
+            case 2:
+                {
+                    __m128d a = ::balisc_atan2_m128d(*((__m128d*)&(x1r[i])), *((__m128d*)&(x2r[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                }
+                return y;
+
+            case 3:
+                {
+                    __m128d a = ::balisc_atan2_m128d(*((__m128d*)&(x1r[i])), *((__m128d*)&(x2r[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                    yr[i+2] = ::balisc_atan2_d(x1r[i+2], x2r[i+2]);
+                }
+                return y;
+        }
+
+        return y;
 #endif
 }
 

--- a/scilab/modules/elementary_functions/src/cpp/cos.cpp
+++ b/scilab/modules/elementary_functions/src/cpp/cos.cpp
@@ -73,7 +73,7 @@ Double* cos(Double* x)
             yr[i] = ::balisc_cos_d(xr[i]);
         }
         return y;
-#else
+#elif !defined(balisc_cos_m256d)
         int i = 0;
         for ( ; i < n - 1; i += 2)
         {
@@ -86,6 +86,42 @@ Double* cos(Double* x)
         {
             yr[i] = ::balisc_cos_d(xr[i]);
             return y;
+        }
+
+        return y;
+#else
+        int i = 0;
+        for ( ; i < n - 3; i += 4)
+        {
+            __m256d a = ::balisc_cos_m256d(_mm256_loadu_pd(&(xr[i])));
+            yr[i] = a[0];
+            yr[i+1] = a[1];
+            yr[i+2] = a[2];
+            yr[i+3] = a[3];
+        }
+
+        switch (n % 4)
+        {
+            case 1:
+                yr[i] = ::balisc_cos_d(xr[i]);
+                return y;
+
+            case 2:
+                {
+                    __m128d a = ::balisc_cos_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                }
+                return y;
+
+            case 3:
+                {
+                    __m128d a = ::balisc_cos_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                    yr[i+2] = ::balisc_cos_d(xr[i+2]);
+                }
+                return y;
         }
 
         return y;

--- a/scilab/modules/elementary_functions/src/cpp/log.cpp
+++ b/scilab/modules/elementary_functions/src/cpp/log.cpp
@@ -111,7 +111,7 @@ Double* log(Double* x)
                 yr[i] = balisc_log_d(xr[i]);
             }
             return y;
-#else
+#elif !defined(balisc_log_m256d)
             int i;
             for (i = 0; i < n - 1; i++)
             {
@@ -124,6 +124,44 @@ Double* log(Double* x)
             {
                 yr[i] = balisc_log_d(xr[i]);
             }
+
+            return y;
+#else
+            int i = 0;
+            for ( ; i < n - 3; i += 4)
+            {
+                __m256d a = ::balisc_log_m256d(_mm256_loadu_pd(&(xr[i])));
+                yr[i] = a[0];
+                yr[i+1] = a[1];
+                yr[i+2] = a[2];
+                yr[i+3] = a[3];
+            }
+
+            switch (n % 4)
+            {
+                case 1:
+                    yr[i] = ::balisc_log_d(xr[i]);
+                    return y;
+
+                case 2:
+                    {
+                        __m128d a = ::balisc_log_m128d(*((__m128d*)&(xr[i])));
+                        yr[i] = a[0];
+                        yr[i+1] = a[1];
+                    }
+                    return y;
+
+                case 3:
+                    {
+                        __m128d a = ::balisc_log_m128d(*((__m128d*)&(xr[i])));
+                        yr[i] = a[0];
+                        yr[i+1] = a[1];
+                        yr[i+2] = ::balisc_log_d(xr[i+2]);
+                    }
+                    return y;
+            }
+
+            return y;
 #endif
         }
 

--- a/scilab/modules/elementary_functions/src/cpp/log10.cpp
+++ b/scilab/modules/elementary_functions/src/cpp/log10.cpp
@@ -111,7 +111,7 @@ Double* log10(Double* x)
                 yr[i] = ::balisc_log10_d(xr[i]);
             }
             return y;
-#else
+#elif !defined(balisc_log10_m256d)
             int i;
             for (i = 0; i < n - 1; i++)
             {
@@ -124,6 +124,44 @@ Double* log10(Double* x)
             {
                 yr[i] = ::balisc_log10_d(xr[i]);
             }
+
+            return y;
+#else
+            int i = 0;
+            for ( ; i < n - 3; i += 4)
+            {
+                __m256d a = ::balisc_log10_m256d(_mm256_loadu_pd(&(xr[i])));
+                yr[i] = a[0];
+                yr[i+1] = a[1];
+                yr[i+2] = a[2];
+                yr[i+3] = a[3];
+            }
+
+            switch (n % 4)
+            {
+                case 1:
+                    yr[i] = ::balisc_log10_d(xr[i]);
+                    return y;
+
+                case 2:
+                    {
+                        __m128d a = ::balisc_log10_m128d(*((__m128d*)&(xr[i])));
+                        yr[i] = a[0];
+                        yr[i+1] = a[1];
+                    }
+                    return y;
+
+                case 3:
+                    {
+                        __m128d a = ::balisc_log10_m128d(*((__m128d*)&(xr[i])));
+                        yr[i] = a[0];
+                        yr[i+1] = a[1];
+                        yr[i+2] = ::balisc_log10_d(xr[i+2]);
+                    }
+                    return y;
+            }
+
+            return y;
 #endif
         }
 

--- a/scilab/modules/elementary_functions/src/cpp/round.cpp
+++ b/scilab/modules/elementary_functions/src/cpp/round.cpp
@@ -1,6 +1,6 @@
 // Balisc (https://github.com/rdbyk/balisc/)
 // 
-// Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+// Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -65,7 +65,9 @@ Double* round(Double* x)
         {
             yr[i] = ::balisc_round_d(xr[i]);
         }
-#else
+
+        return y;
+#elif !defined(balisc_round_m256d)
         int i;
         for (i = 0; i < n - 1; i++)
         {
@@ -78,6 +80,44 @@ Double* round(Double* x)
         {
             yr[i] = ::balisc_round_d(xr[i]);
         }
+
+        return y;
+#else
+        int i = 0;
+        for ( ; i < n - 3; i += 4)
+        {
+            __m256d a = ::balisc_round_m256d(_mm256_loadu_pd(&(xr[i])));
+            yr[i] = a[0];
+            yr[i+1] = a[1];
+            yr[i+2] = a[2];
+            yr[i+3] = a[3];
+        }
+
+        switch (n % 4)
+        {
+            case 1:
+                yr[i] = ::balisc_round_d(xr[i]);
+                return y;
+
+            case 2:
+                {
+                    __m128d a = ::balisc_round_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                }
+                return y;
+
+            case 3:
+                {
+                    __m128d a = ::balisc_round_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                    yr[i+2] = ::balisc_round_d(xr[i+2]);
+                }
+                return y;
+        }
+
+        return y;
 #endif
     }
 

--- a/scilab/modules/elementary_functions/src/cpp/sin.cpp
+++ b/scilab/modules/elementary_functions/src/cpp/sin.cpp
@@ -74,7 +74,7 @@ Double* sin(Double* x)
             yr[i] = ::balisc_sin_d(xr[i]);
         }
         return y;
-#else
+#elif !defined(balisc_sin_m256d)
         int i = 0;
         for ( ; i < n - 1; i += 2)
         {
@@ -87,6 +87,42 @@ Double* sin(Double* x)
         {
             yr[i] = ::balisc_sin_d(xr[i]);
             return y;
+        }
+
+        return y;
+#else
+        int i = 0;
+        for ( ; i < n - 3; i += 4)
+        {
+            __m256d a = ::balisc_sin_m256d(_mm256_loadu_pd(&(xr[i])));
+            yr[i] = a[0];
+            yr[i+1] = a[1];
+            yr[i+2] = a[2];
+            yr[i+3] = a[3];
+        }
+
+        switch (n % 4)
+        {
+            case 1:
+                yr[i] = ::balisc_sin_d(xr[i]);
+                return y;
+
+            case 2:
+                {
+                    __m128d a = ::balisc_sin_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                }
+                return y;
+
+            case 3:
+                {
+                    __m128d a = ::balisc_sin_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                    yr[i+2] = ::balisc_sin_d(xr[i+2]);
+                }
+                return y;
         }
 
         return y;

--- a/scilab/modules/elementary_functions/src/cpp/tan.cpp
+++ b/scilab/modules/elementary_functions/src/cpp/tan.cpp
@@ -66,7 +66,7 @@ Double* tan(Double* x)
             yr[i] = ::balisc_tan_d(xr[i]);
         }
         return y;
-#else
+#elif !defined(balisc_tan_m256d)
         int i = 0;
         for ( ; i < n - 1; i += 2)
         {
@@ -79,6 +79,42 @@ Double* tan(Double* x)
         {
             yr[i] = ::balisc_tan_d(xr[i]);
             return y;
+        }
+
+        return y;
+#else
+        int i = 0;
+        for ( ; i < n - 3; i += 4)
+        {
+            __m256d a = ::balisc_tan_m256d(_mm256_loadu_pd(&(xr[i])));
+            yr[i] = a[0];
+            yr[i+1] = a[1];
+            yr[i+2] = a[2];
+            yr[i+3] = a[3];
+        }
+
+        switch (n % 4)
+        {
+            case 1:
+                yr[i] = ::balisc_tan_d(xr[i]);
+                return y;
+
+            case 2:
+                {
+                    __m128d a = ::balisc_tan_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                }
+                return y;
+
+            case 3:
+                {
+                    __m128d a = ::balisc_tan_m128d(*((__m128d*)&(xr[i])));
+                    yr[i] = a[0];
+                    yr[i+1] = a[1];
+                    yr[i+2] = ::balisc_tan_d(xr[i+2]);
+                }
+                return y;
         }
 
         return y;


### PR DESCRIPTION
This significantly improves run-time performance of `sin` , `cos`, `tan`, `asin`, `acos`, `atan`, `log`, `log10`, and `round` for large real input arrays, e.g.

Scilab 6.0.1
```
--> A=rand(1000,1000);
--> tic;for i=1:1e2;sin(A);end;toc
 ans  =
   2.109465
```

Balisc
```
--> A=rand(1000,1000);
--> tic;for i=1:1e2;sin(A);end;toc
 ans  =
   0.655519
```