### PR TITLE
Avoid Some Obscure/Inconsistent Errors Related to Function Redefinition/Protection

### DIFF
--- a/scilab/modules/ast/includes/ast/visitor_common.hxx
+++ b/scilab/modules/ast/includes/ast/visitor_common.hxx
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2010-2010 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2019 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -49,5 +49,7 @@ void callOnPrompt(void);
 ast::Exp* callTyper(ast::Exp* _tree, std::wstring _msg = std::wstring(L""));
 
 std::string printExp(std::ifstream& _File, ast::Exp* _pExp, const std::string& _stPrompt, int* _piLine /* in/out */, int* _piCol /* in/out */, std::string& _stPreviousBuffer);
+
+void FuncprotErrorOrWarning(const std::wstring name, const Location& loc = Location());
 
 #endif //!AST_VISITOR_COMMON_HXX

--- a/scilab/modules/ast/src/cpp/ast/run_AssignExp.hpp
+++ b/scilab/modules/ast/src/cpp/ast/run_AssignExp.hpp
@@ -87,13 +87,10 @@ void RunVisitorT<T>::visitprivate(const AssignExp  &e)
                     char pstError[1024];
                     char* pstFuncName = wide_string_to_UTF8(pVar->getSymbol().getName().data());
                     os_sprintf(pstError, _("It is not possible to redefine the %s primitive this way (see clearfun).\n"), pstFuncName);
-                    wchar_t* pwstError = to_wide_string(pstError);
-                    std::wstring wstError(pwstError);
                     FREE(pstFuncName);
-                    FREE(pwstError);
                     pIT->killMe();
                     CoverageInstance::stopChrono((void*)&e);
-                    throw InternalError(wstError, 999, e.getLocation());
+                    throw InternalError(pstError, 999, e.getLocation());
                 }
 
                 ((AssignExp*)&e)->setReturn();
@@ -406,10 +403,7 @@ void RunVisitorT<T>::visitprivate(const AssignExp  &e)
 
             if (exec.getResultSize() < iLhsCount)
             {
-                std::wostringstream os;
-                os << _W("Incompatible assignation: trying to assign ") << exec.getResultSize();
-                os << _W(" values in ") << iLhsCount << _W(" variables.") << std::endl;
-                throw ast::InternalError(os.str(), 999, e.getRightExp().getLocation());
+                throw ast::InternalError(49, e.getRightExp().getLocation());
             }
 
             exps_t::const_reverse_iterator it;

--- a/scilab/modules/ast/src/cpp/ast/run_CallExp.hpp
+++ b/scilab/modules/ast/src/cpp/ast/run_CallExp.hpp
@@ -228,10 +228,7 @@ void RunVisitorT<T>::visitprivate(const CallExp &e)
                         os_sprintf(szError, _("%s: Wrong number of output arguments: %lu expected.\n"), "extract", out.size());
                     }
 
-                    wchar_t* wError = to_wide_string(szError);
-                    std::wstring err(wError);
-                    FREE(wError);
-                    throw InternalError(err, 999, e.getLocation());
+                    throw InternalError(szError, 999, e.getLocation());
                 }
 
                 setExpectedSize(iSaveExpectedSize);

--- a/scilab/modules/ast/src/cpp/ast/runvisitor.cpp
+++ b/scilab/modules/ast/src/cpp/ast/runvisitor.cpp
@@ -1433,13 +1433,10 @@ void RunVisitorT<T>::visitprivate(const FunctionDec & e)
         char pstError[1024];
         char* pstFuncName = wide_string_to_UTF8(e.getSymbol().getName().c_str());
         os_sprintf(pstError, _("It is not possible to redefine the %s primitive this way (see clearfun).\n"), pstFuncName);
-        wchar_t* pwstError = to_wide_string(pstError);
-        std::wstring wstError(pwstError);
         FREE(pstFuncName);
