### PR TITLE
Revert "reuse left input arg in matrix+scalar string op"

### DIFF
--- a/scilab/modules/ast/src/cpp/operations/types_addition.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_addition.cpp
@@ -1745,44 +1745,25 @@ InternalType* add_S_M<String, String, String>(String* _pL, String* _pR)
 template<>
 InternalType* add_M_S<String, String, String>(String* _pL, String* _pR)
 {
+    String* pOut = new String(_pL->getDims(), _pL->getDimsArray());
     int size = _pL->getSize();
+    int* sizeOut = new int[size];
     wchar_t* pwstR = _pR->getFirst();
     int sizeR = (int)wcslen(pwstR);
 
-    String* pOut;
-    if (_pL->getRef() > 0)
+    for (int i = 0 ; i < size ; ++i)
     {
-        int* sizeOut = new int[size];
+        wchar_t* pwstL = _pL->get(i);
+        int sizeL = (int)wcslen(pwstL);
 
-        pOut = new String(_pL->getDims(), _pL->getDimsArray());
-
-        for (int i = 0 ; i < size ; ++i)
-        {
-            wchar_t* pwstL = _pL->get(i);
-            int sizeL = (int)wcslen(pwstL);
-
-            sizeOut[i] = sizeL + sizeR + 1;
-            wchar_t* pwstOut = (wchar_t*)MALLOC(sizeOut[i] * sizeof(wchar_t));
-            //assign ptr without strdup
-            pOut->get()[i] = pwstOut;
-        }
-
-        add(_pL->get(), size, pwstR, sizeOut, pOut->get());
-        delete[] sizeOut;
-    }
-    else
-    {
-        pOut = _pL;
-
-        for (int i = 0; i < size; ++i)
-        {
-            wchar_t* pwstL = pOut->get(i);
-            int sizeL = (int)wcslen(pwstL);
-            pOut->get()[i] = (wchar_t*)REALLOC(pwstL, (sizeL + sizeR + 1) * sizeof(wchar_t));
-            wcscat(pOut->get(i), pwstR);
-        }
+        sizeOut[i] = sizeL + sizeR + 1;
+        wchar_t* pwstOut = (wchar_t*) MALLOC(sizeOut[i] * sizeof(wchar_t));
+        //assign ptr without strdup
+        pOut->get()[i] = pwstOut;
     }
 
+    add(_pL->get(), size, pwstR, sizeOut, pOut->get());
+    delete[] sizeOut;
     return pOut;
 }
 


### PR DESCRIPTION
This reverts commit bb019b7307965667c927a21d8decbcc8c9129a17.

Some tests (`cat`, `bug_13409`, and `bug_8297`) of `ast` module failed with crashes :-1:
Somehow, the `REALLOC` in `add_M_S` is not happy with (some) pointer it gets, `test_run("elementary_functions")` yields:
 ```
*** Error in `/home/dirk/Downloads/balisc/scilab/.libs/lt-scilab-cli-bin': realloc(): invalid pointer: 0x00007f97ba7d7798 ***
*** Error in `/home/dirk/Downloads/balisc/scilab/.libs/lt-scilab-cli-bin': realloc(): invalid pointer: 0x00007f8c5d330798 ***
*** Error in `/home/dirk/Downloads/balisc/scilab/.libs/lt-scilab-cli-bin': realloc(): invalid pointer: 0x00007f8a1cb66798 ***
```
and the stack trace for such a test looks like
```
Call stack:
   1: 0x36c37  <gsignal>                        (/lib/x86_64-linux-gnu/libc.so.6)
   2: 0x3a028  <abort>                          (/lib/x86_64-linux-gnu/libc.so.6)
   3: 0x732a4  < >                              (/lib/x86_64-linux-gnu/libc.so.6)
   4: 0x7e007  < >                              (/lib/x86_64-linux-gnu/libc.so.6)
   5: 0x834c2  <realloc>                        (/lib/x86_64-linux-gnu/libc.so.6)
   6: 0x209a79 <types::InternalType* add_M_S<types::String, types::String, types::String>(types::String*, types::String*)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
   7: 0x1939fb <ast::RunVisitorT<ast::ExecVisitor>::visitprivate(ast::OpExp const&)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
   8: 0x1ba6c4 <ast::RunVisitorT<ast::ExecVisitor>::visitprivate(ast::AssignExp const&)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
   9: 0x1c366d <ast::RunVisitorT<ast::ExecVisitor>::visitprivate(ast::SeqExp const&)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  10: 0x180b6d <ast::RunVisitorT<ast::ExecVisitor>::visitprivate(ast::IfExp const&)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  11: 0x1c366d <ast::RunVisitorT<ast::ExecVisitor>::visitprivate(ast::SeqExp const&)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  12: 0x180b6d <ast::RunVisitorT<ast::ExecVisitor>::visitprivate(ast::IfExp const&)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  13: 0x1c366d <ast::RunVisitorT<ast::ExecVisitor>::visitprivate(ast::SeqExp const&)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  14: 0x44f915 <types::Macro::call(std::vector<types::InternalType*, std::allocator<types::InternalType*> >&, std::unordered_map<std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >, types::InternalType*, std::hash<std::basic_string<wchar_t, st> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  15: 0x43b7f8 <types::Callable::invoke(std::vector<types::InternalType*, std::allocator<types::InternalType*> >&, std::unordered_map<std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >, types::InternalType*, std::hash<std::basic_string<wchar_> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  16: 0x1c8e34 <ast::RunVisitorT<ast::ExecVisitor>::visitprivate(ast::CallExp const&)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  17: 0x1ba6c4 <ast::RunVisitorT<ast::ExecVisitor>::visitprivate(ast::AssignExp const&)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  18: 0x1c366d <ast::RunVisitorT<ast::ExecVisitor>::visitprivate(ast::SeqExp const&)> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  19: 0x10277  <sci_exec>                       (/home/dirk/Downloads/balisc/scilab/modules/functions/.libs/libscifunctions.so.6)
  20: 0x44690e <types::DynamicFunction::call(std::vector<types::InternalType*, std::allocator<types::InternalType*> >&, std::unordered_map<std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >, types::InternalType*, std::hash<std::basic_string<w> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  21: 0x43b7f8 <types::Callable::invoke(std::vector<types::InternalType*, std::allocator<types::InternalType*> >&, std::unordered_map<std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >, types::InternalType*, std::hash<std::basic_string<wchar_> (/home/dirk/Downloads/balisc/scilab/modules/ast/.libs/libsciast.so.6)
  22: 0x1c
```

For time being we just revert, but in the long run this should really be investigated in depth! Every pointer to `String` elements is supposed to be allocated via `malloc`, thus `realloc` should not fail like it did ...