### PR TITLE
Refactoring of Some String Addition Ops in "ast" Module (Improved Runtime Perf)

### DIFF
--- a/scilab/modules/ast/src/cpp/operations/types_addition.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_addition.cpp
@@ -1723,25 +1723,44 @@ InternalType* add_S_M<String, String, String>(String* _pL, String* _pR)
 template<>
 InternalType* add_M_S<String, String, String>(String* _pL, String* _pR)
 {
-    String* pOut = new String(_pL->getDims(), _pL->getDimsArray());
     int size = _pL->getSize();
-    int* sizeOut = new int[size];
     wchar_t* pwstR = _pR->getFirst();
     int sizeR = (int)wcslen(pwstR);
 
-    for (int i = 0 ; i < size ; ++i)
+    String* pOut;
+    if (_pL->getRef() > 0)
     {
-        wchar_t* pwstL = _pL->get(i);
-        int sizeL = (int)wcslen(pwstL);
+        int* sizeOut = new int[size];
 
-        sizeOut[i] = sizeL + sizeR + 1;
-        wchar_t* pwstOut = (wchar_t*) MALLOC(sizeOut[i] * sizeof(wchar_t));
-        //assign ptr without strdup
-        pOut->get()[i] = pwstOut;
+        pOut = new String(_pL->getDims(), _pL->getDimsArray());
+
+        for (int i = 0 ; i < size ; ++i)
+        {
+            wchar_t* pwstL = _pL->get(i);
+            int sizeL = (int)wcslen(pwstL);
+
+            sizeOut[i] = sizeL + sizeR + 1;
+            wchar_t* pwstOut = (wchar_t*)MALLOC(sizeOut[i] * sizeof(wchar_t));
+            //assign ptr without strdup
+            pOut->get()[i] = pwstOut;
+        }
+
+        add(_pL->get(), size, pwstR, sizeOut, pOut->get());
+        delete[] sizeOut;
+    }
+    else
+    {
+        pOut = _pL;
+
+        for (int i = 0; i < size; ++i)
+        {
+            wchar_t* pwstL = pOut->get(i);
+            int sizeL = (int)wcslen(pwstL);
+            pOut->get()[i] = (wchar_t*)REALLOC(pwstL, (sizeL + sizeR + 1) * sizeof(wchar_t));
+            wcscat(pOut->get(i), pwstR);
+        }
     }
 
-    add(_pL->get(), size, pwstR, sizeOut, pOut->get());
-    delete[] sizeOut;
     return pOut;
 }
 

--- a/scilab/modules/ast/src/cpp/operations/types_addition.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_addition.cpp
@@ -1749,17 +1749,28 @@ InternalType* add_M_S<String, String, String>(String* _pL, String* _pR)
 template<>
 InternalType* add_S_S<String, String, String>(String* _pL, String* _pR)
 {
-    String* pOut = new String(1, 1);
     wchar_t* pwstL = _pL->getFirst();
     wchar_t* pwstR = _pR->getFirst();
     int sizeL = (int)wcslen(pwstL);
     int sizeR = (int)wcslen(pwstR);
-
     int sizeOut = sizeL + sizeR + 1;
-    wchar_t* pwstOut = (wchar_t*) MALLOC(sizeOut * sizeof(wchar_t));
-    //assign ptr without strdup
-    pOut->get()[0] = pwstOut;
-    add(pwstL, pwstR, sizeOut, *pOut->get());
+
+    String* pOut;
+    if (_pL->getRef() > 0)
+    {
+        pOut = new String(1, 1);
+        wchar_t* pwstOut = (wchar_t*)MALLOC(sizeOut * sizeof(wchar_t));
+        //assign ptr without strdup
+        pOut->get()[0] = pwstOut;
+        add(pwstL, pwstR, sizeOut, *pOut->get());
+    }
+    else
+    {
+        pOut = _pL;
+        pOut->get()[0] = (wchar_t*)REALLOC(pwstL, sizeOut * sizeof(wchar_t));
+        wcscat(*pOut->get(), pwstR);
+    }
+
     return pOut;
 }
 

--- a/scilab/modules/ast/src/cpp/operations/types_addition.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_addition.cpp
@@ -1672,24 +1672,46 @@ InternalType* add_M_M<String, String, String>(String* _pL, String* _pR)
         }
     }
 
-    String* pOut = new String(iDimsL, piDimsL);
     int size = _pL->getSize();
-    int* sizeOut = new int[size];
-    for (int i = 0 ; i < size ; ++i)
-    {
-        wchar_t* pwstL = _pL->get(i);
-        wchar_t* pwstR = _pR->get(i);
-        int sizeL = (int)wcslen(pwstL);
-        int sizeR = (int)wcslen(pwstR);
 
-        sizeOut[i] = sizeL + sizeR + 1;
-        wchar_t* pwstOut = (wchar_t*) MALLOC(sizeOut[i] * sizeof(wchar_t));
-        //assign ptr without strdup
-        pOut->get()[i] = pwstOut;
+    String* pOut;
+    if (_pL->getRef() > 0)
+    {
+        int* sizeOut = new int[size];
+        pOut = new String(iDimsL, piDimsL);
+
+        for (int i = 0 ; i < size ; ++i)
+        {
+            wchar_t* pwstL = _pL->get(i);
+            wchar_t* pwstR = _pR->get(i);
+            int sizeL = (int)wcslen(pwstL);
+            int sizeR = (int)wcslen(pwstR);
+
+            sizeOut[i] = sizeL + sizeR + 1;
+            wchar_t* pwstOut = (wchar_t*) MALLOC(sizeOut[i] * sizeof(wchar_t));
+            //assign ptr without strdup
+            pOut->get()[i] = pwstOut;
+        }
+
+        add(_pL->get(), size, _pR->get(), sizeOut, pOut->get());
+        delete[] sizeOut;
+    }
+    else
+    {
+        pOut = _pL;
+
+        for (int i = 0; i < size; ++i)
+        {
+            wchar_t* pwstL = pOut->get(i);
+            wchar_t* pwstR = _pR->get(i);
+            int sizeL = (int)wcslen(pwstL);
+            int sizeR = (int)wcslen(pwstR);
+
+            pOut->get()[i] = (wchar_t*)REALLOC(pwstL, (sizeL + sizeR + 1) * sizeof(wchar_t));
+            wcscat(pOut->get(i), pwstR);
+        }
     }
 
-    add(_pL->get(), size, _pR->get(), sizeOut, pOut->get());
-    delete[] sizeOut;
     return pOut;
 }
 


### PR DESCRIPTION
Balisc (now)
```
--> a="a";

--> tic;for i=1:1e6;a+a+a+a+a+a+a+a+a+a;end;toc
 ans  =
   1.268163

--> A="a"(ones(1e3,1e3));

--> tic;A+A+A+A+A+A+A+A+A+A;toc
 ans  =
   0.459269
```

Balisc (before)
```
--> a="a";

--> tic;for i=1:1e6;a+a+a+a+a+a+a+a+a+a;end;toc
 ans  =
   2.632451

--> A="a"(ones(1e3,1e3));

--> tic;A+A+A+A+A+A+A+A+A+A;toc
 ans  =
   0.909572
```
Scilab 6.x (master)
```
--> a="a";

--> tic;for i=1:1e6;a+a+a+a+a+a+a+a+a+a;end;toc
 ans  =
   5.210443

--> A="a"(ones(1e3,1e3));

--> tic;A+A+A+A+A+A+A+A+A+A;toc
 ans  =
   2.744612
```