-        FREE(pwstError);
         pMacro->killMe();
         CoverageInstance::stopChrono((void*)&e);
-        throw InternalError(wstError, 999, e.getLocation());
+        throw InternalError(pstError, 999, e.getLocation());
     }
 
     CoverageInstance::stopChrono((void*)&e);

--- a/scilab/modules/ast/src/cpp/symbol/variables.cpp
+++ b/scilab/modules/ast/src/cpp/symbol/variables.cpp
@@ -19,6 +19,7 @@
 #include "macro.hxx"
 #include "macrofile.hxx"
 #include "types_tools.hxx"
+#include "visitor_common.hxx"
 
 extern "C"
 {
@@ -99,28 +100,9 @@ bool Variable::put(types::InternalType* _pIT, int _iLevel)
         if (pIT != _pIT)
         {
             //check macro redefinition
-            if (pIT->isCallable())
+            if (pIT->isCallable() && ConfigVariable::getFuncprot())
             {
-                switch (ConfigVariable::getFuncprot())
-                {
-                    case 1:
-                        {
-                            char pstWarning[1024];
-                            char* pstFuncName = wide_string_to_UTF8(name.getName().c_str());
-                            snprintf(pstWarning, 1024, _("WARNING: Redefining function \"%s\". Use funcprot(0) to avoid this message.\n"), pstFuncName);
-                            FREE(pstFuncName);
-                            Sciwarning(pstWarning);
-                        }
-                        break;
-
-                    case 2:
-                        {
-                            wchar_t pwstError[1024];
-                            os_swprintf(pwstError, 1024, _W("ERROR: Redefining function \"%s\". Use funcprot(0) to avoid this error.\n").c_str(), name.getName().c_str());
-                            throw ast::InternalError(pwstError);
-                        }
-                        break;
-                }
+                FuncprotErrorOrWarning(name.getName());
             }
 
             // _pIT may contained in pIT

--- a/scilab/modules/core/src/cpp/errmsgs.cpp
+++ b/scilab/modules/core/src/cpp/errmsgs.cpp
@@ -47,7 +47,7 @@ static const std::map<int, const char*> errmsgs =
     { 14, _("for expression : Wrong type for loop iterator.\n") },
     { 15, _("for expression can only manage 1 or 2 dimensions variables.\n") },
     { 16, _("for expression : No value for assignment to loop variable.\n") },
-    { 17, _("Unexpected redefinition of Scilab function.\n") },
+    { 17, _("%s: Redefining function '%s'. Use 'funcprot(0)' to avoid this message.\n") },
     { 18, _("Unable to insert multiple item in a Struct.\n") },
     { 19, _("Unable to insert multiple item in a List.\n") },
     { 20, _("Unknown expression.\n") },
@@ -80,6 +80,7 @@ static const std::map<int, const char*> errmsgs =
     { 46, _("Impossible to load %s function in %s library: %s.\n") },
     { 47, _("Can not read input argument #%d.\n") },
     { 48, _("Can not apply \"'\" to several elements.\n") },
+    { 49, _("Not enough values for assignation to several variables.\n") },
 
     // fileio
     { 50, _("Wrong file descriptor: %d.\n") },


### PR DESCRIPTION
before
```
--> sin(1)=1

Unexpected redefinition of Scilab function.
--> sin(1)(1)=1

Wrong insertion: insertion in output of 'sin' is not allowed.

```

after this commit
```
--> sin(1)=1

Function not defined for given argument type(s),
check arguments or define function %s_i_fptr for overloading.

--> sin(1)(1)=1
WARNING: Redefining function 'sin'. Use 'funcprot(0)' to avoid this message.
 sin  = 

  : 1.


--> clear

--> funcprot(2);

--> sin(1)=1

Function not defined for given argument type(s),
check arguments or define function %s_i_fptr for overloading.

--> sin(1)(1)=1

ERROR: Redefining function 'sin'. Use 'funcprot(0)' to avoid this message.

```