### PR TITLE
Fixed #978

### DIFF
--- a/scilab/modules/ast/tests/nonreg_tests/issue_978.tst
+++ b/scilab/modules/ast/tests/nonreg_tests/issue_978.tst
@@ -1,0 +1,20 @@
+// Copyright (C) 2019 - Dirk Reusch, Kybernetik Dr. Reusch
+//
+// <-- CLI SHELL MODE -->
+// <-- NO CHECK REF -->
+//
+// <-- Non-regression test for issue 978 -->
+//
+// <-- Github URL -->
+// https://github.com/rdbyk/balisc/issues/978
+//
+// <-- Short Description -->
+// Execution of "for k=1:0,end" Corrupts Loop Variable
+
+clear("k")
+for k=1:0,end
+assert_checkequal(isdef("k"),%f)
+
+k=123
+for k=1:0,end
+assert_checkequal(k,123)


### PR DESCRIPTION
- fixes #978 
- we are aware of this ["fix"](https://codereview.scilab.org/#/c/21145/), but we prefer
  the following behaviour, ymmv .. (we dont care about big M)

```
--> clear("k")
--> for k=1:0,end
--> k

Undefined variable: 'k'.

--> k=123
 k  = 

   123.

--> for k=1:0,end
--> k
 k  = 

   123.
```
