### PR TITLE
Slightly Refactored Some "ast" Data Types

### DIFF
--- a/scilab/modules/ast/includes/types/arrayof.hxx
+++ b/scilab/modules/ast/includes/types/arrayof.hxx
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2010 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -46,8 +46,22 @@ protected :
     T*                      m_pRealData;
     T*                      m_pImgData;
 
+    // variables to manage print taking care of lines
+    bool m_bPrintFromStart;
+    int  m_iSavePrintState;
+    int  m_iRows1PrintState;
+    int  m_iCols1PrintState;
+    int  m_iRows2PrintState;
+    int  m_iCols2PrintState;
 
-    ArrayOf() : GenericType(), m_pRealData(NULL), m_pImgData(NULL) {}
+    ArrayOf() : GenericType(), m_pRealData(NULL),
+                               m_pImgData(NULL),
+                               m_bPrintFromStart(true),
+                               m_iSavePrintState(0),
+                               m_iRows1PrintState(0),
+                               m_iCols1PrintState(0),
+                               m_iRows2PrintState(0),
+                               m_iCols2PrintState(0) {}
 
     virtual                 ~ArrayOf()
     {
@@ -492,6 +506,8 @@ public :
         ostr << L" " << getTypeStr() << L"]";
         return ostr.str();
     }
+
+    virtual void clearPrintState();
 };
 
 }

--- a/scilab/modules/ast/includes/types/callable.hxx
+++ b/scilab/modules/ast/includes/types/callable.hxx
@@ -132,7 +132,6 @@ public :
 
 protected :
     std::wstring            m_wstName;
-    std::string             m_stName;
     std::wstring            m_wstModule;
     int                     m_iFirstLine;
     int                     m_iLastLine;

--- a/scilab/modules/ast/includes/types/callable.hxx
+++ b/scilab/modules/ast/includes/types/callable.hxx
@@ -3,7 +3,7 @@
  * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -34,7 +34,6 @@ public :
     enum ReturnValue
     {
         OK,
-        OK_NoResult,
         Error
     };
 

--- a/scilab/modules/ast/includes/types/function.hxx
+++ b/scilab/modules/ast/includes/types/function.hxx
@@ -125,7 +125,6 @@ private :
 
 protected:
     LOAD_DEPS               m_pLoadDeps;
-    std::string             m_stName;
 };
 
 class OptFunction : public Function
@@ -165,6 +164,9 @@ public:
 
 private:
     OLDGW_FUNC              m_pOldFunc;
+
+protected:
+    std::string m_stName;
 };
 
 class WrapCFunction : public Function
@@ -184,6 +186,8 @@ public:
 
 private:
     GW_C_FUNC               m_pCFunc;
+protected:
+    std::string m_stName;
 };
 
 class WrapMexFunction : public Function

--- a/scilab/modules/ast/includes/types/function.hxx
+++ b/scilab/modules/ast/includes/types/function.hxx
@@ -1,9 +1,9 @@
 /*
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
- * Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
+ * Copyright (C) 2008 - 2008 - DIGITEO - Antoine ELIAS
+ * Copyright (C) 2010 - 2010 - DIGITEO - Bruno JOFRET
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -125,7 +125,7 @@ private :
 
 protected:
     LOAD_DEPS               m_pLoadDeps;
-
+    std::string             m_stName;
 };
 
 class OptFunction : public Function

--- a/scilab/modules/ast/includes/types/internal.hxx
+++ b/scilab/modules/ast/includes/types/internal.hxx
@@ -188,9 +188,9 @@ public :
 
 protected :
 #ifdef _SCILAB_DEBUGREF_
-    InternalType() : m_iRef(0), m_bPrintFromStart(true), m_iSavePrintState(0), m_iRows1PrintState(0), m_iCols1PrintState(0), m_iRows2PrintState(0), m_iCols2PrintState(0), bKillMe(false)
+    InternalType() : m_iRef(0), bKillMe(false)
 #else
-    InternalType() : m_iRef(0), m_bPrintFromStart(true), m_iSavePrintState(0), m_iRows1PrintState(0), m_iCols1PrintState(0), m_iRows2PrintState(0), m_iCols2PrintState(0)
+    InternalType() : m_iRef(0)
 #endif
     {
 #ifdef _SCILAB_DEBUGREF_
@@ -413,19 +413,12 @@ public :
     virtual bool isLibrary(void);
     virtual bool isUserType(void);
 
-    void clearPrintState();
+    virtual void clearPrintState()
+    {
+    }
 
 protected :
-    int          m_iRef;
-
-    /*variables to manage print taking care of lines*/
-    bool m_bPrintFromStart;
-    int  m_iSavePrintState;
-    int  m_iRows1PrintState;
-    int  m_iCols1PrintState;
-    int  m_iRows2PrintState;
-    int  m_iCols2PrintState;
-
+    int m_iRef;
 #ifdef _SCILAB_DEBUGREF_
     bool bKillMe;
 #endif

