### PR TITLE
Simplified Context::isprotected

### DIFF
--- a/scilab/etc/scilab.start
+++ b/scilab/etc/scilab.start
@@ -166,4 +166,5 @@ if ~(isnan(0*%inf)&&isnan(%inf*0))
   warning("This issue is probably caused the BLAS libary you are using!");
 end
 // ====================================================================
-clear ans main_menubar_cb  getPreferencesValue
+
+clear main_menubar_cb getPreferencesValue

--- a/scilab/modules/ast/src/cpp/symbol/context.cpp
+++ b/scilab/modules/ast/src/cpp/symbol/context.cpp
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -647,12 +647,6 @@ bool Context::isprotected(const Symbol& key)
 
 bool Context::isprotected(Variable* _var)
 {
-    //don't check protection on "ans"
-    if (_var->getSymbol().getName() == L"ans")
-    {
-        return false;
-    }
-
     if (_var->empty() == false)
     {
         ScopedVariable* pSV = _var->top();


### PR DESCRIPTION
protection of `ans` is now possible to avoid explicit modifications by the user (seems reasonable), e.g.

```
--> isprotected ans
 ans  =
  T

--> clear ans

Redefining permanent variable.

--> ans=5

Redefining permanent variable.

--> 1+1
 ans  =
   2.

--> ans
 ans  = 
   2.

--> unprotect ans

--> clear ans

--> ans

Undefined variable: ans

--> 1+2
 ans  =
   3.

--> isprotected ans
 ans  =
  F
```