### PR TITLE
Added New "void" Function

### DIFF
--- a/scilab/modules/core/Makefile.am
+++ b/scilab/modules/core/Makefile.am
@@ -117,6 +117,7 @@ GATEWAY_CPP_SOURCES = \
 	sci_gateway/cpp/sci_isprotected.cpp \
 	sci_gateway/cpp/sci_protect.cpp \
 	sci_gateway/cpp/sci_unprotect.cpp \
+	sci_gateway/cpp/sci_void.cpp \
 	sci_gateway/cpp/sci_fieldnames.cpp \
 	sci_gateway/cpp/sci_checkNamedArguments.cpp
 

--- a/scilab/modules/core/Makefile.in
+++ b/scilab/modules/core/Makefile.in
@@ -279,7 +279,7 @@ am__libscicore_la_SOURCES_DIST = sci_gateway/c/sci_getdebuginfo.c \
 	sci_gateway/cpp/sci_mlist.cpp sci_gateway/cpp/sci_isfield.cpp \
 	sci_gateway/cpp/sci_isprotected.cpp \
 	sci_gateway/cpp/sci_protect.cpp \
-	sci_gateway/cpp/sci_unprotect.cpp \
+	sci_gateway/cpp/sci_unprotect.cpp sci_gateway/cpp/sci_void.cpp \
 	sci_gateway/cpp/sci_fieldnames.cpp \
 	sci_gateway/cpp/sci_checkNamedArguments.cpp \
 	sci_gateway/cpp/sci_inspectorDeleteUnreferencedItems.cpp \
@@ -350,6 +350,7 @@ am__objects_6 = sci_gateway/cpp/libscicore_la-core_gw.lo \
 	sci_gateway/cpp/libscicore_la-sci_isprotected.lo \
 	sci_gateway/cpp/libscicore_la-sci_protect.lo \
 	sci_gateway/cpp/libscicore_la-sci_unprotect.lo \
+	sci_gateway/cpp/libscicore_la-sci_void.lo \
 	sci_gateway/cpp/libscicore_la-sci_fieldnames.lo \
 	sci_gateway/cpp/libscicore_la-sci_checkNamedArguments.lo \
 	$(am__objects_5)
@@ -841,7 +842,7 @@ GATEWAY_CPP_SOURCES = sci_gateway/cpp/core_gw.cpp \
 	sci_gateway/cpp/sci_mlist.cpp sci_gateway/cpp/sci_isfield.cpp \
 	sci_gateway/cpp/sci_isprotected.cpp \
 	sci_gateway/cpp/sci_protect.cpp \
-	sci_gateway/cpp/sci_unprotect.cpp \
+	sci_gateway/cpp/sci_unprotect.cpp sci_gateway/cpp/sci_void.cpp \
 	sci_gateway/cpp/sci_fieldnames.cpp \
 	sci_gateway/cpp/sci_checkNamedArguments.cpp $(am__append_1)
 libscicore_la_CPPFLAGS = -I$(srcdir)/includes/ -I$(srcdir)/src/c/ \
@@ -1381,6 +1382,9 @@ sci_gateway/cpp/libscicore_la-sci_protect.lo:  \
 sci_gateway/cpp/libscicore_la-sci_unprotect.lo:  \
 	sci_gateway/cpp/$(am__dirstamp) \
 	sci_gateway/cpp/$(DEPDIR)/$(am__dirstamp)
+sci_gateway/cpp/libscicore_la-sci_void.lo:  \
+	sci_gateway/cpp/$(am__dirstamp) \
+	sci_gateway/cpp/$(DEPDIR)/$(am__dirstamp)
 sci_gateway/cpp/libscicore_la-sci_fieldnames.lo:  \
 	sci_gateway/cpp/$(am__dirstamp) \
 	sci_gateway/cpp/$(DEPDIR)/$(am__dirstamp)
@@ -1488,6 +1492,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_typename.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_typeof.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_unprotect.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_void.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_warning.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_what.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_where.Plo@am__quote@
@@ -2199,6 +2204,13 @@ sci_gateway/cpp/libscicore_la-sci_unprotect.lo: sci_gateway/cpp/sci_unprotect.cp
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='sci_gateway/cpp/sci_unprotect.cpp' object='sci_gateway/cpp/libscicore_la-sci_unprotect.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o sci_gateway/cpp/libscicore_la-sci_unprotect.lo `test -f 'sci_gateway/cpp/sci_unprotect.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_unprotect.cpp
+
+sci_gateway/cpp/libscicore_la-sci_void.lo: sci_gateway/cpp/sci_void.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT sci_gateway/cpp/libscicore_la-sci_void.lo -MD -MP -MF sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_void.Tpo -c -o sci_gateway/cpp/libscicore_la-sci_void.lo `test -f 'sci_gateway/cpp/sci_void.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_void.cpp
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_void.Tpo sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_void.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='sci_gateway/cpp/sci_void.cpp' object='sci_gateway/cpp/libscicore_la-sci_void.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o sci_gateway/cpp/libscicore_la-sci_void.lo `test -f 'sci_gateway/cpp/sci_void.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_void.cpp
 
 sci_gateway/cpp/libscicore_la-sci_fieldnames.lo: sci_gateway/cpp/sci_fieldnames.cpp
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libscicore_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT sci_gateway/cpp/libscicore_la-sci_fieldnames.lo -MD -MP -MF sci_gateway/cpp/$(DEPDIR)/libscicore_la-sci_fieldnames.Tpo -c -o sci_gateway/cpp/libscicore_la-sci_fieldnames.lo `test -f 'sci_gateway/cpp/sci_fieldnames.cpp' || echo '$(srcdir)/'`sci_gateway/cpp/sci_fieldnames.cpp

