### PR TITLE
Fixed #443 (List Operations are Now Assignable)

### DIFF
--- a/scilab/modules/ast/includes/types/listoperation.hxx
+++ b/scilab/modules/ast/includes/types/listoperation.hxx
@@ -46,7 +46,7 @@ public :
     bool                    toString(std::wostringstream& ostr);
     virtual bool            isAssignable(void)
     {
-        return false;
+        return true;
     }
 
     /* return type as string ( double, int, cell, list, ... )*/

--- a/scilab/modules/ast/src/cpp/ast/run_AssignExp.hpp
+++ b/scilab/modules/ast/src/cpp/ast/run_AssignExp.hpp
@@ -69,22 +69,6 @@ void RunVisitorT<T>::visitprivate(const AssignExp  &e)
 
             if (pIT->isAssignable() == false)
             {
-                if (pIT->isListDelete())
-                {
-                    //used to delete a variable in current scope
-                    symbol::Symbol sym = pVar->getSymbol();
-                    if (ctx->isprotected(sym) == false)
-                    {
-                        ctx->remove(sym);
-                    }
-                    else
-                    {
-                        std::wostringstream os;
-                        os << _W("Redefining permanent variable.\n");
-                        throw ast::InternalError(os.str(), 999, e.getLeftExp().getLocation());
-                    }
-                }
-
                 setResult(NULL);
                 CoverageInstance::stopChrono((void*)&e);
                 return;

--- a/scilab/modules/ast/tests/nonreg_tests/issue_443.tst
+++ b/scilab/modules/ast/tests/nonreg_tests/issue_443.tst
@@ -1,0 +1,24 @@
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// <-- CLI SHELL MODE -->
+// <-- NO CHECK REF -->
+//
+// <-- Non-regression test for issue 443 -->
+//
+// <-- Github URL -->
+// https://github.com/rdbyk/balisc/issues/443
+//
+// <-- Short Description -->
+// Trying to Assign List Operations Does Not Work
+
+a = null()
+assert_checkequal(typeof(a), "listdelete")
+
+a = insert()
+assert_checkequal(typeof(a), "listinsert")
+
+// FIXME: cumbersome creation of "Undefined"
+a = list()
+a(1) = insert()
+a = a(1)
+assert_checkequal(typeof(a), "listundefined")


### PR DESCRIPTION
fixes #443 