--- a/scilab/modules/ast/includes/types/internal.hxx
+++ b/scilab/modules/ast/includes/types/internal.hxx
@@ -187,7 +187,11 @@ public :
     };
 
 protected :
+#ifdef _SCILAB_DEBUGREF_
     InternalType() : m_iRef(0), m_bPrintFromStart(true), m_iSavePrintState(0), m_iRows1PrintState(0), m_iCols1PrintState(0), m_iRows2PrintState(0), m_iCols2PrintState(0), bKillMe(false)
+#else
+    InternalType() : m_iRef(0), m_bPrintFromStart(true), m_iSavePrintState(0), m_iRows1PrintState(0), m_iCols1PrintState(0), m_iRows2PrintState(0), m_iCols2PrintState(0)
+#endif
     {
 #ifdef _SCILAB_DEBUGREF_
 #if defined(_SCILAB_DEBUGREF_WITHOUT_START_END)
@@ -422,7 +426,9 @@ protected :
     int  m_iRows2PrintState;
     int  m_iCols2PrintState;
 
+#ifdef _SCILAB_DEBUGREF_
     bool bKillMe;
+#endif
 };
 
 }

--- a/scilab/modules/ast/includes/types/internal.hxx
+++ b/scilab/modules/ast/includes/types/internal.hxx
@@ -3,7 +3,7 @@
  * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -187,7 +187,7 @@ public :
     };
 
 protected :
-    InternalType() : m_iRef(0), m_bAllowDelete(true), m_bPrintFromStart(true), m_iSavePrintState(0), m_iRows1PrintState(0), m_iCols1PrintState(0), m_iRows2PrintState(0), m_iCols2PrintState(0), bKillMe(false)
+    InternalType() : m_iRef(0), m_bPrintFromStart(true), m_iSavePrintState(0), m_iRows1PrintState(0), m_iCols1PrintState(0), m_iRows2PrintState(0), m_iCols2PrintState(0), bKillMe(false)
     {
 #ifdef _SCILAB_DEBUGREF_
 #if defined(_SCILAB_DEBUGREF_WITHOUT_START_END)
@@ -413,8 +413,6 @@ public :
 
 protected :
     int          m_iRef;
-    //use to know if we can delete this variables or if it's link to a scilab variable.
-    bool         m_bAllowDelete;
 
     /*variables to manage print taking care of lines*/
     bool m_bPrintFromStart;
@@ -425,7 +423,6 @@ protected :
     int  m_iCols2PrintState;
 
     bool bKillMe;
-
 };
 
 }

--- a/scilab/modules/ast/src/cpp/types/arrayof.cpp
+++ b/scilab/modules/ast/src/cpp/types/arrayof.cpp
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2010 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -1675,6 +1675,16 @@ int ArrayOf<T>::getInvokeNbOut()
     return 1;
 }
 
+template<typename T>
+void ArrayOf<T>::clearPrintState()
+{
+    m_bPrintFromStart = true;
+    m_iSavePrintState = 0;
+    m_iRows1PrintState = 0;
+    m_iCols1PrintState = 0;
+    m_iRows2PrintState = 0;
+    m_iCols2PrintState = 0;
+}
 
 // used to allow definition of ArrayOf methode in this cpp file.
 template class ArrayOf < char >;

