### PR TITLE
Fixed #746

### DIFF
--- a/scilab/modules/ast/src/cpp/types/types_tools.cpp
+++ b/scilab/modules/ast/src/cpp/types/types_tools.cpp
@@ -541,7 +541,7 @@ int checkIndexesArguments(InternalType* _pRef, typed_list* _pArgsIn, typed_list*
 
             if (bIsComputable == false)
             {
-                //: or $
+                // : (colon)
                 if (_pRef == NULL)
                 {
                     if (pIL->getStep()->isDouble() &&
@@ -561,8 +561,8 @@ int checkIndexesArguments(InternalType* _pRef, typed_list* _pArgsIn, typed_list*
                 }
                 else
                 {
-                    //evalute polynom with "MaxDim"
-                    int iMaxDim = _pRef->getAs<GenericType>()->getVarMaxDim(i, iDims);
+                    // evalute polynom with "MaxDim"
+                    int iMaxDim = _pRef->isImplicitList() ? 3 : _pRef->getAs<GenericType>()->getVarMaxDim(i, iDims);
 #if defined(_SCILAB_DEBUGREF_)
                     Double* pdbl = new Double(iMaxDim);
 #else


### PR DESCRIPTION
fixes #746
 
Please note, this fix prevents only the crashing and _not_ the buggy extraction form implicit lists , cf. [here](http://bugzilla.scilab.org/show_bug.cgi?id=15855#c1) and [there](http://bugzilla.scilab.org/show_bug.cgi?id=15855#c2)