### PR TITLE
Replace (now wrong) Usage of "null" by "clear" and "rmfield"

### DIFF
--- a/scilab/modules/data_structures/tests/nonreg_tests/bug_5612.dia.ref
+++ b/scilab/modules/data_structures/tests/nonreg_tests/bug_5612.dia.ref
@@ -1,23 +1,6 @@
-// =============================================================================
-// Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-// Copyright (C) 2010 - DIGITEO - Vincent COUVERT
-//
-//  This file is distributed under the same license as the Scilab package.
-// =============================================================================
-// <-- CLI SHELL MODE -->
-// <-- Non-regression test for bug 5612 -->
-//
-// <-- Bugzilla URL -->
-// http://bugzilla.scilab.org/show_bug.cgi?id=5612
-//
-// <-- Short Description -->
-// There is no way for deleting a structure field.
 s = struct("txt","Hello","num",%pi,"pol",%z^2+1);
 if or(getfield(1,s)<>["st", "dims", "txt", "num", "pol"]) then bugmes();quit;end
-// Delete the field called 'num'
-s.num = null();
-// Check that 'num' field has been deleted
+rmfield("num",s);
 if or(getfield(1,s)<>["st", "dims", "txt", "pol"]) then bugmes();quit;end
-// Check that remaining fields have the right value
 if s.txt<>"Hello" then bugmes();quit;end
 if s.pol<>%z^2+1 then bugmes();quit;end

--- a/scilab/modules/data_structures/tests/nonreg_tests/bug_5612.tst
+++ b/scilab/modules/data_structures/tests/nonreg_tests/bug_5612.tst
@@ -1,6 +1,7 @@
 // =============================================================================
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) 2010 - DIGITEO - Vincent COUVERT
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 //  This file is distributed under the same license as the Scilab package.
 // =============================================================================
@@ -20,7 +21,7 @@ s = struct("txt","Hello","num",%pi,"pol",%z^2+1);
 if or(getfield(1,s)<>["st", "dims", "txt", "num", "pol"]) then pause; end
 
 // Delete the field called 'num'
-s.num = null();
+rmfield("num",s);
 
 // Check that 'num' field has been deleted
 if or(getfield(1,s)<>["st", "dims", "txt", "pol"]) then pause; end
@@ -28,5 +29,3 @@ if or(getfield(1,s)<>["st", "dims", "txt", "pol"]) then pause; end
 // Check that remaining fields have the right value
 if s.txt<>"Hello" then pause; end
 if s.pol<>%z^2+1 then pause; end
-
-

--- a/scilab/modules/data_structures/tests/nonreg_tests/bug_7181.dia.ref
+++ b/scilab/modules/data_structures/tests/nonreg_tests/bug_7181.dia.ref
@@ -1,22 +1,4 @@
-// =============================================================================
-// Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-// Copyright (C) 2010 - DIGITEO - Vincent COUVERT
-//
-//  This file is distributed under the same license as the Scilab package.
-// =============================================================================
-// <-- CLI SHELL MODE -->
-// <-- Non-regression test for bug 7181 -->
-//
-// <-- Bugzilla URL -->
-// http://bugzilla.scilab.org/show_bug.cgi?id=7181
-//
-// <-- Short Description -->
-// The display of a struct having no fields does not work.
-// Create a struct
 s = struct("txt","Hello","num",%pi,"pol",%z^2+1);
-// Remove all fields
-s.txt = null();
-s.num = null();
-s.pol = null();
+rmfield(["txt","num","pol"],s);
 disp(s)
 1x1 struct array with no field.

--- a/scilab/modules/data_structures/tests/nonreg_tests/bug_7181.tst
+++ b/scilab/modules/data_structures/tests/nonreg_tests/bug_7181.tst
@@ -1,6 +1,7 @@
 // =============================================================================
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) 2010 - DIGITEO - Vincent COUVERT
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 //  This file is distributed under the same license as the Scilab package.
 // =============================================================================
@@ -19,8 +20,6 @@
 s = struct("txt","Hello","num",%pi,"pol",%z^2+1);
 
 // Remove all fields
-s.txt = null();
-s.num = null();
-s.pol = null();
+rmfield(["txt","num","pol"],s);
 
 disp(s)

