### PR TITLE
Do Not Check # of Return Args in "getfield" for "struct" input

### DIFF
--- a/scilab/modules/data_structures/sci_gateway/cpp/sci_getfield.cpp
+++ b/scilab/modules/data_structures/sci_gateway/cpp/sci_getfield.cpp
@@ -154,13 +154,7 @@ static types::Function::ReturnValue sci_getfieldStruct(types::typed_list &in, in
         return types::Function::Error;
     }
 
-    if (_iRetCount != static_cast<int>(vectResult.size()))
-    {
-        Scierror(81, vectResult.size());
-        return types::Function::Error;
-    }
-
-    for (int i = 0 ; i < _iRetCount ; i++)
+    for (int i = 0 ; i < vectResult.size() ; i++)
     {
         out.push_back(vectResult[i]);
     }


### PR DESCRIPTION
- cf. #971 
- allows easy conversion a  `struct` to a `list` ...