### PR TITLE
Fixed #326

### DIFF
--- a/scilab/modules/ast/src/cpp/symbol/variables.cpp
+++ b/scilab/modules/ast/src/cpp/symbol/variables.cpp
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2015 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -21,7 +21,7 @@
 
 extern "C"
 {
-#include "sciprint.h"
+#include "Sciwarning.h"
 }
 
 namespace symbol
@@ -99,25 +99,25 @@ bool Variable::put(types::InternalType* _pIT, int _iLevel)
             //check macro redefinition
             if (pIT->isCallable())
             {
-                int iFuncProt = ConfigVariable::getFuncprot();
-
-                if (iFuncProt)
+                switch (ConfigVariable::getFuncprot())
                 {
-                    if (iFuncProt == 2)
-                    {
-                        wchar_t pwstError[1024];
-                        os_swprintf(pwstError, 1024, _W("ERROR: Redefining function \"%s\". Use funcprot(0) to avoid this error.\n").c_str(), name.getName().c_str());
+                    case 1:
+                        {
+                            char pstWarning[1024];
+                            char* pstFuncName = wide_string_to_UTF8(name.getName().c_str());
+                            snprintf(pstWarning, 1024, _("WARNING: Redefining function \"%s\". Use funcprot(0) to avoid this message.\n"), pstFuncName);
+                            FREE(pstFuncName);
+                            Sciwarning(pstWarning);
+                        }
+                        break;
 
-                        throw ast::InternalError(pwstError);
-                    }
-
-                    if (ConfigVariable::getWarningMode())
-                    {
-                        char* pstFuncName = wide_string_to_UTF8(name.getName().c_str());
-
-                        sciprint(_("WARNING: Redefining function \"%s\". Use funcprot(0) to avoid this message.\n"), pstFuncName);
-                        FREE(pstFuncName);
-                    }
+                    case 2:
+                        {
+                            wchar_t pwstError[1024];
+                            os_swprintf(pwstError, 1024, _W("ERROR: Redefining function \"%s\". Use funcprot(0) to avoid this error.\n").c_str(), name.getName().c_str());
+                            throw ast::InternalError(pwstError);
+                        }
+                        break;
                 }
             }
 

--- a/scilab/modules/functions/help/en_US/funcprot.xml
+++ b/scilab/modules/functions/help/en_US/funcprot.xml
@@ -5,11 +5,11 @@
           xml:lang="en" xml:id="funcprot">
     <refnamediv>
         <refname>funcprot</refname>
-        <refpurpose>switch scilab functions protection mode</refpurpose>
+        <refpurpose>function protection mode</refpurpose>
     </refnamediv>
     <refsynopsisdiv>
         <title>Syntax</title>
-        <synopsis>funcprot(prot)
+        <synopsis>
             previousprot = funcprot(prot)
             prot = funcprot()
         </synopsis>
@@ -34,23 +34,27 @@
     <refsection>
         <title>Description</title>
         <para>
-            Scilab functions are variable, <function>funcprot</function> allows the user to specify
-            what Scilab do when such  variables are redefined.
+            Scilab functions are variables. The function protection mode <function>funcprot</function> defines the behaviour, whenever
+            the redefinition of a function is detected.
+        </para>
+        <para>
+            Please note, that only redefinitions in the current scope are detected, i.e.
+            possible shadowing of function definitions remain undetected.
         </para>
         <itemizedlist>
             <listitem>
                 <para>
-                    If <code>prot == 0</code> nothing special is done.
+                    If <code>prot == 0</code> nothing is done.
                 </para>
             </listitem>
             <listitem>
                 <para>
-                    If <code>prot == 1</code> Scilab issues a warning message when a function is redefined (default mode).
+                    If <code>prot == 1</code> a warning is issued (default).
                 </para>
             </listitem>
             <listitem>
                 <para>
-                    If <code>prot == 2</code> Scilab issues an error when a function is redefined.
+                    If <code>prot == 2</code> an error is raised.
                 </para>
             </listitem>
         </itemizedlist>
@@ -73,7 +77,10 @@ funcprot(previousprot)
         <title>See Also</title>
         <simplelist type="inline">
             <member>
-                <link linkend="predef">predef</link>
+                <link linkend="protect">protect</link>
+            </member>
+            <member>
+                <link linkend="warning">warning</link>
             </member>
         </simplelist>
     </refsection>
@@ -83,6 +90,10 @@ funcprot(previousprot)
             <revision>
                 <revnumber>5.4.0</revnumber>
                 <revremark>Previous value is returned as output argument when setting a new value.</revremark>