--- a/scilab/modules/data_structures/tests/unit_tests/struct.dia.ref
+++ b/scilab/modules/data_structures/tests/unit_tests/struct.dia.ref
@@ -1,13 +1,3 @@
-// =============================================================================
-// Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
-// Copyright (C) 2010 - DIGITEO - Sylvestre LEDRU
-//
-//  This file is distributed under the same license as the Scilab package.
-// =============================================================================
-// <-- ENGLISH IMPOSED -->
-// <-- CLI SHELL MODE -->
-// unit tests for structs
-// =============================================================================
 date_st=struct('jour',25,'mois','DEC','annee',2006);
 if date_st.jour <> 25 then bugmes();quit;end
 if date_st.mois <> 'DEC' then bugmes();quit;end
@@ -20,7 +10,6 @@ date_st.annee=1973;
 if date_st.annee <> 1973 then bugmes();quit;end
 date_st.semaine=32;
 if date_st.semaine <> 32 then bugmes();quit;end
-// Example from bug #7244
 clear;
 foo(1) = 1;
 foo(2) = 2;
@@ -52,7 +41,9 @@ if or(size(out) <> [2 3]) then bugmes();quit;end
 s=struct("txt","Hello","num",%pi,"pol",%z^2+1);
 if s.pol <> %z^2+1 then bugmes();quit;end
 if s.txt <> "Hello" then bugmes();quit;end
-s.txt=null();s.num=null();s.pol=null();
+rmfield("txt",s);
+rmfield("num",s);
+rmfield("pol",s);
 if isfield( s , "txt"  ) then bugmes();quit;end
 if isfield( s , "num"  ) then bugmes();quit;end
 if isfield( s , "pol"  ) then bugmes();quit;end

--- a/scilab/modules/data_structures/tests/unit_tests/struct.tst
+++ b/scilab/modules/data_structures/tests/unit_tests/struct.tst
@@ -1,6 +1,7 @@
 // =============================================================================
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) 2010 - DIGITEO - Sylvestre LEDRU
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 //  This file is distributed under the same license as the Scilab package.
 // =============================================================================
@@ -67,7 +68,9 @@ s=struct("txt","Hello","num",%pi,"pol",%z^2+1);
 if s.pol <> %z^2+1 then pause, end
 if s.txt <> "Hello" then pause, end
 
-s.txt=null();s.num=null();s.pol=null();
+rmfield("txt",s);
+rmfield("num",s);
+rmfield("pol",s);
 if isfield( s , "txt"  ) then pause, end
 if isfield( s , "num"  ) then pause, end
 if isfield( s , "pol"  ) then pause, end

--- a/scilab/modules/elementary_functions/tests/nonreg_tests/bug_7649.tst
+++ b/scilab/modules/elementary_functions/tests/nonreg_tests/bug_7649.tst
@@ -28,5 +28,5 @@ s(2).w = struct();
 s(3).w = {};
 s(4).w = [];
 assert_checktrue(isempty(s));
-s.w = null();
+rmfield("w",s);
 assert_checktrue(isempty(s));

--- a/scilab/modules/scicos/macros/scicos_scicos/compile_init_modelica.sci
+++ b/scilab/modules/scicos/macros/scicos_scicos/compile_init_modelica.sci
@@ -111,7 +111,7 @@ function   [ok]=compile_init_modelica(xmlmodel,paremb,jaco)
     if size(connectmat, 2) == 6 then
         connectmat = connectmat(:,[1 2 4 5]);
     end
-    scs_m = null();
+    clear scs_m;
 
     icpr = list();
     if exists(%scicos_solver) == 0 | (exists(%scicos_solver) <> 0 & %scicos_solver < 100) then

--- a/scilab/modules/scicos/macros/scicos_scicos/do_compile.sci
+++ b/scilab/modules/scicos/macros/scicos_scicos/do_compile.sci
@@ -83,7 +83,7 @@ function  [%cpr,ok] = do_compile(scs_m)
     end
 
 
-    scs_m = null() ;
+    clear scs_m;
 
     if ~ok then %cpr=list()
         return

--- a/scilab/modules/scicos/macros/scicos_scicos/genfunc1.sci
+++ b/scilab/modules/scicos/macros/scicos_scicos/genfunc1.sci
@@ -60,7 +60,7 @@ function [ok,tt,dep_ut]=genfunc1(tt,inp,out,nci,nco,nx,nz,nrp,type_)
             "as a function of "+depp],txt1)
             if txt1==[] then return,end
             // check if txt defines y from u
