### PR TITLE
Remove Some Specialisations for Bool, Double Ops in types_{and,or}.cpp (introduced by PR #407)

### DIFF
--- a/scilab/modules/ast/src/cpp/operations/types_and.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_and.cpp
@@ -38,20 +38,6 @@ InternalType* and_S_S<Bool, Bool, Bool>(Bool *_pL, Bool *_pR)
     return pOut;
 }
 
-template<>
-InternalType* and_S_S<Bool, Double, Bool>(Bool *_pL, Double *_pR)
-{
-    Bool* pOut =  _pL->getRef() > 0 ? new Bool(0) : _pL;
-    bit_and(_pL->getFirst(), _pR->getFirst(), pOut->get());
-    return pOut;
-}
-
-template<>
-InternalType* and_S_S<Double, Bool, Bool>(Double *_pL, Bool *_pR)
-{
-    return and_S_S<Bool, Double, Bool>(_pR, _pL);
-}
-
 // specializations for Bool (Matrix & Scalar)
 template<>
 InternalType* and_M_S<Bool, Bool, Bool>(Bool *_pL, Bool *_pR)
@@ -59,20 +45,6 @@ InternalType* and_M_S<Bool, Bool, Bool>(Bool *_pL, Bool *_pR)
     Bool* pOut =  _pL->getRef() > 0 ? (_pR->getRef() > 0 ? new Bool(_pL->getDims(), _pL->getDimsArray()) : _pR) : _pL;
     bit_and(_pL->get(), (size_t)_pL->getSize(), _pR->getFirst(), pOut->get());
     return pOut;
-}
-
-template<>
-InternalType* and_M_S<Bool, Double, Bool>(Bool *_pL, Double *_pR)
-{
-    Bool* pOut =  _pL->getRef() > 0 ? new Bool(_pL->getDims(), _pL->getDimsArray()) : _pL;
-    bit_and(_pL->get(), (size_t)_pL->getSize(), _pR->getFirst(), pOut->get());
-    return pOut;
-}
-
-template<>
-InternalType* and_S_M<Double, Bool, Bool>(Double *_pL, Bool *_pR)
-{
-    return and_M_S<Bool, Double, Bool>(_pR, _pL);
 }
 
 // specializations for Bool (Matrix & Matrix)
@@ -102,40 +74,6 @@ InternalType* and_M_M<Bool, Bool, Bool>(Bool *_pL, Bool *_pR)
 
     bit_and(_pL->get(), (long long)_pL->getSize(), _pR->get(), pOut->get());
     return pOut;
-}
-
-template<>
-InternalType* and_M_M<Bool, Double, Bool>(Bool *_pL, Double *_pR)
-{
-    int iDimsL = _pL->getDims();
-    int iDimsR = _pR->getDims();
-
-    if (iDimsL != iDimsR)
-    {
-        return nullptr;
-    }
-
-    int* piDimsL = _pL->getDimsArray();
-    int* piDimsR = _pR->getDimsArray();
-
-    for (int i = 0 ; i < iDimsL ; ++i)
-    {
-        if (piDimsL[i] != piDimsR[i])
-        {
-            throw ast::InternalError(_W("Inconsistent row/column dimensions.\n"));
-        }
-    }
-
-    Bool* pOut =  _pL->getRef() > 0 ? new Bool(iDimsL, piDimsL) : _pL;
-
-    bit_and(_pL->get(), (long long)_pL->getSize(), _pR->get(), pOut->get());
-    return pOut;
-}
-
-template<>
-InternalType* and_M_M<Double, Bool, Bool>(Double *_pL, Bool *_pR)
-{
-    return and_M_M<Bool, Double, Bool>(_pR, _pL);
 }
 
 void fillAndFunction()

--- a/scilab/modules/ast/src/cpp/operations/types_or.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_or.cpp
@@ -40,20 +40,6 @@ InternalType* or_S_S<Bool, Bool, Bool>(Bool *_pL, Bool *_pR)
     return pOut;
 }
 
-template<>
-InternalType* or_S_S<Bool, Double, Bool>(Bool *_pL, Double *_pR)
-{
-    Bool* pOut =  _pL->getRef() > 0 ? new Bool(0) : _pL;
-    bit_or(_pL->getFirst(), _pR->getFirst(), pOut->get());
-    return pOut;
-}
-
-template<>
-InternalType* or_S_S<Double, Bool, Bool>(Double *_pL, Bool *_pR)
-{
-    return or_S_S<Bool, Double, Bool>(_pR, _pL);
-}
-
 // specializations for Bool (Matrix | Scalar)
 template<>
 InternalType* or_M_S<Bool, Bool, Bool>(Bool *_pL, Bool *_pR)
@@ -61,20 +47,6 @@ InternalType* or_M_S<Bool, Bool, Bool>(Bool *_pL, Bool *_pR)
     Bool* pOut =  _pL->getRef() > 0 ? (_pR->getRef() > 0 ? new Bool(_pL->getDims(), _pL->getDimsArray()) : _pR) : _pL;
     bit_or(_pL->get(), (size_t)_pL->getSize(), _pR->getFirst(), pOut->get());
     return pOut;
-}
-
-template<>
-InternalType* or_M_S<Bool, Double, Bool>(Bool *_pL, Double *_pR)
-{
-    Bool* pOut =  _pL->getRef() > 0 ? new Bool(_pL->getDims(), _pL->getDimsArray()) : _pL;
-    bit_or(_pL->get(), (size_t)_pL->getSize(), _pR->getFirst(), pOut->get());
-    return pOut;
-}
-
-template<>
-InternalType* or_S_M<Double, Bool, Bool>(Double *_pL, Bool *_pR)
-{
-    return or_M_S<Bool, Double, Bool>(_pR, _pL);
 }
 
 // specializations for Bool (Matrix | Matrix)
@@ -104,40 +76,6 @@ InternalType* or_M_M<Bool, Bool, Bool>(Bool *_pL, Bool *_pR)
 
     bit_or(_pL->get(), (long long)_pL->getSize(), _pR->get(), pOut->get());
     return pOut;
-}
-
-template<>
-InternalType* or_M_M<Bool, Double, Bool>(Bool *_pL, Double *_pR)
-{
-    int iDimsL = _pL->getDims();
-    int iDimsR = _pR->getDims();
-
-    if (iDimsL != iDimsR)
-    {
-        return nullptr;
-    }
-
-    int* piDimsL = _pL->getDimsArray();
-    int* piDimsR = _pR->getDimsArray();
-
-    for (int i = 0 ; i < iDimsL ; ++i)
-    {
-        if (piDimsL[i] != piDimsR[i])
-        {
-            throw ast::InternalError(_W("Inconsistent row/column dimensions.\n"));
-        }
-    }
-
-    Bool* pOut =  _pL->getRef() > 0 ? new Bool(iDimsL, piDimsL) : _pL;
-
-    bit_or(_pL->get(), (long long)_pL->getSize(), _pR->get(), pOut->get());
-    return pOut;
-}
-
-template<>
-InternalType* or_M_M<Double, Bool, Bool>(Double *_pL, Bool *_pR)
-{
-    return or_M_M<Bool, Double, Bool>(_pR, _pL);
 }
 
 void fillOrFunction()


### PR DESCRIPTION
They just seem not to have a positive impact on over-all performance :frowning_face: