### PR TITLE
Improved and Fixed some Help Pages

### DIFF
--- a/scilab/modules/console/help/en_US/ans.xml
+++ b/scilab/modules/console/help/en_US/ans.xml
@@ -12,7 +12,7 @@
             are not assigned. <literal>ans</literal> contains the last unassigned evaluated expression.
         </para>
         <para>
-            Variable <literal>ans</literal> is not protected by <function>predef</function>.
+            Please note, <literal>ans</literal> is a protected variable.
         </para>
     </refsection>
     <refsection>
@@ -30,7 +30,7 @@ isdef("ans") // F
         <title>See also</title>
         <simplelist type="inline">
             <member>
-                <link linkend="predef">predef</link>
+                <link linkend="protect">protect</link>
             </member>
         </simplelist>
     </refsection>

--- a/scilab/modules/core/help/en_US/1_keywords/brackets.xml
+++ b/scilab/modules/core/help/en_US/1_keywords/brackets.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
- * Copyright (C) 2016 - Samuel GOUGEON
- *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2016 - Samuel GOUGEON
+ * Copyright (C) 2019 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -242,7 +242,7 @@
                         <para>
                           <itemizedlist>
                             <listitem>
-                              To concatenate simple lists, please use <link linkend="lstcat">lstcat</link>.
+                              To concatenate simple lists, please use <link linkend="list">list</link>.
                             </listitem>
                             <listitem>
                               To stack vectors or matrices over some dimension > 2 to build a
@@ -413,9 +413,6 @@ s.r([2 4 6])
             </member>
             <member>
                 <link linkend="cat">cat</link>
-            </member>
-            <member>
-                <link linkend="lstcat">lstcat</link>
             </member>
             <member>
                 <link linkend="comma">comma</link>

--- a/scilab/modules/core/help/en_US/1_keywords/minus.xml
+++ b/scilab/modules/core/help/en_US/1_keywords/minus.xml
@@ -2,9 +2,9 @@
 <!--
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2008 - INRIA
- * Copyright (C) 2018 - Samuel GOUGEON
- *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2018 - Samuel GOUGEON
+ * Copyright (C) 2019 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -144,12 +144,6 @@ c = %t - int8(7), inttype(c)
             </member>
             <member>
                 <link linkend="overloading">overloading</link>
-            </member>
-            <member>
-                <link linkend="oldEmptyBehaviour">oldEmptyBehaviour</link>
-            </member>
-            <member>
-                <link linkend="mtlb_s">mtlb_s</link>
             </member>
         </simplelist>
     </refsection>

--- a/scilab/modules/core/help/en_US/1_keywords/plus.xml
+++ b/scilab/modules/core/help/en_US/1_keywords/plus.xml
@@ -2,9 +2,9 @@
 <!--
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) ???? - INRIA
- * Copyright (C) 2018 - Samuel GOUGEON
- *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2018 - Samuel GOUGEON
+ * Copyright (C) 2019 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -139,12 +139,6 @@
             </member>
             <member>
                 <link linkend="overloading">overloading</link>
-            </member>
-            <member>
-                <link linkend="oldEmptyBehaviour">oldEmptyBehaviour</link>
-            </member>
-            <member>
-                <link linkend="mtlb_a">mtlb_a</link>
             </member>
         </simplelist>
     </refsection>

--- a/scilab/modules/data_structures/help/en_US/list.xml
+++ b/scilab/modules/data_structures/help/en_US/list.xml
@@ -3,7 +3,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2006-2008 - INRIA
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2018 - 2019 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -16,7 +16,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svg="http://www.w3.org/2000/svg" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:db="http://docbook.org/ns/docbook" xmlns:scilab="http://www.scilab.org" xml:lang="en" xml:id="list">
     <refnamediv>
         <refname>list</refname>
-        <refpurpose>a Scilab object and a list definition function</refpurpose>
+        <refpurpose>create a list</refpurpose>
     </refnamediv>
     <refsynopsisdiv>
         <title>Syntax</title>
@@ -58,7 +58,7 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
-                <term>append an element in queue</term>
+                <term>append an element</term>
                 <listitem>
                     <para>
                         <code>L($+1)=e</code>.
