### PR TITLE
Refactored "<>" Op for Sparse (Approx. 250x faster for "Matrix <> Scalar"!!!)

### DIFF
--- a/scilab/modules/ast/includes/types/sparse.hxx
+++ b/scilab/modules/ast/includes/types/sparse.hxx
@@ -360,7 +360,7 @@ struct Sparse : GenericType
        @return ptr to a new Sparse matrix where each element is the result of the logical operator
         '!=' between the elements of *this and those of o.
      */
-    SparseBool* newNotEqualTo(Sparse const&o) const;
+    SparseBool* newNotEqualTo(Sparse &o);
 
     /* coefficient wise relational operator <= between *this sparse matrix and another.
        Matrices must have the same dimensions except if one of them is of size (1,1)

--- a/scilab/modules/ast/src/cpp/operations/types_comparison_ne.cpp
+++ b/scilab/modules/ast/src/cpp/operations/types_comparison_ne.cpp
@@ -2756,8 +2756,6 @@ InternalType* compnoequal_M_M<Sparse, Double, Bool>(Sparse* _pL, Double* _pR)
 template<class T, class U, class O>
 InternalType* compnoequal_M_SP(T* _pL, U* _pR)
 {
-    //pending changes
-
     //D -> SP != SP
     Sparse* pspConvert = NULL;
     types::SparseBool* pOut = NULL;
@@ -2765,23 +2763,16 @@ InternalType* compnoequal_M_SP(T* _pL, U* _pR)
 
     if (_pL->isScalar())
     {
-        int iSizeOut = _pR->getSize();
         if (_pL->isComplex())
         {
-            pspConvert = new Sparse(_pR->getRows(), _pR->getCols(), true);
+            pspConvert = new Sparse(1, 1, true);
             std::complex<double> stComplex((double)_pL->getFirst(), (double)_pL->getImgFirst());
-            for (int i = 0; i < iSizeOut; i++)
-            {
-                pspConvert->set(i, stComplex, false);
-            }
+            pspConvert->set(0, stComplex, false);
         }
         else
         {
-            pspConvert = new Sparse(_pR->getRows(), _pR->getCols(), _pR->isComplex());
-            for (int i = 0; i < iSizeOut; i++)
-            {
-                pspConvert->set(i, (double)_pL->getFirst(), false);
-            }
+            pspConvert = new Sparse(1,1, _pR->isComplex());
+            pspConvert->set(0, (double)_pL->getFirst(), false);
         }
     }
     else
@@ -2823,30 +2814,21 @@ InternalType* compnoequal_M_SP(T* _pL, U* _pR)
 template<class T, class U, class O>
 InternalType* compnoequal_SP_M(T* _pL, U* _pR)
 {
-    //pending changes
-
     Sparse* pspConvert = NULL;
     types::SparseBool* pOut = NULL;
 
     if (_pR->isScalar())
     {
-        int iSizeOut = _pL->getSize();
         if (_pR->isComplex())
         {
-            pspConvert = new Sparse(_pL->getRows(), _pL->getCols(), true);
+            pspConvert = new Sparse(1, 1, true);
             std::complex<double> stComplex((double)_pR->getFirst(), (double)_pR->getImgFirst());
-            for (int i = 0; i < iSizeOut; i++)
-            {
-                pspConvert->set(i, stComplex, false);
-            }
+            pspConvert->set(0, stComplex, false);
         }
         else
         {
-            pspConvert = new Sparse(_pL->getRows(), _pL->getCols(), _pL->isComplex());
-            for (int i = 0; i < iSizeOut; i++)
-            {
-                pspConvert->set(i, (double)_pR->getFirst(), false);
-            }
+            pspConvert = new Sparse(1, 1, _pL->isComplex());
+            pspConvert->set(0, (double)_pR->getFirst(), false);
         }
     }
     else


### PR DESCRIPTION
BEFORE
```
--> n=1000;

--> a=sprand(n, n, 0.001);

--> tic;a<>0.5;toc
 ans  =

   15.454315
```
AFTER
```
--> n=1000;

--> a=sprand(n, n, 0.001);

--> tic;a<>0.5;toc
 ans  =

   0.057661
```