+            </revision>
+            <revision>
+                <revnumber>Balisc 1</revnumber>
+                <revremark>Pointed out limitations wrt to the detection of function redefinitions.</revremark>
             </revision>
         </revhistory>
     </refsection>

--- a/scilab/modules/graphic_export/sci_gateway/graphic_export_gateway.xml
+++ b/scilab/modules/graphic_export/sci_gateway/graphic_export_gateway.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE module SYSTEM "../../functions/xml/gateway.dtd">
 <!--
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2012 - Scilab Enterprises - Cedric DELAMARRE
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2012 - Scilab Enterprises - Cedric DELAMARRE
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -29,7 +29,6 @@
     <gateway name="sci_xs2ppm"  function="xs2ppm"   type="0" />
     <gateway name="sci_xs2eps"  function="xs2eps"   type="0" />
     <gateway name="sci_xs2pdf"  function="xs2pdf"   type="0" />
-    <gateway name="sci_xs2svg"  function="xs2svg"   type="0" />
     <gateway name="sci_xs2svg"  function="xs2svg"   type="0" />
     <gateway name="sci_xs2ps"   function="xs2ps"    type="0" />
     <gateway name="sci_driver"  function="driver"   type="0" />

--- a/scilab/modules/scicos/sci_gateway/scicos_gateway.xml
+++ b/scilab/modules/scicos/sci_gateway/scicos_gateway.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module SYSTEM "../../functions/xml/gateway.dtd">
 <!--
-            /*
-            *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-            *  Copyright (C) 2014 - Scilab Enterprises - Clement DAVID
-            *
+/*
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2014 - Scilab Enterprises - Clement DAVID
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -13,20 +13,19 @@
  * and continues to be available under such terms.
  * For more information, see the COPYING file which you should have received
  * along with this program.
-            *
-            */
-            Scilab
-            Interface description. In this file, we define the list of the function which
-            will be available into Scilab and the link to the "native" function.
+ *
+ */
+ Scilab
+ Interface description. In this file, we define the list of the function which
+ will be available into Scilab and the link to the "native" function.
 
-            Don't touch if you do not know what you are doing !
-        -->
+ Don't touch if you do not know what you are doing !
+-->
 <module name="scicos">
     <gateway type="0" name="sci_sctree" function="sctree"/>
     <gateway type="0" name="sci_tree2" function="sci_tree2"/>
     <gateway type="0" name="sci_tree3" function="sci_tree3"/>
     <gateway type="0" name="sci_tree4" function="sci_tree4"/>
-    <gateway type="0" name="sci_model2blk" function="model2blk"/>
     <gateway type="0" name="sci_loadScicos" function="loadScicos"/>
     <!-- C++ Gateways -->
     <gateway type="1" name="sci_buildouttb" function="buildouttb"/>

--- a/scilab/modules/xcos/sci_gateway/xcos_gateway.xml
+++ b/scilab/modules/xcos/sci_gateway/xcos_gateway.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE module SYSTEM "../../functions/xml/gateway.dtd">
 <!--
 /*
- *  Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- *  Copyright (C) 2014 - Scilab Enterprises - Clement DAVID
- *
+ * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
+ * Copyright (C) 2014 - Scilab Enterprises - Clement DAVID
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -37,7 +37,6 @@
     <gateway name="sci_xcosPalGet"              function="xcosPalGet"               type="0" />
     <!-- Scilab 6 Gateways (C++) -->
     <gateway name="sci_Xcos"                    function="xcos"                     type="1" />
-    <gateway name="sci_xcosCellCreated"         function="xcosCellCreated"          type="1" />
     <gateway name="sci_xcosUpdateBlock"         function="xcosUpdateBlock"          type="1" />
     <gateway name="sci_xcosDiagramToScilab"     function="xcosDiagramToScilab"      type="1" />
     <gateway name="sci_xcosPalGenerateIcon"     function="xcosPalGenerateIcon"      type="1" />


### PR DESCRIPTION
fixes #326 

Remarks:
- trying to redefine built-in primitives by assigment (e.g. `sin=1`), does actually `shadow` them, thus
 `funcprot` is not triggered
- macros from libraries are not loaded upon their first usage, thus
```
--> sinm=5
 sinm  = 
   5. // OK, because sinm was not loaded, i.e. was not redefined 

--> clear

--> sinm // force loading of sinm
at line     4 of function sinm ( /home/dirk/Downloads/balisc/scilab/modules/elementary_functions/macros/sinm.sci line 16 )

sinm: Wrong number of input arguments: 1 expected.
--> sinm=5
WARNING: Redefining function "sinm". Use funcprot(0) to avoid this message.
 sinm  = 
   5.
```