### PR TITLE
Introduction of New Predefined Dash "–" Variable

### DIFF
--- a/scilab/modules/ast/src/cpp/ast/run_AssignExp.hpp
+++ b/scilab/modules/ast/src/cpp/ast/run_AssignExp.hpp
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - 2019 Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2020 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -88,6 +88,11 @@ void RunVisitorT<T>::visitprivate(const AssignExp  &e)
                 }
                 else
                 {
+                    if (pVar->getSymbol().getName() == L"–")
+                    {
+                        CoverageInstance::stopChrono((void*)&e);
+                        return;
+                    }
                     throw ast::InternalError(4, e.getLeftExp().getLocation());
                 }
             }

--- a/scilab/modules/core/src/cpp/InitScilab.cpp
+++ b/scilab/modules/core/src/cpp/InitScilab.cpp
@@ -3,7 +3,7 @@
  * Copyright (C) 2013 - Scilab Enterprises - Antoine ELIAS
  * Copyright (C) 2013 - Scilab Enterprises - Cedric DELAMARRE
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - 2019 Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2020 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -22,6 +22,7 @@
 #include "polynom.hxx"
 #include "string.hxx"
 #include "bool.hxx"
+#include "listundefined.hxx"
 
 #include "scilabWrite.hxx"
 #include "tasks.hxx"
@@ -111,12 +112,14 @@ static void Add_Nan(void);
 static void Add_Inf(void);
 static void Add_io(void);
 static void Add_balisc(void);
+static void Add_dash(void);
 static void Add_All_Variables(void);
 static void Add_Double_Constant(const std::wstring& _szName, double _dblReal);
 static void Add_Double_Constant(const std::wstring& _szName, double _dblReal, double _dblImg);
 static void Add_Poly_Constant(const std::wstring& _szName, const std::wstring& _szPolyVar, int _iRank, types::Double * _pdblReal);
 static void Add_Boolean_Constant(const std::wstring& _szName, bool _bBool);
 static void Add_String_Constant(const std::wstring& _szName, const char *_pstString);
+static void Add_Undefined_Constant(const std::wstring& _szName);
 static void checkForLinkerErrors(void);
 
 static int batchMain(ScilabEngineInfo* _pSEI);
@@ -1062,6 +1065,7 @@ static void Add_All_Variables(void)
     Add_Inf();
     Add_io();
     Add_balisc();
+    Add_dash();
 }
 
 static void Add_Nan(void)
@@ -1144,6 +1148,11 @@ static void Add_balisc(void)
     Add_Double_Constant(L"%balisc", 1);
 }
 
+static void Add_dash(void)
+{
+    Add_Undefined_Constant(L"–");
+}
+
 static void Add_Poly_Constant(const std::wstring& _szName, const std::wstring& _szPolyVar, int _iRank, types::Double * _pdbl)
 {
     types::Polynom * pVar = new types::Polynom(_szPolyVar, 1, 1, &_iRank);
@@ -1178,6 +1187,12 @@ static void Add_String_Constant(const std::wstring& _szName, const char *_pstStr
 {
     types::String * ps = new types::String(_pstString);
     symbol::Context::getInstance()->put(symbol::Symbol(_szName), ps);
+}
+
+static void Add_Undefined_Constant(const std::wstring& _szName)
+{
+    types::ListUndefined* v = new types::ListUndefined();
+    symbol::Context::getInstance()->put(symbol::Symbol(_szName), v);
 }
 
 // manage debugger commands


### PR DESCRIPTION
`–` may serve different purposes
1. Shorthand for `void()`
```
--> –
 –  = 

    Undefined

--> void()
 ans  =

    Undefined
```

2. Ignore Output Arguments
```
--> [a,b]=frexp(7.93)
 a  = 

   0.99125
 b  = 

   3.

--> clear a b

--> [–,b]=frexp(7.93)
 b  = 

   3.

--> a

Undefined variable: 'a'.

--> clear b

--> [a,–]=frexp(7.93)
 a  = 

   0.99125

--> b

Undefined variable: 'b'.
```

Remarks:

- Assignations to the _protected_ `–` variable are silently ignored
- The special features (cf. above) may be disabled using `unprotect('–')`
- `–` corresponds to Unicode U+2013 aka UTF8 e28093
- Pressing `AltGr`+`-` under Ubuntu produces the `–` character