### PR TITLE
Fixed #418 (Enhancement of "protect", "unprotect", and "isprotected")

### DIFF
--- a/scilab/modules/core/sci_gateway/cpp/sci_isprotected.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_isprotected.cpp
@@ -40,9 +40,36 @@ static const char fname[] = "isprotected";
 
 Function::ReturnValue sci_isprotected(typed_list &in, int _iRetCount, typed_list &out)
 {
+    Context *pCtx = Context::getInstance();
+
+    if (in.size() == 0)
+    {
+        std::list<std::wstring> pvars;
+
+        int n = pCtx->protectedVars(pvars);
+
+        if (n == 0)
+        {
+            // return []
+            out.push_back(types::Double::Empty());
+            return Function::OK;
+        }
+
+        String* pS = new types::String(n, 1);
+
+        int i = 0;
+        for (auto p : pvars)
+        {
+            pS->set(i++, p.c_str());
+        }
+
+        out.push_back(pS);
+        return Function::OK;
+    }
+
     if (in.size() != 1)
     {
-        Scierror(77, _("%s: Wrong number of input argument(s): %d expected.\n"), fname, 1);
+        Scierror(77, _("%s: Wrong number of input argument(s): %d to %d expected.\n"), fname, 0, 1);
         return types::Function::Error;
     }
 
@@ -53,15 +80,6 @@ Function::ReturnValue sci_isprotected(typed_list &in, int _iRetCount, typed_list
     }
     
     String* pS = in[0]->getAs<String>();
-    
-    if (pS->getSize() == 0)
-    {
-        out.push_back(
-        Double::Empty());
-        return Function::OK;
-    }
-
-    Context *pCtx = Context::getInstance();
 
     for (int i = 0; i < pS->getSize(); ++i)
     {

--- a/scilab/modules/core/sci_gateway/cpp/sci_protect.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_protect.cpp
@@ -28,8 +28,6 @@ extern "C"
 #include "localization.h"
 }
 
-using types::Bool;
-using types::Double;
 using types::Function;
 using types::String;
 using types::typed_list;
@@ -42,60 +40,59 @@ static const char fname[] = "protect";
 
 Function::ReturnValue sci_protect(typed_list &in, int _iRetCount, typed_list &out)
 {
-    if (in.size() != 1)
-    {
-        Scierror(77, _("%s: Wrong number of input argument(s): %d expected.\n"), fname, 1);
-        return types::Function::Error;
-    }
+    Context *pCtx = Context::getInstance();
 
-    if (in[0]->isString() == false)
+    if (in.size() == 0)
     {
-        Scierror(999, _("%s: Wrong type for input argument #%d: A String expected.\n"), fname, 1);
-        return types::Function::Error;
-    }
-    
-    String* pS = in[0]->getAs<String>();
-    
-    if (pS->getSize() == 0)
-    {
-        out.push_back(
-        Double::Empty());
+        pCtx->protect();
         return Function::OK;
     }
 
-    Context *pCtx = Context::getInstance();
-    
-    for (int i = 0; i < pS->getSize(); ++i)
+    for (int i = 0; i < in.size(); ++i)
     {
-        wchar_t* wcsVarName = pS->get(i);
-
-        if (pCtx->isValidVariableName(wcsVarName) == false)
+        if (in[i]->isString() == false)
         {
-            char* pstrVarName = wide_string_to_UTF8(wcsVarName);
-            Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, 1);
-            FREE(pstrVarName);
-            return Function::Error;
-        }
-        
-        if (pCtx->get(Symbol(wcsVarName)) == NULL)
-        {
-            char* pstrVarName = wide_string_to_UTF8(wcsVarName);
-            Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: An existent variable expected.\n"), fname, pstrVarName, 1);
-            FREE(pstrVarName);
+            Scierror(999, _("%s: Wrong type for input argument #%d: A String matrix expected.\n"), fname, i);
             return Function::Error;
         }
     }
 
-    for (int i = 0; i < pS->getSize(); ++i)
+    for (int i = 0; i < in.size(); ++i)
     {
-        wchar_t* wcsVarName = pS->get(i);
-
-        Variable* pV = pCtx->getOrCreate(Symbol(wcsVarName));
+        String* pS = in[i]->getAs<String>();
         
-        if (pV->empty() == false)
+        for (int j = 0; j < pS->getSize(); ++j)
         {
-            ScopedVariable* pSV = pV->top();
-            pSV->protect = true;
+            wchar_t* wcsVarName = pS->get(j);
+
+            if (pCtx->isValidVariableName(wcsVarName) == false)
+            {
+                char* pstrVarName = wide_string_to_UTF8(wcsVarName);
+                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, i);
+                FREE(pstrVarName);
+                return Function::Error;
+            }
+
+            if (pCtx->get(Symbol(wcsVarName)) == NULL)
+            {
+                char* pstrVarName = wide_string_to_UTF8(wcsVarName);
+                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: An existent variable expected.\n"), fname, pstrVarName, i);
+                FREE(pstrVarName);
+                return Function::Error;
+            }
+        }
+
+        for (int j = 0; j < pS->getSize(); ++j)
+        {
+            wchar_t* wcsVarName = pS->get(j);
+
+            Variable* pV = pCtx->getOrCreate(Symbol(wcsVarName));
+
+            if (pV->empty() == false)
+            {
+                ScopedVariable* pSV = pV->top();
+                pSV->protect = true;
+            }
         }
     }
 