--- a/scilab/modules/core/includes/core_gw.hxx
+++ b/scilab/modules/core/includes/core_gw.hxx
@@ -85,6 +85,7 @@ CPP_GATEWAY_PROTOTYPE(sci_isfield);
 CPP_GATEWAY_PROTOTYPE(sci_isprotected);
 CPP_GATEWAY_PROTOTYPE(sci_protect);
 CPP_GATEWAY_PROTOTYPE(sci_unprotect);
+CPP_GATEWAY_PROTOTYPE(sci_void);
 CPP_GATEWAY_PROTOTYPE(sci_fieldnames);
 CPP_GATEWAY_PROTOTYPE(sci_checkNamedArguments);
 

--- a/scilab/modules/core/sci_gateway/cpp/core_gw.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/core_gw.cpp
@@ -79,6 +79,7 @@ int CoreModule::Load()
     symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"isprotected", &sci_isprotected, MODULE_NAME));
     symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"protect", &sci_protect, MODULE_NAME));
     symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"unprotect", &sci_unprotect, MODULE_NAME));
+    symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"void", &sci_void, MODULE_NAME));
     symbol::Context::getInstance()->addFunction(types::Function::createFunction(L"checkNamedArguments", &sci_checkNamedArguments, MODULE_NAME));
 
 #ifndef NDEBUG

--- a/scilab/modules/core/sci_gateway/cpp/sci_void.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_void.cpp
@@ -1,0 +1,48 @@
+// Balisc (https://github.com/rdbyk/balisc/)
+// 
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 
+// 02110-1301, USA.
+
+#include "core_gw.hxx"
+#include "function.hxx"
+#include "listundefined.hxx"
+
+extern "C"
+{
+#include "Scierror.h"
+#include "localization.h"
+}
+
+using types::Function;
+using types::ListUndefined;
+using types::typed_list;
+
+static const char fname[] = "void";
+
+Function::ReturnValue sci_void(typed_list &in, int _iRetCount, typed_list &out)
+{
+    if (in.size() == 0)
+    {
+        out.push_back(new ListUndefined());
+        return Function::OK;
+    }
+    else
+    {
+        Scierror(77, _("%s: Wrong number of input arguments: %d expected."), "void", 0);
+        return Function::Error;
+    }
+}

--- a/scilab/modules/core/tests/unit_tests/void.tst
+++ b/scilab/modules/core/tests/unit_tests/void.tst
@@ -1,0 +1,10 @@
+// Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// <-- CLI SHELL MODE -->
+// <-- NO CHECK REF -->
+//
+
+assert_checktrue(typeof(void())=="listundefined")
+
+errmsg=msprintf(_("%s: Wrong number of input arguments: %d expected."), "void", 0);
+assert_checkerror("void(1)",errmsg)

--- a/scilab/modules/javasci/Makefile.in
+++ b/scilab/modules/javasci/Makefile.in
@@ -1018,10 +1018,10 @@ maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"
 	@echo "it deletes files that may require special tools to rebuild."
 	-test -z "$(BUILT_SOURCES)" || rm -f $(BUILT_SOURCES)
-@JAVASCI_FALSE@install-html-local:
 @JAVASCI_FALSE@install-data-local:
 @JAVASCI_FALSE@clean-local:
 @JAVASCI_FALSE@distclean-local:
+@JAVASCI_FALSE@install-html-local:
 clean: clean-am
 
 clean-am: clean-generic clean-libtool clean-local \


### PR DESCRIPTION
Due to some changes in the past, we consider expressions like `list(1,,,4)` as illegal, and thus we provide a new utility function `void()`, whose sole purpose is to return a `ListUndefined` object.

`L=list(1,void(),void(),3)` is more explicit than the old (now illegal) expression `L=list(1,,4)`. Of course, one has to type "void()" twice ... but e.g. an equivalent for `L=list(,,,,,,,)` could be `?=void();L=list(?,?,?,?,?,?,?,?)`, `L=list();L(1:8)=void() `, or even better `L=list();L(8)=void() ` ... still more typing is needed, but IOHO it is much more explicit to the user ...