### PR TITLE
Fixed #584

### DIFF
--- a/scilab/modules/ast/Makefile.am
+++ b/scilab/modules/ast/Makefile.am
@@ -273,6 +273,8 @@ libsciast_la_CPPFLAGS = \
 	-I$(top_srcdir)/modules/fileio/includes \
 	-I$(top_srcdir)/modules/fileio/src/c \
 	-I$(top_srcdir)/modules/coverage/includes \
+	-I$(top_srcdir)/modules/jvm/includes \
+	-I$(top_srcdir)/modules/graphic_objects/includes \
 	$(EIGEN_CPPFLAGS) \
 	$(AM_CPPFLAGS)
 

--- a/scilab/modules/ast/Makefile.in
+++ b/scilab/modules/ast/Makefile.in
@@ -1201,6 +1201,8 @@ libsciast_la_CPPFLAGS = \
 	-I$(top_srcdir)/modules/fileio/includes \
 	-I$(top_srcdir)/modules/fileio/src/c \
 	-I$(top_srcdir)/modules/coverage/includes \
+	-I$(top_srcdir)/modules/jvm/includes \
+	-I$(top_srcdir)/modules/graphic_objects/includes \
 	$(EIGEN_CPPFLAGS) \
 	$(AM_CPPFLAGS)
 

--- a/scilab/modules/ast/includes/types/cell.hxx
+++ b/scilab/modules/ast/includes/types/cell.hxx
@@ -92,15 +92,9 @@ public :
     }
     bool                subMatrixToString(std::wostringstream& ostr, int* _piDims, int _iDims) override;
 
-    bool isTrue()
-    {
-        return false;
-    }
+    bool isTrue();
 
-    virtual bool neg(InternalType *& /*out*/)
-    {
-        return false;
-    }
+    virtual bool neg(InternalType *& /*out*/);
 
     virtual bool transpose(InternalType *& out);
 

--- a/scilab/modules/ast/includes/types/double.hxx
+++ b/scilab/modules/ast/includes/types/double.hxx
@@ -110,7 +110,35 @@ public :
             return true;
         }
 
-        return ArrayOf<double>::neg(out);
+        out = new Bool(this->m_iDims, this->m_piDims);
+        int* pb = static_cast<Bool*>(out)->get();
+
+        if (m_pImgData ==  NULL)
+        {
+            if (isViewAsZComplex())
+            {
+                for (int i = 0; i < m_iSize; ++i)
+                {
+                    pb[i] = !(m_pRealData[i] || m_pRealData[2*i+1]);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < m_iSize; ++i)
+                {
+                    pb[i] = !(m_pRealData[i]);
+                }
+            }
+        }
+        else
+        {
+            for (int i = 0; i < m_iSize; ++i)
+            {
+                pb[i] = !(m_pRealData[i] || m_pImgData[i]);
+            }
+        }
+
+        return true;
     }
 
     void                        setViewAsInteger(bool _bViewAsInteger = true)

--- a/scilab/modules/ast/includes/types/graphichandle.hxx
+++ b/scilab/modules/ast/includes/types/graphichandle.hxx
@@ -61,15 +61,9 @@ public :
         return false;
     }
 
-    bool isTrue()
-    {
-        return false;
-    }
+    bool isTrue();
 
-    virtual bool neg(InternalType *& /*out*/)
-    {
-        return false;
-    }
+    virtual bool neg(InternalType *& /*out*/);
 
     virtual bool transpose(InternalType *& out);
 

--- a/scilab/modules/ast/includes/types/list.hxx
+++ b/scilab/modules/ast/includes/types/list.hxx
@@ -17,6 +17,7 @@
 #define __LIST_HH__
 
 #include <list>
+#include "bool.hxx"
 #include "container.hxx"
 
 namespace types
@@ -128,6 +129,8 @@ public :
     virtual bool                    operator==(const InternalType& it);
 
     bool isTrue();
+
+    virtual bool neg(InternalType*&);
 
 protected :
     std::vector<InternalType *>*    m_plData;

--- a/scilab/modules/ast/includes/types/list.hxx
+++ b/scilab/modules/ast/includes/types/list.hxx
@@ -127,6 +127,8 @@ public :
 
     virtual bool                    operator==(const InternalType& it);
 
+    bool isTrue();
+
 protected :
     std::vector<InternalType *>*    m_plData;
 };

