### PR TITLE
Do Not Check # of Return Args in "getfield"

### DIFF
--- a/scilab/modules/data_structures/sci_gateway/cpp/sci_getfield.cpp
+++ b/scilab/modules/data_structures/sci_gateway/cpp/sci_getfield.cpp
@@ -70,7 +70,7 @@ types::Function::ReturnValue sci_getfield(types::typed_list &in, int _iRetCount,
         //extraction by fieldnames
         if (pL->isMList() == false && pL->isTList() == false)
         {
-            Scierror(999, _("%s: Soft coded field names not yet implemented.\n"), "getfield");
+            Scierror(2);
             return types::Function::Error;
         }
 
@@ -111,13 +111,7 @@ types::Function::ReturnValue sci_getfield(types::typed_list &in, int _iRetCount,
     types::List* pList = pITOut->getAs<types::List>();
     int iListSize = pList->getSize();
 
-    if (_iRetCount < iListSize)
-    {
-        Scierror(81, iListSize);
-        return types::Function::Error;
-    }
-
-    for (int i = 0 ; i < iListSize ; i++)
+    for (int i = 0; i < iListSize; i++)
     {
         out.push_back(pList->get(i));
     }


### PR DESCRIPTION
For the user this an almost invisible modification, however now a `mlist` can be easily converted to
a `tlist` or just a`list`, e.g.
```
--> M=mlist(["d","e","f"],4,5,6);

--> T=tlist(getfield(:,M));

--> type(T)
 ans  =

   16.

--> typeof(T)
 ans  =

 d

--> L=list(getfield(:,M));

--> type(L)
 ans  =

   15.

--> typeof(L)
 ans  =

 list

--> L
 L  = 

       L(1)

!d  e  f  !

       L(2)

   4.

       L(3)

   5.

       L(4)

   6.

```