### PR TITLE
Fixed #299 #412

### DIFF
--- a/scilab/modules/ast/src/cpp/operations/types_addition.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_addition.cpp
@@ -754,7 +754,7 @@ void fillAddFunction()
     scilab_fill_add(Bool, UInt32, M_M, Bool, UInt32, UInt32);
     scilab_fill_add(Bool, Int64, M_M, Bool, Int64, Int64);
     scilab_fill_add(Bool, UInt64, M_M, Bool, UInt64, UInt64);
-    scilab_fill_add(Bool, Bool, M_M, Bool, Bool, Bool);
+    scilab_fill_add(Bool, Bool, M_M, Bool, Bool, Double);
     scilab_fill_add(Bool, Empty, M_E, Bool, Double, Double);
 
     //Matrix + Scalar
@@ -767,7 +767,7 @@ void fillAddFunction()
     scilab_fill_add(Bool, ScalarUInt32, M_S, Bool, UInt32, UInt32);
     scilab_fill_add(Bool, ScalarInt64, M_S, Bool, Int64, Int64);
     scilab_fill_add(Bool, ScalarUInt64, M_S, Bool, UInt64, UInt64);
-    scilab_fill_add(Bool, ScalarBool, M_S, Bool, Bool, Bool);
+    scilab_fill_add(Bool, ScalarBool, M_S, Bool, Bool, Double);
 
     //Scalar + Matrix
     scilab_fill_add(ScalarBool, Double, S_M, Bool, Double, Double);
@@ -779,7 +779,7 @@ void fillAddFunction()
     scilab_fill_add(ScalarBool, UInt32, S_M, Bool, UInt32, UInt32);
     scilab_fill_add(ScalarBool, Int64, S_M, Bool, Int64, Int64);
     scilab_fill_add(ScalarBool, UInt64, S_M, Bool, UInt64, UInt64);
-    scilab_fill_add(ScalarBool, Bool, S_M, Bool, Bool, Bool);
+    scilab_fill_add(ScalarBool, Bool, S_M, Bool, Bool, Double);
     scilab_fill_add(ScalarBool, Empty, S_E, Bool, Double, Double);
 
     //Scalar + Scalar
@@ -792,7 +792,7 @@ void fillAddFunction()
     scilab_fill_add(ScalarBool, ScalarUInt32, S_S, Bool, UInt32, UInt32);
     scilab_fill_add(ScalarBool, ScalarInt64, S_S, Bool, Int64, Int64);
     scilab_fill_add(ScalarBool, ScalarUInt64, S_S, Bool, UInt64, UInt64);
-    scilab_fill_add(ScalarBool, ScalarBool, S_S, Bool, Bool, Bool);
+    scilab_fill_add(ScalarBool, ScalarBool, S_S, Bool, Bool, Double);
 
     //String
     scilab_fill_add(String, String, M_M, String, String, String);

--- a/scilab/modules/ast/src/cpp/operations/types_dotdivide.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_dotdivide.cpp
@@ -752,7 +752,7 @@ void fillDotDivFunction()
     scilab_fill_dotdiv(Bool, UInt32, M_M, Bool, UInt32, UInt32);
     scilab_fill_dotdiv(Bool, Int64, M_M, Bool, Int64, Int64);
     scilab_fill_dotdiv(Bool, UInt64, M_M, Bool, UInt64, UInt64);
-    scilab_fill_dotdiv(Bool, Bool, M_M, Bool, Bool, Bool);
+    scilab_fill_dotdiv(Bool, Bool, M_M, Bool, Bool, Double);
     scilab_fill_dotdiv(Bool, Empty, M_E, Bool, Double, Double);
 
     //Matrix ./ Scalar
@@ -765,7 +765,7 @@ void fillDotDivFunction()
     scilab_fill_dotdiv(Bool, ScalarUInt32, M_S, Bool, UInt32, UInt32);
     scilab_fill_dotdiv(Bool, ScalarInt64, M_S, Bool, Int64, Int64);
     scilab_fill_dotdiv(Bool, ScalarUInt64, M_S, Bool, UInt64, UInt64);
-    scilab_fill_dotdiv(Bool, ScalarBool, M_S, Bool, Bool, Bool);
+    scilab_fill_dotdiv(Bool, ScalarBool, M_S, Bool, Bool, Double);
 
     //Scalar ./ Matrix
     scilab_fill_dotdiv(ScalarBool, Double, S_M, Bool, Double, Double);