-            mac=null();
+            clear mac;
             if execstr("deff(""[]=mac()"",txt1)", "errcatch") <> 0 then
                 messagebox(["Incorrect syntax: ";lasterror()],"modal")
             else
@@ -97,7 +97,7 @@ function [ok,tt,dep_ut]=genfunc1(tt,inp,out,nci,nco,nx,nz,nrp,type_)
             "as  function(s) of "+depp],txt0)
 
             if txt0==[] then return,end
-            mac=null();
+            clear mac;
             if execstr("deff(""[]=mac()"",txt0)", "errcatch") <> 0 then
                 messagebox(["Incorrect syntax: ";lasterror()],"modal")
             else
@@ -128,7 +128,7 @@ function [ok,tt,dep_ut]=genfunc1(tt,inp,out,nci,nco,nx,nz,nrp,type_)
             t1
             "at event time, as functions of "+depp],txt2)
             if txt2==[] then return,end
-            mac=null();
+            clear mac;
             if execstr("deff(""[]=mac()"",txt2)", "errcatch") <> 0 then
                 messagebox(["Incorrect syntax: ";lasterror()],"modal")
             else
@@ -152,7 +152,7 @@ function [ok,tt,dep_ut]=genfunc1(tt,inp,out,nci,nco,nx,nz,nrp,type_)
             "vector of output time events t_evo (size:"+string(nco)+")"
             "at event time. "],txt3)
             if txt3==[] then return,end
-            mac=null();
+            clear mac;
             if execstr("deff(""[]=mac()"",txt3)", "errcatch") <> 0 then
                 messagebox(["Incorrect syntax: ";lasterror()],"modal")
             else
@@ -185,7 +185,7 @@ function [ok,tt,dep_ut]=genfunc1(tt,inp,out,nci,nco,nx,nz,nrp,type_)
         t1
         "as  function(s) of "+depp],txt4)
         if txt4==[] then return,end
-        mac=null();
+        clear mac;
         if execstr("deff(""[]=mac()"",txt4)", "errcatch") <> 0 then
             messagebox(["Incorrect syntax: ";lasterror()],"modal")
         else
@@ -212,7 +212,7 @@ function [ok,tt,dep_ut]=genfunc1(tt,inp,out,nci,nco,nx,nz,nrp,type_)
         t1
         "as  function(s) of "+depp],txt5)
         if txt5==[] then return,end
-        mac=null();
+        clear mac;
         if execstr("deff(""[]=mac()"",txt5)", "errcatch") <> 0 then
             messagebox(["Incorrect syntax: ";lasterror()],"modal")
         else
@@ -247,7 +247,7 @@ function [ok,tt,dep_ut]=genfunc1(tt,inp,out,nci,nco,nx,nz,nrp,type_)
             "as a function of "+depp],txt6)
             if txt6==[] then return,end
 
-            mac=null();
+            clear mac;
             if execstr("deff(""[]=mac()"",txt6)", "errcatch") <> 0 then
                 messagebox(["Incorrect syntax: ";lasterror()],"modal")
             else

--- a/scilab/modules/scicos/macros/scicos_scicos/genfunc2.sci
+++ b/scilab/modules/scicos/macros/scicos_scicos/genfunc2.sci
@@ -60,7 +60,7 @@ function [ok,tt,dep_ut]=genfunc2(tt,inp,out,nci,nco,nx,nz,nrp,type_)
             "as a function of "+depp],txt1)
             if txt1==[] then return,end
             // check if txt defines y from u
-            mac=null();
+            clear mac;
             if execstr("deff(""[]=mac()"",txt1)", "errcatch") <> 0 then
                 messagebox(["Incorrect syntax: ";lasterror()],"modal")
             else
@@ -97,7 +97,7 @@ function [ok,tt,dep_ut]=genfunc2(tt,inp,out,nci,nco,nx,nz,nrp,type_)
             "as  function(s) of "+depp],txt0)
 
             if txt0==[] then return,end
-            mac=null();
+            clear mac;
             if execstr("deff(""[]=mac()"",txt0)", "errcatch") <> 0 then
                 messagebox(["Incorrect syntax: ";lasterror()],"modal")
             else