--- a/scilab/modules/ast/includes/types/polynom.hxx
+++ b/scilab/modules/ast/includes/types/polynom.hxx
@@ -114,7 +114,28 @@ public :
 
     bool isTrue()
     {
-        return false;
+        for (int i = 0; i < m_iSize; ++i)
+        {
+            if (!get(i)->isTrue())
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    virtual bool neg(InternalType*& out)
+    {
+        out = new Bool(this->m_iDims, this->m_piDims);
+        int* pb = static_cast<Bool*>(out)->get();
+
+        for (int i = 0; i < m_iSize; ++i)
+        {
+            pb[i] = !get(i)->isTrue();
+        }
+
+        return true;
     }
 
     bool transpose(InternalType *& out);

--- a/scilab/modules/ast/includes/types/singlepoly.hxx
+++ b/scilab/modules/ast/includes/types/singlepoly.hxx
@@ -48,6 +48,11 @@ public :
     virtual double          copyValue(double _dblData);
     virtual bool            subMatrixToString(std::wostringstream& ostr, int* _piDims, int _iDims) override;
 
+    bool isTrue()
+    {
+        return getDegree() != -INFINITY;
+    }
+
     bool                    setZeros();
     int                     getRank();
     double                  getDegree();

--- a/scilab/modules/ast/includes/types/singlestruct.hxx
+++ b/scilab/modules/ast/includes/types/singlestruct.hxx
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2011 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -73,6 +73,21 @@ public :
 
     bool                                    operator==(const InternalType& it);
     bool                                    operator!=(const InternalType& it);
+
+    bool isTrue()
+    {
+        for (int i = 0; i < m_Data.size(); ++i)
+        {
+            InternalType* e = m_Data[i];
+
+            if ((e->isGenericType() && e->getAs<GenericType>()->getSize()) || e->isTrue())
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /* return type as string ( double, int, cell, list, ... )*/
     virtual std::wstring                    getTypeStr() const

--- a/scilab/modules/ast/includes/types/singlestruct.hxx
+++ b/scilab/modules/ast/includes/types/singlestruct.hxx
@@ -80,7 +80,7 @@ public :
         {
             InternalType* e = m_Data[i];
 
-            if ((e->isGenericType() && e->getAs<GenericType>()->getSize()) || e->isTrue())
+            if ((e->isGenericType() && !e->isString() && e->getAs<GenericType>()->getSize()) || e->isTrue())
             {
                 return true;
             }

--- a/scilab/modules/ast/includes/types/string.hxx
+++ b/scilab/modules/ast/includes/types/string.hxx
@@ -83,10 +83,7 @@ public :
         return true;
     }
 
-    bool isTrue()
-    {
-        return false;
-    }
+    bool isTrue();
 
     virtual bool neg(InternalType *& /*out*/)
     {

--- a/scilab/modules/ast/includes/types/string.hxx
+++ b/scilab/modules/ast/includes/types/string.hxx
@@ -85,10 +85,7 @@ public :
 
     bool isTrue();
 
-    virtual bool neg(InternalType *& /*out*/)
-    {
-        return false;
-    }
+    virtual bool neg(InternalType *& /*out*/);
 
     virtual bool transpose(InternalType *& out);
 

--- a/scilab/modules/ast/includes/types/struct.hxx
+++ b/scilab/modules/ast/includes/types/struct.hxx
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2011 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -90,12 +90,39 @@ public :
 
     bool isTrue()
     {
-        return false;
+        if (getSize() == 0)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < getSize(); ++i)
+        {
+            if (!get(i)->isTrue())
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
-    virtual bool neg(InternalType *& /*out*/)
+    virtual bool neg(InternalType*& out)
     {
-        return false;
+        if (getSize() == 0)
+        {
+            out = new Bool(false);
+            return true;
+        }
+
+        out = new Bool(this->m_iDims, this->m_piDims);
+        int* pb = static_cast<Bool*>(out)->get();
+
+        for (int i = 0; i < m_iSize; ++i)
+        {
+            pb[i] = !get(i)->isTrue();
+        }
+
+        return true;
     }
 
     bool                        subMatrixToString(std::wostringstream& ostr, int* _piDims, int _iDims) override;

--- a/scilab/modules/ast/includes/types/struct.hxx
+++ b/scilab/modules/ast/includes/types/struct.hxx
@@ -110,7 +110,7 @@ public :
     {
         if (getSize() == 0)
         {
-            out = new Bool(false);
+            out = new Bool(true);
             return true;
         }
 

--- a/scilab/modules/ast/src/cpp/types/cell.cpp
+++ b/scilab/modules/ast/src/cpp/types/cell.cpp
@@ -474,4 +474,40 @@ Cell* Cell::createEmpty()
 {
     return new Cell();
 }
+
+bool Cell::isTrue()
+{
+    for (int i = 0; i < getSize(); ++i)
+    {
+        InternalType* e = get(i);
+
+        if ((e->isGenericType() && e->getAs<GenericType>()->getSize()) || e->isTrue())
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool Cell::neg(InternalType*& out)
+{
+    if (getSize() == 0)
+    {
+        out = new Bool(true);
+        return true;
+    }
+
+    out = new Bool(this->m_iDims, this->m_piDims);
+    int* pb = static_cast<Bool*>(out)->get();
+
+    for (int i = 0; i < m_iSize; ++i)
+    {
+        InternalType* e = get(i);
+        pb[i] = !((e->isGenericType() && e->getAs<GenericType>()->getSize()) || e->isTrue());
+    }
+
+    return true;
+}
+
 }

--- a/scilab/modules/ast/src/cpp/types/cell.cpp
+++ b/scilab/modules/ast/src/cpp/types/cell.cpp
@@ -481,7 +481,7 @@ bool Cell::isTrue()
     {
         InternalType* e = get(i);
 
-        if ((e->isGenericType() && e->getAs<GenericType>()->getSize()) || e->isTrue())
+        if ((e->isGenericType() && !e->isString() && e->getAs<GenericType>()->getSize()) || e->isTrue())
         {
             return true;
         }
@@ -504,7 +504,7 @@ bool Cell::neg(InternalType*& out)
     for (int i = 0; i < m_iSize; ++i)
     {
         InternalType* e = get(i);
-        pb[i] = !((e->isGenericType() && e->getAs<GenericType>()->getSize()) || e->isTrue());
+        pb[i] = !((e->isGenericType() && !e->isString() && e->getAs<GenericType>()->getSize()) || e->isTrue());
     }
 
     return true;

--- a/scilab/modules/ast/src/cpp/types/double.cpp
+++ b/scilab/modules/ast/src/cpp/types/double.cpp
@@ -1249,11 +1249,27 @@ ast::Exp* Double::getExp(const Location& loc)
 
 bool Double::isTrue()
 {
-    if (isEmpty() || isComplex())
+    if (isEmpty())
     {
         return false;
     }
 
-    return type_traits::isTrue<double>(m_iSize, m_pRealData);
+    if (m_pImgData ==  NULL)
+    {
+        return type_traits::isTrue<double>(isViewAsZComplex() ? 2 * m_iSize : m_iSize, m_pRealData);
+    }
+    else
+    {
+        for (int i = 0; i < m_iSize; ++i)
+        {
+            if (!(m_pRealData[i] || m_pImgData[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }
+
 }

--- a/scilab/modules/ast/src/cpp/types/graphichandle.cpp
+++ b/scilab/modules/ast/src/cpp/types/graphichandle.cpp
@@ -24,6 +24,7 @@ extern "C"
 #include "localization.h"
 #include "os_string.h"
 #include "sci_malloc.h"
+#include "HandleManagement.h"
 }
 
 namespace types
@@ -198,6 +199,32 @@ bool GraphicHandle::invoke(typed_list & in, optional_list & opt, int _iRetCount,
 bool GraphicHandle::transpose(InternalType *& out)
 {
     return type_traits::transpose(*this, out);
+}
+
+bool GraphicHandle::isTrue()
+{
+    for (int i = 0; i < m_iSize; ++i)
+    {
+        if (!getObjectFromHandle(get(i)))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool GraphicHandle::neg(InternalType*& out)
+{
+    out = new Bool(this->m_iDims, this->m_piDims);
+    int* pb = static_cast<Bool*>(out)->get();
+
+    for (int i = 0; i < m_iSize; ++i)
+    {
+        pb[i] = !getObjectFromHandle(get(i));
+    }
+
+    return true;
 }
 
 }

--- a/scilab/modules/ast/src/cpp/types/internal.cpp
+++ b/scilab/modules/ast/src/cpp/types/internal.cpp
@@ -17,6 +17,9 @@
 #include "callexp.hxx"
 
 #include "internal.hxx"
+#include "bool.hxx"
+#include "function.hxx"
+#include "overload.hxx"
 
 namespace types
 {
@@ -43,7 +46,26 @@ ast::Exp * InternalType::getExp(const Location& /*loc*/)
 
 bool InternalType::isTrue()
 {
-    return false;
+    typed_list in;
+    typed_list out;
+
+    in.push_back(this);
+
+    std::wstring wstFuncName = L"%" + getShortTypeStr() + L"_T";
+
+    if (Overload::call(wstFuncName, in, 1, out) == Function::OK && out[0]->isBool())
+    {
+        types::Bool* pB = out[0]->getAs<Bool>();
+
+        if (pB->isScalar())
+        {
+            return pB->getFirst();
+        }
+    }
+
+    std::wostringstream os;
+    os << _W("An error occurred in overload function ") << wstFuncName << "." << std::endl;
+    throw ast::InternalError(os.str());
 }
 
 bool InternalType::neg(InternalType *& /*out*/)

--- a/scilab/modules/ast/src/cpp/types/list.cpp
+++ b/scilab/modules/ast/src/cpp/types/list.cpp
@@ -392,4 +392,22 @@ bool List::operator==(const InternalType& it)
     return true;
 }
 
+bool List::isTrue()
+{
+    for (int i = 0; i < getSize(); ++i)
+    {
+        // FIXME: is this a reasonable definition?
+        switch(get(i)->getType())
+        {
+            // case ScilabListInsertOperation:
+            // case ScilabListDeleteOperation:
+            case ScilabListUndefinedOperation:
+            case ScilabVoid:
+                return true;
+        }
+    }
+
+    return false;
+}
+
 }

--- a/scilab/modules/ast/src/cpp/types/list.cpp
+++ b/scilab/modules/ast/src/cpp/types/list.cpp
@@ -396,14 +396,11 @@ bool List::isTrue()
 {
     for (int i = 0; i < getSize(); ++i)
     {
-        // FIXME: is this a reasonable definition? (cf. neg)
-        switch(get(i)->getType())
+        InternalType* e = get(i);
+
+        if ((e->isGenericType() && e->getAs<GenericType>()->getSize()) || e->isTrue())
         {
-            // case ScilabListInsertOperation:
-            // case ScilabListDeleteOperation:
-            case ScilabListUndefinedOperation:
-            case ScilabVoid:
-                return true;
+            return true;
         }
     }
 
@@ -412,24 +409,7 @@ bool List::isTrue()
 
 bool List::neg(InternalType *& out)
 {
-    for (int i = 0; i < getSize(); ++i)
-    {
-        // FIXME: is this a reasonable definition? (cf. isTrue)
-        switch(get(i)->getType())
-        {
-            // case ScilabListInsertOperation:
-            // case ScilabListDeleteOperation:
-            case ScilabListUndefinedOperation:
-            case ScilabVoid:
-                break;
-
-            default:
-                out = new Bool(false);
-                return true;
-        }
-    }
-
-    out = new Bool(true);
+    out = new Bool(!isTrue());
     return true;
 }
 

--- a/scilab/modules/ast/src/cpp/types/list.cpp
+++ b/scilab/modules/ast/src/cpp/types/list.cpp
@@ -398,7 +398,7 @@ bool List::isTrue()
     {
         InternalType* e = get(i);
 
-        if ((e->isGenericType() && e->getAs<GenericType>()->getSize()) || e->isTrue())
+        if ((e->isGenericType() && !e->isString() && e->getAs<GenericType>()->getSize()) || e->isTrue())
         {
             return true;
         }

--- a/scilab/modules/ast/src/cpp/types/list.cpp
+++ b/scilab/modules/ast/src/cpp/types/list.cpp
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2010-2010 - DIGITEO - Bruno JOFRET
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -396,7 +396,7 @@ bool List::isTrue()
 {
     for (int i = 0; i < getSize(); ++i)
     {
-        // FIXME: is this a reasonable definition?
+        // FIXME: is this a reasonable definition? (cf. neg)
         switch(get(i)->getType())
         {
             // case ScilabListInsertOperation:
@@ -408,6 +408,29 @@ bool List::isTrue()
     }
 
     return false;
+}
+
+bool List::neg(InternalType *& out)
+{
+    for (int i = 0; i < getSize(); ++i)
+    {
+        // FIXME: is this a reasonable definition? (cf. isTrue)
+        switch(get(i)->getType())
+        {
+            // case ScilabListInsertOperation:
+            // case ScilabListDeleteOperation:
+            case ScilabListUndefinedOperation:
+            case ScilabVoid:
+                break;
+
+            default:
+                out = new Bool(false);
+                return true;
+        }
+    }
+
+    out = new Bool(true);
+    return true;
 }
 
 }

--- a/scilab/modules/ast/src/cpp/types/overload.cpp
+++ b/scilab/modules/ast/src/cpp/types/overload.cpp
@@ -123,7 +123,7 @@ types::Function::ReturnValue Overload::call(const std::wstring& _stOverloadingFu
             }
             else
             {
-                os_sprintf(pstError2, _("  check arguments or define function %s for overloading.\n"), pstFuncName);
+                os_sprintf(pstError2, _("check arguments or define function %s for overloading.\n"), pstFuncName);
                 os_sprintf(pstError1, "%s%s", _("Function not defined for given argument type(s),\n"), pstError2);
             }
 

--- a/scilab/modules/ast/src/cpp/types/string.cpp
+++ b/scilab/modules/ast/src/cpp/types/string.cpp
@@ -689,6 +689,19 @@ ast::Exp* String::getExp(const Location& loc)
     return new ast::StringExp(loc, this);
 }
 
+bool String::isTrue()
+{
+    for (int i = 0; i < getSize(); ++i)
+    {
+        if (wcslen(get(i)) > 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool String::transpose(InternalType *& out)
 {
     return type_traits::transpose(*this, out);

--- a/scilab/modules/ast/src/cpp/types/string.cpp
+++ b/scilab/modules/ast/src/cpp/types/string.cpp
@@ -702,6 +702,19 @@ bool String::isTrue()
     return false;
 }
 
+bool String::neg(InternalType *& out)
+{
+    out = new Bool(m_iDims, m_piDims);
+    int* o = out->getAs<Bool>()->get();
+
+    for (int i = 0; i < getSize(); ++i)
+    {
+        o[i] = (wcslen(get(i)) == 0);
+    }
+
+    return true;
+}
+
 bool String::transpose(InternalType *& out)
 {
     return type_traits::transpose(*this, out);

--- a/scilab/modules/javasci/Makefile.in
+++ b/scilab/modules/javasci/Makefile.in
@@ -1018,10 +1018,10 @@ maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
 	-test -z "$(BUILT_SOURCES)" || rm -f $(BUILT_SOURCES)
-@JAVASCI_FALSE@distclean-local:
+@JAVASCI_FALSE@install-html-local:
 @JAVASCI_FALSE@clean-local:
 @JAVASCI_FALSE@install-data-local:
-@JAVASCI_FALSE@install-html-local:
+@JAVASCI_FALSE@distclean-local:
 clean: clean-am
 
 clean-am: clean-generic clean-libtool clean-local \


### PR DESCRIPTION
- fixes #584 
- provides sensible implemenations for types `Double`, `Polynom`, `String`, `Cell`, `Struct`, `List`, and `GraphicHandle`
- makes `isempty` to some extent superfluous
- calls overload for all other types using a **_new_** additonal op_code `T`

What can you expect? E.g. the following

```
--> if 0, disp("TRUE"), end

--> if 1, disp("TRUE"), end

 TRUE


--> if %i, disp("TRUE"), end

 TRUE


--> if 0*%i, disp("TRUE"), end

--> if [], disp("TRUE"), end

--> if [0,0], disp("TRUE"), end

--> if [0,1], disp("TRUE"), end

--> if [1,1], disp("TRUE"), end

 TRUE


--> if {1,1}, disp("TRUE"), end

 TRUE


--> if {}, disp("TRUE"), end

--> if "", disp("TRUE"), end

--> if "ABC", disp("TRUE"), end

 TRUE


--> if ["A","B"], disp("TRUE"), end

 TRUE


--> if struct(), disp("TRUE"), end

--> if struct("a",2), disp("TRUE"), end

 TRUE


--> if struct(), disp("TRUE"), end

--> if sin, disp("TRUE"), end

Function not defined for given argument type(s),
check arguments or define function %fptr_T for overloading.

--> if sinm, disp("TRUE"), end

Function not defined for given argument type(s),
check arguments or define function %function_T for overloading.
```