--- a/scilab/modules/core/sci_gateway/cpp/sci_protect.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_protect.cpp
@@ -52,7 +52,7 @@ Function::ReturnValue sci_protect(typed_list &in, int _iRetCount, typed_list &ou
     {
         if (in[i]->isString() == false)
         {
-            Scierror(999, _("%s: Wrong type for input argument #%d: A String matrix expected.\n"), fname, i);
+            Scierror(999, _("%s: Wrong type for input argument #%d: A String matrix expected.\n"), fname, i+1);
             return Function::Error;
         }
     }
@@ -68,7 +68,7 @@ Function::ReturnValue sci_protect(typed_list &in, int _iRetCount, typed_list &ou
             if (pCtx->isValidVariableName(wcsVarName) == false)
             {
                 char* pstrVarName = wide_string_to_UTF8(wcsVarName);
-                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, i);
+                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, i+1);
                 FREE(pstrVarName);
                 return Function::Error;
             }
@@ -76,7 +76,7 @@ Function::ReturnValue sci_protect(typed_list &in, int _iRetCount, typed_list &ou
             if (pCtx->get(Symbol(wcsVarName)) == NULL)
             {
                 char* pstrVarName = wide_string_to_UTF8(wcsVarName);
-                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: An existent variable expected.\n"), fname, pstrVarName, i);
+                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: An existent variable expected.\n"), fname, pstrVarName, i+1);
                 FREE(pstrVarName);
                 return Function::Error;
             }

--- a/scilab/modules/core/sci_gateway/cpp/sci_unprotect.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_unprotect.cpp
@@ -52,7 +52,7 @@ Function::ReturnValue sci_unprotect(typed_list &in, int _iRetCount, typed_list &
     {
         if (in[i]->isString() == false)
         {
-            Scierror(999, _("%s: Wrong type for input argument #%d: A String matrix expected.\n"), fname, i);
+            Scierror(999, _("%s: Wrong type for input argument #%d: A String matrix expected.\n"), fname, i+1);
             return Function::Error;
         }
     }
@@ -68,7 +68,7 @@ Function::ReturnValue sci_unprotect(typed_list &in, int _iRetCount, typed_list &
             if (pCtx->isValidVariableName(wcsVarName) == false)
             {
                 char* pstrVarName = wide_string_to_UTF8(wcsVarName);
-                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, i);
+                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, i+1);
                 FREE(pstrVarName);
                 return Function::Error;
             }
@@ -76,7 +76,7 @@ Function::ReturnValue sci_unprotect(typed_list &in, int _iRetCount, typed_list &
             if (pCtx->get(Symbol(wcsVarName)) == NULL)
             {
                 char* pstrVarName = wide_string_to_UTF8(wcsVarName);
-                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: An existent variable expected.\n"), fname, pstrVarName, i);
+                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: An existent variable expected.\n"), fname, pstrVarName, i+1);
                 FREE(pstrVarName);
                 return Function::Error;
             }

--- a/scilab/modules/core/sci_gateway/cpp/sci_unprotect.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_unprotect.cpp
@@ -28,8 +28,6 @@ extern "C"
 #include "localization.h"
 }
 
-using types::Bool;
-using types::Double;
 using types::Function;
 using types::String;
 using types::typed_list;
@@ -42,60 +40,59 @@ static const char fname[] = "unprotect";
 
 Function::ReturnValue sci_unprotect(typed_list &in, int _iRetCount, typed_list &out)
 {
-    if (in.size() != 1)
-    {
-        Scierror(77, _("%s: Wrong number of input argument(s): %d expected.\n"), fname, 1);
-        return types::Function::Error;
-    }
+    Context *pCtx = Context::getInstance();
 
-    if (in[0]->isString() == false)
+    if (in.size() == 0)
     {
-        Scierror(999, _("%s: Wrong type for input argument #%d: A String expected.\n"), fname, 1);
-        return types::Function::Error;
-    }
-    
-    String* pS = in[0]->getAs<String>();
-    
-    if (pS->getSize() == 0)
-    {
-        out.push_back(
-        Double::Empty());
+        pCtx->unprotect();
         return Function::OK;
     }
 
-    Context *pCtx = Context::getInstance();
-    
-    for (int i = 0; i < pS->getSize(); ++i)
+    for (int i = 0; i < in.size(); ++i)
     {
-        wchar_t* wcsVarName = pS->get(i);
-
-        if (pCtx->isValidVariableName(wcsVarName) == false)
+        if (in[i]->isString() == false)
         {
-            char* pstrVarName = wide_string_to_UTF8(wcsVarName);
-            Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, 1);
-            FREE(pstrVarName);
-            return Function::Error;
-        }
-        
-        if (pCtx->get(Symbol(wcsVarName)) == NULL)
-        {
-            char* pstrVarName = wide_string_to_UTF8(wcsVarName);
-            Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: An existent variable expected.\n"), fname, pstrVarName, 1);
-            FREE(pstrVarName);
+            Scierror(999, _("%s: Wrong type for input argument #%d: A String matrix expected.\n"), fname, i);
             return Function::Error;
         }
     }
 
-    for (int i = 0; i < pS->getSize(); ++i)
+    for (int i = 0; i < in.size(); ++i)
     {
-        wchar_t* wcsVarName = pS->get(i);
-
-        Variable* pV = pCtx->getOrCreate(Symbol(wcsVarName));
+        String* pS = in[i]->getAs<String>();
         
-        if (pV->empty() == false)
+        for (int j = 0; j < pS->getSize(); ++j)
         {
-            ScopedVariable* pSV = pV->top();
-            pSV->protect = false;
+            wchar_t* wcsVarName = pS->get(j);
+
+            if (pCtx->isValidVariableName(wcsVarName) == false)
+            {
+                char* pstrVarName = wide_string_to_UTF8(wcsVarName);
+                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: A valid variable name expected.\n"), fname, pstrVarName, i);
+                FREE(pstrVarName);
+                return Function::Error;
+            }
+
+            if (pCtx->get(Symbol(wcsVarName)) == NULL)
+            {
+                char* pstrVarName = wide_string_to_UTF8(wcsVarName);
+                Scierror(999, _("%s: Wrong value \"%s\" in argument #%d: An existent variable expected.\n"), fname, pstrVarName, i);
+                FREE(pstrVarName);
+                return Function::Error;
+            }
+        }
+
+        for (int j = 0; j < pS->getSize(); ++j)
+        {
+            wchar_t* wcsVarName = pS->get(j);
+
+            Variable* pV = pCtx->getOrCreate(Symbol(wcsVarName));
+
+            if (pV->empty() == false)
+            {
+                ScopedVariable* pSV = pV->top();
+                pSV->protect = false;
+            }
         }
     }
 


### PR DESCRIPTION
fixes #418 

`protect()` - protects all variables
`protect a b c` - protect variables named `a`, `b`, and `c`
`protect(a,...)` - protect variables specified by one or several string matrices `a,...`

`unprotect()` - protects all variables
`unprotect a b c` - unprotect variables named `a`, `b`, and `c`
`unprotect(a,...)` - unprotect variables specified by one or several string matrices `a,...`

`names  = isprotected()` - return `names` (vector of strings) of all protected variables
`yesno = isprotected(a)` - return a boolean matrix `yesno`, which indicates whether a variable specified in string matrix `a` is protected or not
