### PR TITLE
Function "mode" may now return Old (previously set) Mode

### DIFF
--- a/scilab/modules/ast/includes/system_env/configvariable.hxx
+++ b/scilab/modules/ast/includes/system_env/configvariable.hxx
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - 2018 Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2020 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -404,7 +404,7 @@ public :
 
 private :
     static int m_iPromptMode;
-
+    static int m_iPreviousPromptMode;
     static int m_iPrintMode;
     const static int m_iPromptToPrintMode[];
 
@@ -422,6 +422,11 @@ public:
     static int getPromptMode(void)
     {
         return m_iPromptMode;
+    }
+
+    static int getPreviousPromptMode(void)
+    {
+        return m_iPreviousPromptMode;
     }
 
     static bool isPrintInput(void)

--- a/scilab/modules/ast/src/cpp/system_env/configvariable.cpp
+++ b/scilab/modules/ast/src/cpp/system_env/configvariable.cpp
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2008-2008 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2020 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -210,6 +210,7 @@ bool ConfigVariable::m_iSilentError = false;
 
 /* Prompt Mode */
 int ConfigVariable::m_iPromptMode = 0;
+int ConfigVariable::m_iPreviousPromptMode = 0;
 
 // Prompt  Print Mode
 // mode    (bits: input,output,compact,interactive)
@@ -264,6 +265,7 @@ void ConfigVariable::setPromptMode(int _iPromptMode)
 {
     int i = _iPromptMode;
 
+    m_iPreviousPromptMode = m_iPromptMode;
     m_iPromptMode = i;
     // map prompt mode (-1 .. 7) to index of print mode array (0 .. 8)
     // if index is out of range (0 .. 8), then we use 0 as default

--- a/scilab/modules/console/help/en_US/mode.xml
+++ b/scilab/modules/console/help/en_US/mode.xml
@@ -3,8 +3,8 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2009 - DIGITEO - Allan CORNET
  * Copyright (C) 2017 - Samuel GOUGEON
- *
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
+ * Copyright (C) 2020 - Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -28,6 +28,7 @@
         <synopsis>
             mode(k)
             k = mode()
+            [k, kold] = mode()
         </synopsis>
     </refsynopsisdiv>
     <refsection>
@@ -36,6 +37,13 @@
             <varlistentry>
                 <term>k</term>
                 <para>integer from -1 to 6: chosen or current execution / echoing mode.
+                </para>
+            </varlistentry>
+        </variablelist>
+        <variablelist>
+            <varlistentry>
+                <term>kold</term>
+                <para>previously set execution / echoing mode.
                 </para>
             </varlistentry>
         </variablelist>
@@ -375,6 +383,13 @@ delmenu mode_test
                         default in the current <literal>mode()</literal>.
                     </listitem>
                 </itemizedlist>
+                </revdescription>
+            </revision>
+            <revision>
+                <revnumber>Balisc 2</revnumber>
+                <revdescription>
+                    Now mode() may return as second output argument the mode kold, which
+                    was set just before the very last mode change.
                 </revdescription>
             </revision>
         </revhistory>

--- a/scilab/modules/core/sci_gateway/cpp/sci_mode.cpp
+++ b/scilab/modules/core/sci_gateway/cpp/sci_mode.cpp
@@ -2,7 +2,7 @@
  * Scilab ( http://www.scilab.org/ ) - This file is part of Scilab
  * Copyright (C) 2010 - DIGITEO - Antoine ELIAS
  * Copyright (C) 2012 - 2016 - Scilab Enterprises
- * Copyright (C) 2017 - 2019 Dirk Reusch, Kybernetik Dr. Reusch
+ * Copyright (C) 2017 - 2020 Dirk Reusch, Kybernetik Dr. Reusch
  *
  * This file is hereby licensed under the terms of the GNU GPL v2.0,
  * pursuant to article 5.3.4 of the CeCILL v.2.1.
@@ -38,6 +38,10 @@ types::Function::ReturnValue sci_mode(types::typed_list &in, int _iRetCount, typ
     if (in.size() == 0)
     {
         out.push_back(new types::Double(ConfigVariable::getPromptMode()));
+        if (_iRetCount == 2)
+        {
+            out.push_back(new types::Double(ConfigVariable::getPreviousPromptMode()));
+        }
     }
     else
     {


### PR DESCRIPTION
- Motivation cf. [here](https://bugzilla.scilab.org/show_bug.cgi?id=16280)
- Alternative approach can be found [here](https://codereview.scilab.org/#/c/21439/), however
do we really want to add more and more generic overhead and introduce whole new user functions
to be used almost never ever by ordinary users? IOHO, Non, merci!
 