### PR TITLE
Aftermath related to PR #612 #616

### DIFF
--- a/scilab/modules/overloading/macros/%3d_i_h.sci
+++ b/scilab/modules/overloading/macros/%3d_i_h.sci
@@ -1,7 +1,7 @@
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) INRIA
-//
 // Copyright (C) 2012 - 2016 - Scilab Enterprises
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 // This file is hereby licensed under the terms of the GNU GPL v2.0,
 // pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -9,6 +9,7 @@
 // and continues to be available under such terms.
 // For more information, see the COPYING file which you should have received
 // along with this program.
+
 function h=%3d_i_h(i,v,h)
     if type(i)==10 then
         set(h,i,v)
@@ -19,7 +20,7 @@ function h=%3d_i_h(i,v,h)
             index=i($)
             i($)=null()
         else
-            index=:
+            index=1:1:$
         end
         n = size(i)
         for k=1:n-1

--- a/scilab/modules/overloading/macros/%champdat_i_h.sci
+++ b/scilab/modules/overloading/macros/%champdat_i_h.sci
@@ -1,7 +1,7 @@
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) INRIA
-//
 // Copyright (C) 2012 - 2016 - Scilab Enterprises
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 // This file is hereby licensed under the terms of the GNU GPL v2.0,
 // pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -9,6 +9,7 @@
 // and continues to be available under such terms.
 // For more information, see the COPYING file which you should have received
 // along with this program.
+
 function h=%champdat_i_h(i,v,h)
     if type(i)==10 then
         set(h,i,v)
@@ -19,7 +20,7 @@ function h=%champdat_i_h(i,v,h)
             index=i($)
             i($)=null()
         else
-            index=:
+            index=1:1:$
         end
         n = size(i)
         for k=1:n-1

--- a/scilab/modules/overloading/macros/%grayplot_i_h.sci
+++ b/scilab/modules/overloading/macros/%grayplot_i_h.sci
@@ -1,7 +1,7 @@
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) INRIA
-//
 // Copyright (C) 2012 - 2016 - Scilab Enterprises
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 // This file is hereby licensed under the terms of the GNU GPL v2.0,
 // pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -9,6 +9,7 @@
 // and continues to be available under such terms.
 // For more information, see the COPYING file which you should have received
 // along with this program.
+
 function h=%grayplot_i_h(i,v,h)
     if type(i)==10 then
         set(h,i,v)
@@ -19,7 +20,7 @@ function h=%grayplot_i_h(i,v,h)
             index=i($)
             i($)=null()
         else
-            index=:
+            index=1:1:$
         end
         n = size(i)
         for k=1:n-1

--- a/scilab/modules/overloading/macros/%ticks_i_h.sci
+++ b/scilab/modules/overloading/macros/%ticks_i_h.sci
@@ -1,7 +1,7 @@
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) INRIA
-//
 // Copyright (C) 2012 - 2016 - Scilab Enterprises
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 // This file is hereby licensed under the terms of the GNU GPL v2.0,
 // pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -20,7 +20,7 @@ function h=%ticks_i_h(i,v,h)
             index=i($)
             i($)=null()
         else
-            index=:
+            index=1:1:$
         end
         n = size(i)
         for k=1:n-1

--- a/scilab/modules/overloading/macros/generic_i_h.sci
+++ b/scilab/modules/overloading/macros/generic_i_h.sci
@@ -17,7 +17,7 @@ function h=generic_i_h(i,v,h)
     if type(i)<>15 then  error(msprintf(_("%s: Wrong type for input argument #%d.\n"),"generic_i_h",1)),end
 
     if and(type(i($))<>[1 2 4 8 129 15]) then
-        i($+1)=:
+        i($+1)=eye()
     end
 
     n = size(i)

--- a/scilab/modules/signal_processing/macros/fftshift.sci
+++ b/scilab/modules/signal_processing/macros/fftshift.sci
@@ -18,7 +18,7 @@ function x = fftshift(x,job)
     if job=="all" then
         for sk=size(x),ind($+1)=fun(sk),end
     else
-        for sk=size(x),ind($+1)=:,end;
+        for sk=size(x),ind($+1)=eye(),end;
         ind(job)=fun(size(x,job))
     end
     x=x(ind(:))

--- a/scilab/modules/statistics/macros/nanstdev.sci
+++ b/scilab/modules/statistics/macros/nanstdev.sci
@@ -46,7 +46,7 @@ function [s]=nanstdev(x,orient)
         x=x-Mean
     else
         N=size(x,orient)-sum(bool2s(isn),orient)
-        ind=list();for k=size(x),ind($+1)=:;end
+        ind=list();for k=size(x),ind($+1)=eye();end
         ind(orient)=ones(size(x,orient),1)
         x=x-Mean(ind(:))
     end

--- a/scilab/modules/statistics/macros/variancef.sci
+++ b/scilab/modules/statistics/macros/variancef.sci
@@ -58,21 +58,21 @@ function [s, m] = variancef(x, fre, orien, m)
     if nargin==4 then
         if typeof(m)~="constant" then
             tmp = gettext("%s: Wrong value of m : a priori mean expected.\n")
-            error(msprintf(tmp, "variancef", ))
+            error(msprintf(tmp, "variancef"))
         elseif orien=="*" then
             if ~isscalar(m) then
                 tmp = gettext("%s: Wrong value of m : a priori mean expected.\n")
-                error(msprintf(tmp, "variancef", ))
+                error(msprintf(tmp, "variancef"))
             end
         elseif orien=="r" | orien==1 then
             if size(m)~=[1 size(x,"c")] & ~isscalar(m) then
                 tmp = gettext("%s: Wrong value of m : a priori mean expected.\n")
-                error(msprintf(tmp, "variancef", ))
+                error(msprintf(tmp, "variancef"))
             end
         elseif orien=="c" | orien==2 then
             if size(m)~=[size(x,"r") 1] & ~isscalar(m) then
                 tmp = gettext("%s: Wrong value of m : a priori mean expected.\n")
-                error(msprintf(tmp, "variancef", ))
+                error(msprintf(tmp, "variancef"))
             end
         end
         if isnan(m) then


### PR DESCRIPTION
The dubious `a=:` and the syntax `func(a,b,)` was actually used (probably 30 years ago ...) a few times in the code base ... :frowning_face: ... but now we have hopefully extinguished this stuff forever ...