@@ -66,15 +66,14 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
-                <term>append an element in head</term>
+                <term>prepend an element</term>
                 <listitem>
                     <para>
                         <code>L(0)=e</code>.
                         <note>
                             After this
-                            operation <literal>e</literal> is an index 1,
-                            the initial elements being shifted on the
-                            right.
+                            operation <literal>e</literal> is the first element (index 1),
+                            the initial elements being shifted on the right.
                         </note>
                     </para>
                 </listitem>
@@ -93,7 +92,7 @@
                 <term>concatenation of two lists</term>
                 <listitem>
                     <para>
-                        <code>L3 = lstcat(L1,L2)</code>.
+                        <code>L3 = list(L1(:),L2(:))</code>.
                     </para>
                 </listitem>
             </varlistentry>
@@ -124,11 +123,7 @@
         <para>
             Scilab provides also other kinds of list, the <link linkend="tlist">tlist</link> type (typed list) and
             the <link linkend="mlist">mlist</link> type which are useful to define a new data type with operator
-            <link linkend="overloading">overloading</link> facilities (<link linkend="hypermatrices">hypermatrices</link> which are
-            multidimensional arrays in Scilab are in fact <emphasis>mlist</emphasis>).
-        </para>
-        <para>
-            Matlab <emphasis>struct</emphasis> are also available.
+            <link linkend="overloading">overloading</link> facilities.
         </para>
     </refsection>
     <refsection>
@@ -163,9 +158,6 @@ size(lter) - size(lbis) - size(l)  // must be zero
                 <link linkend="null">null</link>
             </member>
             <member>
-                <link linkend="lstcat">lstcat</link>
-            </member>
-            <member>
                 <link linkend="tlist">tlist</link>
             </member>
             <member>
@@ -191,7 +183,14 @@ size(lter) - size(lbis) - size(l)  // must be zero
             <revision>
                 <revnumber>Balisc 1</revnumber>
                 <revdescription>
-                    Using an array <literal>i</literal> of indices allows multiple insertions and deletions at once. 
+                    Using an array <literal>i</literal> of indices allows multiple insertions and deletions at once.
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>Balisc 2</revnumber>
+                <revdescription>
+                    Removed reference to <function>lstcat</function>, describe usage of <function>list</function> for
+                    concatentation of lists.
                 </revdescription>
             </revision>
         </revhistory>

--- a/scilab/modules/elementary_functions/help/en_US/matrixmanipulation/cat.xml
+++ b/scilab/modules/elementary_functions/help/en_US/matrixmanipulation/cat.xml
@@ -4,6 +4,7 @@
  * Copyright (C) 2008 - INRIA - Farid BELAHCENE
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
  * Copyright (C) 2018 - Samuel GOUGEON
+ * Copyright (C) 2019 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -178,9 +179,6 @@ cat(3, A1, A2)
         <simplelist type="inline">
             <member>
                 <link linkend="brackets">brackets [..]</link>
-            </member>
-            <member>
-                <link linkend="lstcat">lstcat</link>
             </member>
             <member>
                 <link linkend="permute">permute</link>

--- a/scilab/modules/functions/help/en_US/libraries/genlib.xml
+++ b/scilab/modules/functions/help/en_US/libraries/genlib.xml
@@ -2,8 +2,8 @@
 <!--
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) ????-2008 - INRIA
- *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2019 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -88,7 +88,7 @@
             When all <literal>.sci</literal> files have been processed, <literal>genlib</literal> creates a
             library variable named <literal>lib_name</literal> and saves it in the file
             <literal>lib</literal> in <literal>dir_name</literal>. If the Scilab variable
-            <literal>lib_name</literal> is not protected (see <link linkend="predef">predef</link>) this
+            <literal>lib_name</literal> is not protected (see <link linkend="protect">protect</link>) this
             variable is updated.
         </para>
         <para>


### PR DESCRIPTION
- only `en_US` pages have been updated
- removed references to `lstcat` in help pages of `list`, `cat`, `brackets` in order to keep (new) users from
assuming bad habits ...
- fixed invalid links in help pages of `ans`, `minus`, `plus`, and `genlib`