@@ -128,7 +128,7 @@ function [ok,tt,dep_ut]=genfunc2(tt,inp,out,nci,nco,nx,nz,nrp,type_)
             t1
             "at event time, as functions of "+depp],txt2)
             if txt2==[] then return,end
-            mac=null();
+            clear mac;
             if execstr("deff(""[]=mac()"",txt2)", "errcatch") <> 0 then
                 messagebox(["Incorrect syntax: ";lasterror()],"modal")
             else
@@ -152,7 +152,7 @@ function [ok,tt,dep_ut]=genfunc2(tt,inp,out,nci,nco,nx,nz,nrp,type_)
             "vector of output time events t_evo (size:"+string(nco)+")"
             "at event time. "],txt3)
             if txt3==[] then return,end
-            mac=null();
+            clear mac;
             if execstr("deff(""[]=mac()"",txt3)", "errcatch") <> 0 then
                 messagebox(["Incorrect syntax: ";lasterror()],"modal")
             else
@@ -185,7 +185,7 @@ function [ok,tt,dep_ut]=genfunc2(tt,inp,out,nci,nco,nx,nz,nrp,type_)
         t1
         "as  function(s) of "+depp],txt4)
         if txt4==[] then return,end
-        mac=null();
+        clear mac;
         if execstr("deff(""[]=mac()"",txt4)", "errcatch") <> 0 then
             messagebox(["Incorrect syntax: ";lasterror()],"modal")
         else
@@ -212,7 +212,7 @@ function [ok,tt,dep_ut]=genfunc2(tt,inp,out,nci,nco,nx,nz,nrp,type_)
         t1
         "as  function(s) of "+depp],txt5)
         if txt5==[] then return,end
-        mac=null();
+        clear mac;
         if execstr("deff(""[]=mac()"",txt5)", "errcatch") <> 0 then
             messagebox(["Incorrect syntax: ";lasterror()],"modal")
         else
@@ -248,7 +248,7 @@ function [ok,tt,dep_ut]=genfunc2(tt,inp,out,nci,nco,nx,nz,nrp,type_)
             "as a function of "+depp],txt6)
             if txt6==[] then return,end
 
-            mac=null();
+            clear mac;
             if execstr("deff(""[]=mac()"",txt6)", "errcatch") <> 0 then
                 messagebox(["Incorrect syntax: ";lasterror()],"modal")
             else

--- a/scilab/modules/scicos/macros/scicos_scicos/genmac.sci
+++ b/scilab/modules/scicos/macros/scicos_scicos/genmac.sci
@@ -21,7 +21,7 @@
 
 function mac=genmac(tt,nin,nout)
     [txt1,txt0,txt2,txt3,txt4,txt5,txt6]=tt(1:7)
-    mac=null()
+    clear mac
     //    [y,  x,  z,  tvec,xd]=func(flag,nevprt,t,x,z,rpar,ipar,u)
     blank="  "
     // if txt2_1<>' ' then

--- a/scilab/modules/string/tests/unit_tests/string.tst
+++ b/scilab/modules/string/tests/unit_tests/string.tst
@@ -52,7 +52,7 @@ assert_checkequal(out, "y");
 assert_checkequal(in, "x");
 assert_checkequal(text, [" "; "y = x + 1"; " "]);
 //===============================
-mymacro = null();
+clear mymacro;
 deff("y = mymacro(x)", "y = x + 1");
 [out, in, text]=string(mymacro);
 assert_checkequal(out, "y");

--- a/scilab/modules/types/tests/nonreg_tests/bug_14564.tst
+++ b/scilab/modules/types/tests/nonreg_tests/bug_14564.tst
@@ -1,6 +1,7 @@
 // =============================================================================
 // Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
 // Copyright (C) 2016 - Scilab Enterprises - Nicolas Carrez
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
 //
 //  This file is distributed under the same license as the Scilab package.
 // =============================================================================
@@ -17,7 +18,7 @@
 // fieldnames failed for empty struct, tlist & mlist
 
 a.r = 1;
-a.r = null();
+rmfield("r",a);
 assert_checkequal(fieldnames(a), []);
 
 u = mlist("v");


### PR DESCRIPTION
`a=null()` => `clear a`
`a.b=null` => `rmfield("b",a)`