@@ -777,7 +777,7 @@ void fillDotDivFunction()
     scilab_fill_dotdiv(ScalarBool, UInt32, S_M, Bool, UInt32, UInt32);
     scilab_fill_dotdiv(ScalarBool, Int64, S_M, Bool, Int64, Int64);
     scilab_fill_dotdiv(ScalarBool, UInt64, S_M, Bool, UInt64, UInt64);
-    scilab_fill_dotdiv(ScalarBool, Bool, S_M, Bool, Bool, Bool);
+    scilab_fill_dotdiv(ScalarBool, Bool, S_M, Bool, Bool, Double);
     scilab_fill_dotdiv(ScalarBool, Empty, M_E, Bool, Double, Double);
 
     //Scalar ./ Scalar
@@ -790,7 +790,7 @@ void fillDotDivFunction()
     scilab_fill_dotdiv(ScalarBool, ScalarUInt32, S_S, Bool, UInt32, UInt32);
     scilab_fill_dotdiv(ScalarBool, ScalarInt64, S_S, Bool, Int64, Int64);
     scilab_fill_dotdiv(ScalarBool, ScalarUInt64, S_S, Bool, UInt64, UInt64);
-    scilab_fill_dotdiv(ScalarBool, ScalarBool, S_S, Bool, Bool, Bool);
+    scilab_fill_dotdiv(ScalarBool, ScalarBool, S_S, Bool, Bool, Double);
 
     //Identity
     scilab_fill_dotdiv(Identity, Double, I_M, Double, Double, Double);

--- a/scilab/modules/ast/src/cpp/operations/types_opposite.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_opposite.cpp
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2014 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -39,7 +39,7 @@ void fillOppositeFunction()
     //Scalar
     scilab_fill_opposite(ScalarDouble, S, Double, Double);
     scilab_fill_opposite(ScalarDoubleComplex, SC, Double, Double);
-    scilab_fill_opposite(ScalarBool, S, Bool, Bool);
+    scilab_fill_opposite(ScalarBool, S, Bool, Double);
     scilab_fill_opposite(ScalarInt8, S, Int8, Int8);
     scilab_fill_opposite(ScalarUInt8, S, UInt8, UInt8);
     scilab_fill_opposite(ScalarInt16, S, Int16, Int16);
@@ -54,7 +54,7 @@ void fillOppositeFunction()
     //Matrix
     scilab_fill_opposite(Double, M, Double, Double);
     scilab_fill_opposite(DoubleComplex, MC, Double, Double);
-    scilab_fill_opposite(Bool, M, Bool, Bool);
+    scilab_fill_opposite(Bool, M, Bool, Double);
     scilab_fill_opposite(Int8, M, Int8, Int8);
     scilab_fill_opposite(UInt8, M, UInt8, UInt8);
     scilab_fill_opposite(Int16, M, Int16, Int16);
@@ -175,7 +175,7 @@ types::InternalType* opposite_M<types::Bool, types::Double>(types::Bool* _pL)
     double* pD = pOut->get();
     for (int i = 0 ; i < iSize ; ++i)
     {
-        pD[i] = pI[i] == 0 ? 1 : 0;
+        pD[i] = pI[i] == 0 ? 0 : -1;
     }
 
     return pOut;

--- a/scilab/modules/ast/src/cpp/operations/types_subtraction.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_subtraction.cpp
@@ -807,7 +807,7 @@ void fillSubtractFunction()
     scilab_fill_sub(Bool, UInt32, M_M, Bool, UInt32, UInt32);
     scilab_fill_sub(Bool, Int64, M_M, Bool, Int64, Int64);
     scilab_fill_sub(Bool, UInt64, M_M, Bool, UInt64, UInt64);
-    scilab_fill_sub(Bool, Bool, M_M, Bool, Bool, Bool);
+    scilab_fill_sub(Bool, Bool, M_M, Bool, Bool, Double);
     scilab_fill_sub(Bool, Empty, M_E, Bool, Double, Double);
 
     //Matrix - Scalar
@@ -820,7 +820,7 @@ void fillSubtractFunction()
     scilab_fill_sub(Bool, ScalarUInt32, M_S, Bool, UInt32, UInt32);
     scilab_fill_sub(Bool, ScalarInt64, M_S, Bool, Int64, Int64);
     scilab_fill_sub(Bool, ScalarUInt64, M_S, Bool, UInt64, UInt64);
