### PR TITLE
Add Missing "delete[]" arrays in ImplicitList::extract

### DIFF
--- a/scilab/modules/ast/src/cpp/types/implicitlist.cpp
+++ b/scilab/modules/ast/src/cpp/types/implicitlist.cpp
@@ -650,6 +650,8 @@ InternalType* ImplicitList::extract(typed_list* _pArgs)
     {
         //free pArg content
         cleanIndexesArguments(_pArgs, &pArg);
+        delete[] piMaxDim;
+        delete[] piCountDim;
         return Double::Empty();
     }
 


### PR DESCRIPTION
Please note, that even arrays of zero size should be deleted, cf. [here](https://stackoverflow.com/questions/1087042/c-new-int0-will-it-allocate-memory)