--- a/scilab/modules/ast/src/cpp/types/function.cpp
+++ b/scilab/modules/ast/src/cpp/types/function.cpp
@@ -181,18 +181,12 @@ Function* Function::createFunction(const std::wstring& _wstName, GW_C_FUNC _pFun
 Function::Function(const std::wstring& _wstName, GW_FUNC _pFunc, LOAD_DEPS _pLoadDeps, const std::wstring& _wstModule) : Callable(), m_pFunc(_pFunc), m_pLoadDeps(_pLoadDeps)
 {
     setName(_wstName);
-    char* s = wide_string_to_UTF8(m_wstName.data());
-    m_stName = s;
-    FREE(s);
-
     setModule(_wstModule);
 }
 
 Function::~Function()
 {
-
 }
-
 
 Function::ReturnValue Function::call(typed_list &in, optional_list &/*opt*/, int _iRetCount, typed_list &out)
 {
@@ -239,9 +233,6 @@ bool Function::operator==(const InternalType& it)
 OptFunction::OptFunction(const std::wstring& _wstName, GW_FUNC_OPT _pFunc, LOAD_DEPS _pLoadDeps, const std::wstring& _wstModule)
 {
     m_wstName = _wstName;
-    char* s = wide_string_to_UTF8(m_wstName.data());
-    m_stName = s;
-    FREE(s);
     m_pFunc = _pFunc;
     m_pLoadDeps = _pLoadDeps;
     m_wstModule = _wstModule;
@@ -251,9 +242,6 @@ OptFunction::OptFunction(OptFunction* _pWrapFunction)
 {
     m_wstModule  = _pWrapFunction->getModule();
     m_wstName    = _pWrapFunction->getName();
-    char* s = wide_string_to_UTF8(m_wstName.data());
-    m_stName = s;
-    FREE(s);
     m_pFunc = _pWrapFunction->getFunc();
     m_pLoadDeps = _pWrapFunction->getDeps();
 }
@@ -465,9 +453,6 @@ Function::ReturnValue WrapFunction::call(typed_list &in, optional_list &opt, int
 WrapMexFunction::WrapMexFunction(const std::wstring& _wstName, MEXGW_FUNC _pFunc, LOAD_DEPS _pLoadDeps, const std::wstring& _wstModule)
 {
     m_wstName = _wstName;
-    char* s = wide_string_to_UTF8(m_wstName.data());
-    m_stName = s;
-    FREE(s);
     m_pOldFunc = _pFunc;
     m_wstModule = _wstModule;
     m_pLoadDeps = _pLoadDeps;
@@ -476,9 +461,6 @@ WrapMexFunction::WrapMexFunction(const std::wstring& _wstName, MEXGW_FUNC _pFunc
 WrapMexFunction::WrapMexFunction(WrapMexFunction* _pWrapFunction)
 {
     m_wstModule = _pWrapFunction->getModule();
-    char* s = wide_string_to_UTF8(m_wstName.data());
-    m_stName = s;
-    FREE(s);
     m_wstName = _pWrapFunction->getName();
     m_pOldFunc = _pWrapFunction->getFunc();
     m_pLoadDeps = _pWrapFunction->getDeps();
@@ -627,9 +609,6 @@ Function::ReturnValue WrapCFunction::call(typed_list& in, optional_list& opt, in
 DynamicFunction::DynamicFunction(const std::wstring& _wstName, const std::wstring& _wstEntryPointName, const std::wstring& _wstLibName, FunctionType _iType, const std::wstring& _wstLoadDepsName, const std::wstring& _wstModule, bool _bCloseLibAfterCall)
 {
     m_wstName               = _wstName;
-    char* s = wide_string_to_UTF8(m_wstName.data());
-    m_stName = s;
-    FREE(s);
     m_wstLibName = _wstLibName;
     m_wstModule             = _wstModule;
     m_wstEntryPoint         = _wstEntryPointName;
@@ -648,9 +627,6 @@ DynamicFunction::DynamicFunction(const std::wstring& _wstName, const std::wstrin
 DynamicFunction::DynamicFunction(const std::wstring& _wstName, const std::wstring& _wstEntryPointName, const std::wstring& _wstLibName, FunctionType _iType, LOAD_DEPS _pLoadDeps, const std::wstring& _wstModule, bool _bCloseLibAfterCall)
 {
     m_wstName               = _wstName;
-    char* s = wide_string_to_UTF8(m_wstName.data());
-    m_stName = s;
-    FREE(s);
     m_wstLibName = _wstLibName;
     m_wstModule             = _wstModule;
     m_wstEntryPoint         = _wstEntryPointName;

--- a/scilab/modules/ast/src/cpp/types/internal.cpp
+++ b/scilab/modules/ast/src/cpp/types/internal.cpp
@@ -1,8 +1,8 @@
 /*
-*  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-*  Copyright (C) 2015 - Scilab Enterprises - Calixte DENIZET
-*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2015 - Scilab Enterprises - Calixte DENIZET
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -10,8 +10,8 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-*
-*/
+ *
+ */
 
 #include "exp.hxx" // for invoke
 #include "callexp.hxx"
@@ -324,15 +324,4 @@ bool InternalType::isUserType(void)
 {
     return false;
 }
-
-void InternalType::clearPrintState()
-{
-    m_bPrintFromStart = true;
-    m_iSavePrintState = 0;
-    m_iRows1PrintState = 0;
-    m_iCols1PrintState = 0;
-    m_iRows2PrintState = 0;
-    m_iCols2PrintState = 0;
-}
-
 }


### PR DESCRIPTION
- slightly decreased memory foot print of types *__not__* derived from `ArrayOf`
- additional tiny decrease of memory foot print of some types derived from `Callable`
- avoid some useless `wide_string_to_UTF8` calls in ctors of some types derived from `Function`