-    scilab_fill_sub(Bool, ScalarBool, M_S, Bool, Bool, Bool);
+    scilab_fill_sub(Bool, ScalarBool, M_S, Bool, Bool, Double);
 
     //Scalar - Matrix
     scilab_fill_sub(ScalarBool, Double, S_M, Bool, Double, Double);
@@ -832,7 +832,7 @@ void fillSubtractFunction()
     scilab_fill_sub(ScalarBool, UInt32, S_M, Bool, UInt32, UInt32);
     scilab_fill_sub(ScalarBool, Int64, S_M, Bool, Int64, Int64);
     scilab_fill_sub(ScalarBool, UInt64, S_M, Bool, UInt64, UInt64);
-    scilab_fill_sub(ScalarBool, Bool, S_M, Bool, Bool, Bool);
+    scilab_fill_sub(ScalarBool, Bool, S_M, Bool, Bool, Double);
     scilab_fill_sub(ScalarBool, Empty, S_E, Bool, Double, Double);
 
     //Scalar - Scalar
@@ -845,7 +845,7 @@ void fillSubtractFunction()
     scilab_fill_sub(ScalarBool, ScalarUInt32, S_S, Bool, UInt32, UInt32);
     scilab_fill_sub(ScalarBool, ScalarInt64, S_S, Bool, Int64, Int64);
     scilab_fill_sub(ScalarBool, ScalarUInt64, S_S, Bool, UInt64, UInt64);
-    scilab_fill_sub(ScalarBool, ScalarBool, S_S, Bool, Bool, Bool);
+    scilab_fill_sub(ScalarBool, ScalarBool, S_S, Bool, Bool, Double);
 
     //Identity
     scilab_fill_sub(Identity, Double, I_M, Double, Double, Double);

--- a/scilab/modules/ast/tests/nonreg_tests/issue_299.tst
+++ b/scilab/modules/ast/tests/nonreg_tests/issue_299.tst
@@ -1,0 +1,45 @@
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// <-- CLI SHELL MODE -->
+// <-- NO CHECK REF -->
+//
+// <-- Non-regression test for issue 299 -->
+//
+// <-- Github URL -->
+// https://github.com/rdbyk/balisc/issues/299
+//
+// <-- Short Description -->
+// (Un)defined Operations for Boolean Values
+
+assert_checkequal(%f+%f, 0)
+assert_checkequal(%f+%t, 1)
+assert_checkequal(%t+%f, 1)
+assert_checkequal(%t+%t, 2)
+
+assert_checkequal(%f-%f, 0)
+assert_checkequal(%f-%t, -1)
+assert_checkequal(%t-%f, 1)
+assert_checkequal(%t-%t, 0)
+
+assert_checkequal(%f*%f, 0)
+assert_checkequal(%f*%t, 0)
+assert_checkequal(%t*%f, 0)
+assert_checkequal(%t*%t, 1)
+
+assert_checkequal(%f/%f, %nan)
+assert_checkequal(%f/%t, 0)
+assert_checkequal(%t/%f, %inf)
+assert_checkequal(%t/%t, 1)
+
+assert_checkequal(%f.*%f, 0)
+assert_checkequal(%f.*%t, 0)
+assert_checkequal(%t.*%f, 0)
+assert_checkequal(%t.*%t, 1)
+
+assert_checkequal(%f./%f, %nan)
+assert_checkequal(%f./%t, 0)
+assert_checkequal(%t./%f, %inf)
+assert_checkequal(%t./%t, 1)
+
+assert_checkequal(-%f, 0)
+assert_checkequal(-%t, -1)

--- a/scilab/modules/ast/tests/nonreg_tests/issue_412.tst
+++ b/scilab/modules/ast/tests/nonreg_tests/issue_412.tst
@@ -1,0 +1,17 @@
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// <-- CLI SHELL MODE -->
+// <-- NO CHECK REF -->
+//
+// <-- Non-regression test for issue 412 -->
+//
+// <-- Github URL -->
+// https://github.com/rdbyk/balisc/issues/412
+//
+// <-- Short Description -->
+// Execution of "%t./%f" yields a Crash
+
+assert_checkequal(%f./%f, %nan)
+assert_checkequal(%f./%t, 0)
+assert_checkequal(%t./%f, %inf)
+assert_checkequal(%t./%t, 1)

--- a/scilab/modules/ast/tests/unit_tests/addition_output_type.dia.ref
+++ b/scilab/modules/ast/tests/unit_tests/addition_output_type.dia.ref
@@ -1,6 +1,7 @@
 // ============================================================================
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) 2014 - Scilab Enterprises - Antoine ELIAS
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 //  This file is distributed under the same license as the Scilab package.
 // ============================================================================
