### PR TITLE
Replaced "os_wcsicmp" by "wcscmp" in "sci_{exec,execstr,mclose,intppty}.cpp"

### DIFF
--- a/scilab/modules/core/sci_gateway/cpp/sci_intppty.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_intppty.cpp
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2014 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2019 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -24,10 +24,7 @@ extern "C"
 {
 #include "Scierror.h"
 #include "localization.h"
-#include "os_string.h"
 }
-
-static const char fname[] = "intppty";
 
 types::Function::ReturnValue sci_intppty(types::typed_list &in, int _iRetCount, types::typed_list &out)
 {
@@ -47,17 +44,17 @@ types::Function::ReturnValue sci_intppty(types::typed_list &in, int _iRetCount, 
         }
 
         types::String* pMode = in[1]->getAs<types::String>();
-        if (os_wcsicmp(pMode->getFirst(), L"add") == 0)
+        if (wcscmp(pMode->getFirst(), L"add") == 0)
         {
             bAdd = true;
         }
-        else if (os_wcsicmp(pMode->getFirst(), L"remove") == 0)
+        else if (wcscmp(pMode->getFirst(), L"remove") == 0)
         {
             bAdd = false;
         }
         else
         {
-            Scierror(999, _("%s: Wrong value for input argument #%d: '%s' or '%s' expected.\n"), fname, 2, "add", "remove");
+            Scierror(110, 2, _("'add' or 'remove'"));
             return types::Function::Error;
         }
 

--- a/scilab/modules/fileio/sci_gateway/cpp/sci_mclose.cpp
+++ b/scilab/modules/fileio/sci_gateway/cpp/sci_mclose.cpp
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2010-2010 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2018 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2018 - 2019 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -25,7 +25,6 @@ extern "C"
 #include "Scierror.h"
 #include "localization.h"
 #include "mclose.h"
-#include "os_string.h"
 }
 #include "stdio.h"
 
@@ -62,13 +61,13 @@ types::Function::ReturnValue sci_mclose(types::typed_list &in, int _iRetCount, t
                 }
                 iRet = mclose(iFileID);
             }
-            else if (os_wcsicmp(pS->getFirst(), L"all") == 0)
+            else if (wcscmp(pS->getFirst(), L"all") == 0)
             {
                 iRet = mcloseAll();
             }
             else
             {
-                Scierror(999, _("%s: Wrong input arguments: '%s' expected.\n"), fname, "all");
+                Scierror(110, 1, "'all'");
                 return types::Function::Error;
             }
         }

--- a/scilab/modules/functions/sci_gateway/cpp/sci_exec.cpp
+++ b/scilab/modules/functions/sci_gateway/cpp/sci_exec.cpp
@@ -36,12 +36,10 @@
 
 extern "C"
 {
-#include "os_string.h"
 #include "expandPathVariable.h"
 #include "prompt.h"
 #include "Scierror.h"
 #include "localization.h"
-#include "os_string.h"
 #include "mopen.h"
 #include "mclose.h"
 #include "fullpath.h"
@@ -111,7 +109,7 @@ types::Function::ReturnValue sci_exec(types::typed_list &in, int _iRetCount, typ
         {
             //errcatch
             types::String* pS = in[1]->getAs<types::String>();
-            if (os_wcsicmp(pS->getFirst(), L"errcatch") == 0)
+            if (wcscmp(pS->getFirst(), L"errcatch") == 0)
             {
                 bErrCatch = true;
             }

--- a/scilab/modules/functions/sci_gateway/cpp/sci_execstr.cpp
+++ b/scilab/modules/functions/sci_gateway/cpp/sci_execstr.cpp
@@ -29,11 +29,9 @@
 extern "C"
 {
 #include "sci_malloc.h"
-#include "os_string.h"
 #include "Scierror.h"
 #include "sciprint.h"
 #include "localization.h"
-#include "os_string.h"
 }
 
 #define MUTE_FLAG       L"n"
@@ -66,7 +64,7 @@ types::Function::ReturnValue sci_execstr(types::typed_list &in, int _iRetCount, 
         }
 
         types::String* pS = in[1]->getAs<types::String>();
-        if (os_wcsicmp(pS->getFirst(), L"errcatch") == 0)
+        if (wcscmp(pS->getFirst(), L"errcatch") == 0)
         {
             bErrCatch = true;
         }
@@ -88,11 +86,11 @@ types::Function::ReturnValue sci_execstr(types::typed_list &in, int _iRetCount, 
             return types::Function::Error;
         }
 
-        if (os_wcsicmp(in[2]->getAs<types::String>()->getFirst(), MUTE_FLAG) == 0)
+        if (wcscmp(in[2]->getAs<types::String>()->getFirst(), MUTE_FLAG) == 0)
         {
             bMute = true;
         }
-        else if (os_wcsicmp(in[2]->getAs<types::String>()->getFirst(), NO_MUTE_FLAG) == 0)
+        else if (wcscmp(in[2]->getAs<types::String>()->getFirst(), NO_MUTE_FLAG) == 0)
         {
             bMute = false;
         }


### PR DESCRIPTION
- probably this was supposed to be "userfriendly", but not documented, so what's the point?
- it just introduces overhead ... ymmv

Please be aware, that after this commit, the following will now raise an error.
```
--> execstr("a=1","ErRcAtCh")

execstr: Wrong value for input argument #2: 'errcatch' expected.
```