@@ -18,7 +19,7 @@ ref =[  "int8","uint8","int16","uint16","int32","uint32","int64","uint64","int8"
         "int64","uint64","int64","uint64","int64","uint64","int64","uint64","int64","int64"; ...
         "uint64","uint64","uint64","uint64","uint64","uint64","uint64","uint64","uint64","uint64"; ...
         "int8","uint8","int16","uint16","int32","uint32","int64","uint64","constant","constant"; ...
-        "int8","uint8","int16","uint16","int32","uint32","int64","uint64","constant","boolean"];
+        "int8","uint8","int16","uint16","int32","uint32","int64","uint64","constant","constant"];
 typesize = size(types);
 //Scalar + Scalar
 for i = 1 : typesize

--- a/scilab/modules/ast/tests/unit_tests/addition_output_type.tst
+++ b/scilab/modules/ast/tests/unit_tests/addition_output_type.tst
@@ -1,6 +1,7 @@
 // ============================================================================
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) 2014 - Scilab Enterprises - Antoine ELIAS
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 //  This file is distributed under the same license as the Scilab package.
 // ============================================================================
@@ -22,7 +23,7 @@ ref =[  "int8","uint8","int16","uint16","int32","uint32","int64","uint64","int8"
         "int64","uint64","int64","uint64","int64","uint64","int64","uint64","int64","int64"; ...
         "uint64","uint64","uint64","uint64","uint64","uint64","uint64","uint64","uint64","uint64"; ...
         "int8","uint8","int16","uint16","int32","uint32","int64","uint64","constant","constant"; ...
-        "int8","uint8","int16","uint16","int32","uint32","int64","uint64","constant","boolean"];
+        "int8","uint8","int16","uint16","int32","uint32","int64","uint64","constant","constant"];
 
 typesize = size(types);
 

--- a/scilab/modules/data_structures/help/en_US/boolean.xml
+++ b/scilab/modules/data_structures/help/en_US/boolean.xml
@@ -2,8 +2,8 @@
 <!--
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2007-2008 - INRIA
- *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -22,10 +22,12 @@
         <title>Description</title>
         <para>
             A boolean variable is <constant>%T</constant> (for "true") or <constant>%F</constant> (for "false"). These variables can be used to define matrices of booleans, with the usual syntax. Boolean matrices can be manipulated as ordinary matrices for elements extraction/insertion and concatenation.
+            There are three special operators defined for boolean matrices: <literal>~</literal>, <literal>&amp;</literal>, and <literal>|</literal>.
         </para>
         <para>
             <note>
-                Note that other usual operations (<literal>+</literal>, <literal>*</literal>, <literal>-</literal>, <literal>^</literal>, etc) are undefined for boolean matrices. Three special operators are defined for boolean matrices:
+                Note that some arithmetic operations (<literal>+</literal>, <literal>*</literal>, <literal>-</literal>, <literal>/</literal>, etc) are defined for boolean matrices. They are carried out by interpreting %t as 1, %f as 0, and return a corresponding real Double result.
+                Other (a priori undefined) arithmetic operations for boolean matrices might be provided by the user through overloading.
             </note>
         </para>
         <variablelist>
@@ -86,5 +88,18 @@ a=1:5; a(a>2)
                 <link linkend="not">not</link>
             </member>
         </simplelist>
+    </refsection>
+    <refsection>
+        <title>History</title>
+        <revhistory>
+            <revision>
+                <revnumber>Balisc 1</revnumber>
+                <revdescription>
+                    <itemizedlist>
+                        <listitem>Some arithmetic oprations are defined for boolean values and return a real Double result.</listitem>
+                    </itemizedlist>
+                </revdescription>
+            </revision>
+        </revhistory>
     </refsection>
 </refentry>


### PR DESCRIPTION
fixes #299 #412

Arithmetic operations carried out on boolean values return now consistent results, furthermore they do not create corrupted boolean results (cf. #299) and they do not crash (cf. #412),  e.g.

```
--> %t/%f
 ans  =
   Inf

--> %t*%f
 ans  =
   0.

--> %t-%f
 ans  =
   1.

--> %t+%f
 ans  =
   1.

--> %t+%t
 ans  =
   2.

--> %t./%f
 ans  =
   Inf

--> %f./%f
 ans  =
   Nan


```